### PR TITLE
Fix：解决独立环境下的 npm 安装和类型检查错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "openclaw": "^2026.1.29",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.0.0",
-    "openclaw": "workspace:*",
     "prettier": "^3.0.0",
     "typescript": "^5.3.0"
   },

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,16 @@
+declare module 'openclaw/plugin-sdk' {
+  export interface OpenClawPluginApi {
+    [key: string]: any;
+  }
+
+  export interface OpenClawConfig {
+    [key: string]: any;
+  }
+
+  export interface PluginRuntime {
+    [key: string]: any;
+  }
+
+  export const emptyPluginConfigSchema: any;
+  export const buildChannelConfigSchema: any;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
@@ -25,9 +24,6 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "rootDir": ".",
-    "paths": {
-      "openclaw/plugin-sdk": ["../../src/plugin-sdk/index.ts"]
-    },
     "types": ["node"]
   },
   "include": ["index.ts", "src/**/*.ts", "utils.ts"],


### PR DESCRIPTION
此 PR 解决了在独立环境下（非 monorepo）设置插件时遇到的问题。
  
主要变更：
- package.json: 移除了 openclaw 的 workspace:* 依赖，因为标准 npm 不支持该协议，从而解决了安装错误。
- tsconfig.json: 移除了依赖于父目录 monorepo 结构的 extends 和 paths 配置，确保能够独立编译。
- src/declarations.d.ts: 为 openclaw/plugin-sdk 添加了类型声明文件（shim），解决了缺失类型定义导致的类型检查错误。
  
验证情况：
- 已验证 npm install 能够正常运行，无协议错误。
- 已验证 npm run type-check 能够顺利通过，无错误