### PR TITLE
fix: 启用 WebSocket keepAlive 解决连接假死问题

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -965,6 +965,7 @@ export const dingtalkPlugin = {
         clientId: config.clientId,
         clientSecret: config.clientSecret,
         debug: config.debug || false,
+        keepAlive: true,
       });
 
       client.registerCallbackListener(TOPIC_ROBOT, async (res: any) => {


### PR DESCRIPTION
## 问题描述

钉钉通道会出现"假连接"现象：表面上看 WebSocket 连接是正常的，但实际上已经断开了，导致：
- 收不到钉钉消息
- 没有任何错误日志
- 需要手动重启 Gateway 才能恢复

## 根本原因

WebSocket 连接在静默断开时，TCP 连接可能需要几分钟甚至更长时间才能超时。在此期间，`autoReconnect` 无法触发重连，因为没有检测到连接异常。

## 解决方案

在 DWClient 配置中启用 `keepAlive: true`，开启 WebSocket 心跳检测：
- 心跳间隔：8 秒
- 能够快速检测到连接异常（8 秒内 vs 原来的几分钟 TCP 超时）
- 配合 `autoReconnect` 实现自动恢复

## 改动

```diff
@@ -965,6 +965,7 @@ export const dingtalkPlugin = {
         clientId: config.clientId,
         clientSecret: config.clientSecret,
         debug: config.debug || false,
+        keepAlive: true,
       });
```

## 测试

- [x] 连接断开后能够在 8 秒内检测到并重连
- [x] 不再出现"假死"状态

---
**作者**: OpenClaw 令狐 🦊