### PR TITLE
feat: 添加 peer-id-registry，修复 conversationId 大小写敏感问题

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,6 +9,7 @@ import { buildChannelConfigSchema } from 'openclaw/plugin-sdk';
 import { maskSensitiveData, cleanupOrphanedTempFiles, retryWithBackoff } from '../utils';
 import { getDingTalkRuntime } from './runtime';
 import { DingTalkConfigSchema } from './config-schema.js';
+import { registerPeerId, resolveOriginalPeerId } from './peer-id-registry';
 import type {
   DingTalkConfig,
   TokenInfo,
@@ -180,6 +181,22 @@ function resolveGroupConfig(cfg: DingTalkConfig, groupId: string): { systemPromp
   return groups[groupId] || groups['*'] || undefined;
 }
 
+// ============ Target Prefix Helpers ============
+
+/**
+ * Strip group: or user: prefix from target ID
+ * Returns the raw targetId and whether it was explicitly marked as a user
+ */
+function stripTargetPrefix(target: string): { targetId: string; isExplicitUser: boolean } {
+  if (target.startsWith('group:')) {
+    return { targetId: target.slice(6), isExplicitUser: false };
+  }
+  if (target.startsWith('user:')) {
+    return { targetId: target.slice(5), isExplicitUser: true };
+  }
+  return { targetId: target, isExplicitUser: false };
+}
+
 // ============ Config Helpers ============
 
 function getConfig(cfg: OpenClawConfig, accountId?: string): DingTalkConfig {
@@ -230,8 +247,12 @@ async function sendProactiveTextOrMarkdown(
   options: SendMessageOptions = {}
 ): Promise<AxiosResponse> {
   const token = await getAccessToken(config, options.log);
-  const isGroup = target.startsWith('cid');
   const log = options.log || getLogger();
+
+  // Support group: and user: prefixes, and resolve case-sensitive conversationId
+  const { targetId, isExplicitUser } = stripTargetPrefix(target);
+  const resolvedTarget = resolveOriginalPeerId(targetId);
+  const isGroup = !isExplicitUser && resolvedTarget.startsWith('cid');
 
   const url = isGroup
     ? 'https://api.dingtalk.com/v1.0/robot/groupMessages/send'
@@ -240,7 +261,7 @@ async function sendProactiveTextOrMarkdown(
   // Use shared helper function for markdown detection and title extraction
   const { useMarkdown, title } = detectMarkdownAndExtractTitle(text, options, 'OpenClaw 提醒');
 
-  log?.debug?.(`[DingTalk] Sending proactive message to ${isGroup ? 'group' : 'user'} ${target} with title "${title}"`);
+  log?.debug?.(`[DingTalk] Sending proactive message to ${isGroup ? 'group' : 'user'} ${resolvedTarget} with title "${title}"`);
 
   // Choose msgKey based on whether we're sending markdown or plain text
   // Note: DingTalk's proactive message API uses predefined message templates
@@ -255,9 +276,9 @@ async function sendProactiveTextOrMarkdown(
   };
 
   if (isGroup) {
-    payload.openConversationId = target;
+    payload.openConversationId = resolvedTarget;
   } else {
-    payload.userIds = [target];
+    payload.userIds = [resolvedTarget];
   }
 
   const result = await axios({
@@ -657,6 +678,10 @@ async function handleDingTalkMessage(params: HandleDingTalkMessageParams): Promi
   const groupId = data.conversationId;
   const groupName = data.conversationTitle || 'Group';
 
+  // Register original peer IDs to preserve case-sensitive conversationId (base64)
+  if (groupId) registerPeerId(groupId);
+  if (senderId) registerPeerId(senderId);
+
   // 2. Check authorization for direct messages based on dmPolicy
   let commandAuthorized = true;
   if (isDirect) {
@@ -982,7 +1007,10 @@ export const dingtalkPlugin = {
           error: new Error('DingTalk message requires --to <conversationId>'),
         };
       }
-      return { ok: true, to: trimmed };
+      // Strip group: or user: prefix and resolve original case-sensitive conversationId
+      const { targetId } = stripTargetPrefix(trimmed);
+      const resolved = resolveOriginalPeerId(targetId);
+      return { ok: true, to: resolved };
     },
     sendText: async ({ cfg, to, text, accountId, log }: any) => {
       const config = getConfig(cfg, accountId);

--- a/src/peer-id-registry.ts
+++ b/src/peer-id-registry.ts
@@ -1,0 +1,35 @@
+/**
+ * Peer ID Registry
+ *
+ * Maps lowercased peer/session keys back to their original case-sensitive
+ * DingTalk conversationId values. DingTalk conversationIds are base64-encoded
+ * and therefore case-sensitive, but the framework may lowercase session keys
+ * internally. This registry preserves the original casing so outbound messages
+ * can be delivered correctly.
+ */
+
+const peerIdMap = new Map<string, string>();
+
+/**
+ * Register an original peer ID, keyed by its lowercased form.
+ */
+export function registerPeerId(originalId: string): void {
+  if (!originalId) return;
+  peerIdMap.set(originalId.toLowerCase(), originalId);
+}
+
+/**
+ * Resolve a possibly-lowercased peer ID back to its original casing.
+ * Returns the original if found, otherwise returns the input as-is.
+ */
+export function resolveOriginalPeerId(id: string): string {
+  if (!id) return id;
+  return peerIdMap.get(id.toLowerCase()) || id;
+}
+
+/**
+ * Clear the registry (for testing or shutdown).
+ */
+export function clearPeerIdRegistry(): void {
+  peerIdMap.clear();
+}


### PR DESCRIPTION
## 问题描述

钉钉的 `conversationId` 是 base64 编码的字符串，**大小写敏感**。但框架内部在某些场景下可能会将 session key 转为小写，导致：

- 主动发送消息时无法找到正确的会话
- 群聊消息发送失败（API 返回会话不存在）

**复现步骤**：
1. 收到群聊消息，conversationId 为 `cidXXX+YYY==`
2. 框架内部将其转为小写 `cidxxx+yyy==`
3. 主动发送消息时使用小写 ID
4. 钉钉 API 报错：会话不存在

## 解决方案

### 1. 新增 `peer-id-registry.ts` 模块

```typescript
// 维护小写 ID 到原始 ID 的映射
const peerIdMap = new Map<string, string>();

// 注册原始 ID
export function registerPeerId(originalId: string): void;

// 解析回原始大小写
export function resolveOriginalPeerId(id: string): string;
```

### 2. 新增 `stripTargetPrefix()` 辅助函数

支持 `group:` 和 `user:` 前缀，正确区分群聊和单聊：

```typescript
function stripTargetPrefix(target: string): { targetId: string; isExplicitUser: boolean }
```

### 3. 代码修改

- **`handleDingTalkMessage()`**: 注册入站消息的 `groupId` 和 `senderId`
- **`sendProactiveTextOrMarkdown()`**: 解析目标并获取原始大小写
- **`outbound.resolveTarget()`**: 出站消息也使用相同逻辑

## 测试方法

1. 向机器人发送群聊消息
2. 使用主动发送 API 向该群发送消息
3. 确认消息正确送达（而非报错会话不存在）