### PR TITLE
feat: 添加本地媒体自动上传功能

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -51,6 +51,12 @@ export const DingTalkConfigSchema = z.object({
    */
   cardTemplateId: z.string().optional().default('382e4302-551d-4880-bf29-a30acfab2e71.schema'),
 
+  /** Enable automatic upload of local images in AI responses
+   * When enabled, local file paths like ![alt](/path/to/image.png) in AI output
+   * will be automatically uploaded to DingTalk and replaced with media_id
+   */
+  enableMediaUpload: z.boolean().optional().default(false),
+
   /** Per-group configuration, keyed by conversationId (supports "*" wildcard) */
   groups: z.record(z.string(), z.object({
     systemPrompt: z.string().optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface DingTalkConfig extends OpenClawConfig {
   debug?: boolean;
   messageType?: 'markdown' | 'card';
   cardTemplateId?: string;
+  enableMediaUpload?: boolean;
   groups?: Record<string, { systemPrompt?: string }>;
   accounts?: Record<string, DingTalkConfig>;
 }
@@ -50,6 +51,7 @@ export interface DingTalkChannelConfig {
   debug?: boolean;
   messageType?: 'markdown' | 'card';
   cardTemplateId?: string;
+  enableMediaUpload?: boolean;
   groups?: Record<string, { systemPrompt?: string }>;
   accounts?: Record<string, DingTalkConfig>;
 }


### PR DESCRIPTION
## 问题描述

AI 生成的图片保存在本地路径（如 `/tmp/screenshot.png`），无法直接在钉钉聊天中显示。用户需要手动将图片上传到钉钉，使用体验不佳。

## 解决方案

新增 `enableMediaUpload` 配置项，启用后系统自动处理 AI 输出中的本地图片：

```json
{
  "channels": {
    "dingtalk": {
      "enableMediaUpload": true
    }
  }
}
```

### 工作流程

1. AI 输出 Markdown 图片：`![截图](/tmp/screenshot.png)`
2. 系统检测到本地路径，自动上传到钉钉
3. 路径替换为 `media_id`：`![截图](@lADPxxx)`
4. 图片正常显示在钉钉聊天中

## 主要改动

### 1. OAPI Token 缓存

```typescript
const oapiTokenCache = new Map<string, { token: string; expiry: number }>();
```

- 媒体上传使用 `oapi.dingtalk.com` 的旧版 token
- 按 `clientId` 隔离，支持多账号

### 2. 媒体上传缓存（含多账号隔离）

```typescript
// 缓存 key 格式：clientId:filePath
function getCachedMediaId(clientId: string, filePath: string): string | null
function cacheMediaId(clientId: string, filePath: string, mediaId: string): void
```

- **缓存 key 使用 `clientId:filePath` 格式**
- 防止流式输出时重复上传同一文件
- 多账号场景下各账号缓存隔离，避免 `media_id` 跨账号复用
- TTL 10 分钟，超过 100 条自动清理

### 3. 系统提示词注入

启用媒体上传后，自动向 AI 注入格式指导：

```markdown
## 钉钉媒体输出规则

输出图片时，直接使用本地文件路径，系统会自动上传：

**正确方式**：
- ![描述](/path/to/image.png)
- ![描述](/tmp/screenshot.jpg)

**禁止**：
- 不要猜测或构造 URL
- 不要对路径添加转义字符
```

### 4. 代码改动

| 文件 | 改动 |
|------|------|
| `src/channel.ts` | 添加上传逻辑、缓存、系统提示词 |
| `src/config-schema.ts` | 新增 `enableMediaUpload` 配置项 |
| `src/types.ts` | 类型定义同步更新 |

## 测试方法

1. 配置 `enableMediaUpload: true`
2. 让 AI 生成包含图片的回复（如截图、图表）
3. 确认图片在钉钉中正常显示
4. 检查日志：`[DingTalk] Image uploaded: /tmp/xxx.png -> @lADPxxx`

## 多账号场景测试

1. 配置两个不同 `clientId` 的账号
2. 同一图片路径分别在两个账号上传
3. 确认各账号获得独立的 `media_id`（日志可见）