### PR TITLE
fix: 修复页面点击Accounts并删除后，accounts是一个空字典，从而导致无法使用默认账户，无法启动Stream监听的问题

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -931,7 +931,7 @@ export const dingtalkPlugin = {
   config: {
     listAccountIds: (cfg: OpenClawConfig): string[] => {
       const config = getConfig(cfg);
-      return config.accounts ? Object.keys(config.accounts) : isConfigured(cfg) ? ['default'] : [];
+      return (config.accounts && Object.keys(config.accounts).length > 0) ? Object.keys(config.accounts) : isConfigured(cfg) ? ['default'] : [];
     },
     resolveAccount: (cfg: OpenClawConfig, accountId?: string) => {
       const config = getConfig(cfg);


### PR DESCRIPTION
当openclaw web控制台点击添加Accounts，然后删除后，保存的配置会是空的字典或者数组:
`"dingtalk": {
    "accounts": {},
    "allowFrom": []
  }`

需要判断字典内容是否为空，不然会找不到default账户，从而无法启动Stream监听