### PR TITLE
feat: 实现钉钉渠道插件的文件上传和发送功能，支持向用户和群组发送图片、视频和文件

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,8 @@ export interface SendMessageOptions {
   useMarkdown?: boolean;
   atUserId?: string | null;
   log?: any;
+  mediaPath?: string;
+  mediaType?: 'image' | 'voice' | 'video' | 'file';
 }
 
 /**


### PR DESCRIPTION
## Summary
实现钉钉渠道插件的原生媒体文件上传和发送功能，支持向用户和群组发送图片、音频、视频和文件。

## 实现原理

### 媒体上传流程
1. 调用 `getAccessToken()` 获取访问令牌
2. 上传文件到 `https://oapi.dingtalk.com/media/upload?access_token=xxx&type=image`
3. 从钉钉获取 `media_id`
4. 使用对应的消息类型发送带有 `media_id` 的消息

### 使用的消息类型
| 媒体类型 | msgKey | 参数 |
|---------|--------|------|
| 图片 | `sampleImageMsg` | `photoURL: media_id` |
| 音频 | `sampleAudio` | `mediaId, duration` |
| 视频/文件 | `sampleFile` | `mediaId, fileName, fileType` |

### API 端点
- 个人消息: `POST https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend`
- 群消息: `POST https://api.dingtalk.com/v1.0/robot/groupMessages/send`

## 新增函数

### `detectMediaTypeFromExtension(filePath)`
根据文件扩展名检测媒体类型：
- `.jpg/.png/.gif/.bmp` → `image`
- `.mp3/.amr/.wav` → `voice`
- `.mp4/.avi/.mov` → `video`
- 其他 → `file`

### `uploadMedia(config, mediaPath, mediaType, log)`
上传本地媒体文件到钉钉媒体服务器，返回 `media_id`。

### `sendProactiveMedia(config, target, mediaPath, mediaType, options)`
发送主动媒体消息到用户或群组。

## 修改的函数

### `outbound.sendMedia`
- 支持真正的媒体上传（替代原来的占位文本）
- 兼容 `mediaPath`、`filePath`、`mediaUrl` 三种参数名
- 返回 `via` 和 `messageId` 供 CLI 显示

### `outbound.sendText`

- 添加 `via` 和 `messageId` 到响应

## 类型更新 (types.ts)
扩展 `SendMessageOptions`：

typescript
mediaPath?: string;
mediaType?: 'image' | 'voice' | 'video' | 'file';
## 使用方式

### CLI
bash
openclaw message send --channel dingtalk --account asuka --target <userId> --media <path>

### message 工具
json
{
  "action": "send",
  "channel": "dingtalk",
  "target": "<userId>",
  "filePath": "<图片路径>"
}
## 限制
- 视频消息作为文件发送（`sampleVideo` 需要单独的封面图）
- 媒体文件由钉钉临时存储（非永久存储）
- 上传限制：每个组织每年 10,000 次


<img width="543" height="366" alt="Weixin Image_20260205220107_71_297" src="https://github.com/user-attachments/assets/9032e19b-792c-4a1d-a310-300cd5d7aa0d" />
<img width="1086" height="504" alt="Weixin Image_20260205220236_74_297" src="https://github.com/user-attachments/assets/e93e3ea8-67a2-430c-9941-9c2a1e43fbf7" />
<img width="542" height="258" alt="Weixin Image_20260205220107_73_297" src="https://github.com/user-attachments/assets/f5ab8c1c-6371-4b9f-8e31-1beeeb821b99" />

