### PR TITLE
fix: targetResolver.looksLikeId 正则支持 base64 中的 '+' 字符

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1370,7 +1370,7 @@ export const dingtalkPlugin = {
   },
   messaging: {
     normalizeTarget: ({ target }: any) => (target ? { targetId: target.replace(/^(dingtalk|dd|ding):/i, '') } : null),
-    targetResolver: { looksLikeId: (id: string): boolean => /^[\w-/=]+$/.test(id), hint: '<conversationId>' },
+    targetResolver: { looksLikeId: (id: string): boolean => /^[\w+\-/=]+$/.test(id), hint: '<conversationId>' },
   },
   outbound: {
     deliveryMode: 'direct',


### PR DESCRIPTION
钉钉 conversationId 为 base64 编码，可能包含 '+' 字符（如 cidixIX+qtR3ZmxEnRDmfHL6g==）， 原正则 /^[\w-/=]+$/ 未包含 '+'，导致群消息发送时报 Unknown target 错误。

修复正则为 /^[\w+\-/=]+$/，完整覆盖 base64 字符集。