### PR TITLE
feat(dingtalk): add quote message support

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -677,7 +677,7 @@ function extractMessageContent(data: DingTalkInboundMessage): MessageContent {
       }
     }
 
-    // Case 2: isReplyMsg=true WITHOUT repliedMsg (mobile client - only has originalMsgId)
+    // Case 2: isReplyMsg=true WITHOUT repliedMsg (rich media quote, mobile or desktop - only has originalMsgId)
     if (textField?.isReplyMsg && !textField?.repliedMsg && data.originalMsgId) {
       return `[这是一条引用消息，原消息ID: ${data.originalMsgId}]\n\n`;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export interface DingTalkInboundMessage {
     senderNick?: string;
     senderId?: string;
   };
-  // 手机端引用，仅有消息ID
+  // 富媒体引用，仅有消息ID的情况（包括手机端和PC端）
   originalMsgId?: string;
   conversationType: string;
   conversationId: string;


### PR DESCRIPTION
## 概述

为 OpenClaw DingTalk 插件添加引用消息（Reply/Quote Message）支持，使 Agent 能够看到用户回复的消息内容。

## 变更内容

### src/types.ts

新增字段到 DingTalkInboundMessage 接口：
- `text.isReplyMsg` - 是否是回复消息
- `text.repliedMsg` - 被回复的消息内容
- `content.quoteContent` - 替代引用格式
- `quoteMessage` - Legacy 引用格式
- `originalMsgId` - 富媒体引用仅有消息ID（手机端和PC端均可能）

### src/channel.ts

新增 `formatQuotedContent()` 函数（约60行），处理：
- PC 端纯文本引用
- PC 端富文本引用
- 富媒体引用（仅消息ID，手机端和PC端均可能出现）
- Legacy 格式
- 替代格式

## 支持的场景

| 场景 | 格式 | 输出 |
|------|------|------|
| PC 端纯文本引用 | text.isReplyMsg + repliedMsg.content.text | [引用消息: "原消息内容"] |
| PC 端富文本引用 | text.isReplyMsg + repliedMsg.content.richText | [引用消息: "文本@某人[表情][图片]"] |
| 富媒体引用（无内容） | isReplyMsg + originalMsgId | [这是一条引用消息，原消息ID: msg_xxx] |

## 测试建议

1. PC 端钉钉群组中引用消息并 @机器人
2. 手机端钉钉引用消息并 @机器人
3. 检查 Agent 收到的消息是否包含 `[引用消息: ...]` 前缀

## 注意

- 当被引用的消息包含富媒体内容（emoji、图片等）时，无论手机端还是PC端，钉钉 API 都不返回被引用消息的具体内容，仅返回消息 ID
- 富文本支持：text, emoji, picture, at