### PR TITLE
fix: keep startAccount promise pending to prevent auto-restart loop

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1827,6 +1827,15 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
         throw err;
       }
 
+      // Keep the promise pending until the channel is stopped.
+      // OpenClaw core treats a resolved startAccount promise as channel exit,
+      // which triggers auto-restart. We must stay pending for the channel's lifetime.
+      if (!stopped && abortSignal && !abortSignal.aborted) {
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+
       // Return stop handler
       return {
         stop: () => {


### PR DESCRIPTION
## Summary

- `startAccount` resolves its promise immediately after connecting. OpenClaw core treats a resolved `startAccount` promise as channel exit and triggers auto-restart with exponential backoff (up to 10 attempts).
- Each restart creates a new `DWClient` + WebSocket **without closing the previous one**, resulting in accumulated zombie WSS connections (visible in proxy dashboards like Clash).
- Fix: after successful connection, await a promise that only resolves when the `abortSignal` fires, keeping the channel alive for its full lifecycle.

## Root Cause

OpenClaw core channel lifecycle (`gateway-cli`):
```javascript
const trackedPromise = Promise.resolve(task) // task = startAccount(ctx)
  .catch(...)
  .finally(() => { /* marks running: false */ })
  .then(async () => {
    // if not manuallyStopped → triggers auto-restart
  });
```

When `startAccount` resolves immediately, the `.then()` chain fires and schedules a restart since the channel wasn't manually stopped.

## Observed Behavior (before fix)

```
01:24:32  connect success → auto-restart 1/10 in 5s
01:24:37  connect success → auto-restart 2/10 in 10s
01:24:47  connect success → auto-restart 3/10 in 21s
01:25:08  connect success → auto-restart 4/10 in 40s
01:25:49  connect success → auto-restart 5/10 in 88s
01:27:17  connect success → auto-restart 6/10 in 166s
...continues to 10/10
```

## After Fix

```
01:32:40  connect success (init phase)
01:32:44  abort signal → clean disconnect (normal config reload)
01:32:49  connect success → stable, no auto-restart
```

## Test plan

- [ ] Verify DingTalk Stream client connects and stays connected without auto-restart loop
- [ ] Verify `abort` signal properly unblocks the keep-alive promise and triggers clean shutdown
- [ ] Verify no zombie WSS connections accumulate over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)