### PR TITLE
refactor: remove shared AI Card cache

### DIFF
--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -16,12 +16,9 @@ vi.mock('axios', () => {
 });
 
 import {
-    cleanupCardCache,
     createAICard,
     finishAICard,
     formatContentForCard,
-    getActiveCardIdByTarget,
-    getCardById,
     streamAICard,
 } from '../../src/card-service';
 import { getAccessToken } from '../../src/auth';
@@ -39,14 +36,13 @@ describe('card-service', () => {
         mockedGetAccessToken.mockResolvedValue('token_abc');
     });
 
-    it('createAICard returns card instance and caches mapping', async () => {
+    it('createAICard returns card instance', async () => {
         mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const card = await createAICard(
             { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
             'cidA1B2C3',
-            { conversationType: '2' } as any,
-            'main'
+            { conversationType: '2' } as any
         );
 
         expect(card).toBeTruthy();
@@ -58,8 +54,7 @@ describe('card-service', () => {
         const card = await createAICard(
             { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
-            { conversationType: '2' } as any,
-            'main'
+            { conversationType: '2' } as any
         );
 
         expect(card).toBeNull();
@@ -191,30 +186,6 @@ describe('card-service', () => {
         expect(result).toContain('思考中');
         expect(result).toContain('> ');
         expect(result.endsWith('…')).toBe(true);
-    });
-
-    it('cleanupCardCache removes expired terminal cards and active mapping', async () => {
-        mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { ok: true } });
-
-        const card = await createAICard(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
-            'cid_old',
-            { conversationType: '2' } as any,
-            'main'
-        );
-
-        expect(card).toBeTruthy();
-        if (!card) {
-            return;
-        }
-
-        card.state = AICardStatus.FINISHED;
-        card.lastUpdated = Date.now() - 2 * 60 * 60 * 1000;
-
-        cleanupCardCache();
-
-        expect(getCardById(card.cardInstanceId)).toBeUndefined();
-        expect(getActiveCardIdByTarget('main:cid_old')).toBeUndefined();
     });
 
     it('refreshes aged token before streaming', async () => {

--- a/tests/unit/send-service-advanced.test.ts
+++ b/tests/unit/send-service-advanced.test.ts
@@ -1,14 +1,6 @@
 import axios from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const cardMocks = vi.hoisted(() => ({
-    getActiveCardIdByTargetMock: vi.fn(),
-    getCardByIdMock: vi.fn(),
-    isCardInTerminalStateMock: vi.fn(),
-    streamAICardMock: vi.fn(),
-    deleteActiveCardByTargetMock: vi.fn(),
-}));
-
 vi.mock('../../src/auth', () => ({
     getAccessToken: vi.fn().mockResolvedValue('token_abc'),
 }));
@@ -22,11 +14,8 @@ vi.mock('axios', () => {
 });
 
 vi.mock('../../src/card-service', () => ({
-    getActiveCardIdByTarget: cardMocks.getActiveCardIdByTargetMock,
-    getCardById: cardMocks.getCardByIdMock,
-    isCardInTerminalState: cardMocks.isCardInTerminalStateMock,
-    streamAICard: cardMocks.streamAICardMock,
-    deleteActiveCardByTarget: cardMocks.deleteActiveCardByTargetMock,
+    isCardInTerminalState: vi.fn(),
+    streamAICard: vi.fn(),
 }));
 
 import { sendMessage } from '../../src/send-service';
@@ -35,7 +24,6 @@ import {
     getProactiveRiskObservation,
     recordProactiveRiskObservation,
 } from '../../src/proactive-risk-registry';
-import { AICardStatus } from '../../src/types';
 
 const mockedAxios = vi.mocked(axios);
 
@@ -43,28 +31,6 @@ describe('send-service advanced branches', () => {
     beforeEach(() => {
         mockedAxios.mockReset();
         clearProactiveRiskObservationsForTest();
-        cardMocks.getActiveCardIdByTargetMock.mockReset();
-        cardMocks.getCardByIdMock.mockReset();
-        cardMocks.isCardInTerminalStateMock.mockReset();
-        cardMocks.streamAICardMock.mockReset();
-        cardMocks.deleteActiveCardByTargetMock.mockReset();
-    });
-
-    it('deletes active card mapping when card is terminal', async () => {
-        cardMocks.getActiveCardIdByTargetMock.mockReturnValue('card_terminal');
-        cardMocks.getCardByIdMock.mockReturnValue({ state: AICardStatus.FINISHED });
-        cardMocks.isCardInTerminalStateMock.mockReturnValue(true);
-        mockedAxios.mockResolvedValue({ data: { processQueryKey: 'q1' } } as any);
-
-        const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', messageType: 'card' } as any,
-            'cidA1B2C3',
-            'text',
-            { accountId: 'main' }
-        );
-
-        expect(cardMocks.deleteActiveCardByTargetMock).toHaveBeenCalledWith('main:cidA1B2C3');
-        expect(result.ok).toBe(true);
     });
 
     it('returns {ok:false} when proactive send throws', async () => {


### PR DESCRIPTION
Should also fix an issue where multiple messages interference with each other. e.g. agent calls message tool.

- Remove global aiCardInstances and activeCardsByTarget caches
- Remove getCardById, getActiveCardIdByTarget, deleteActiveCardByTarget, cleanupCardCache functions
- Pass card instance directly via options instead of looking up by target key
- Simplify send-service and inbound-handler card handling logic