### PR TITLE
fix(ai-card): fix proactive notification being overwritten by AI card reply

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -140,6 +140,8 @@ export async function createAICard(
     );
 
     const isGroup = conversationId.startsWith("cid");
+    // For IM_ROBOT single chat, the openSpaceId must use the sender's userId, not conversationId.
+    const spaceId = isGroup ? conversationId : (data.senderStaffId || data.senderId);
 
     if (!config.cardTemplateId) {
       throw new Error("DingTalk cardTemplateId is not configured.");
@@ -150,19 +152,23 @@ export async function createAICard(
       cardTemplateId: config.cardTemplateId,
       outTrackId: cardInstanceId,
       cardData: {
-        cardParamMap: {},
+        // DingTalk streaming API requires at least one field in cardParamMap to accept subsequent
+        // PUT /v1.0/card/streaming updates; an empty map causes param.empty errors.
+        cardParamMap: { content: "" },
       },
       callbackType: "STREAM",
       imGroupOpenSpaceModel: { supportForward: true },
       imRobotOpenSpaceModel: { supportForward: true },
       openSpaceId: isGroup
-        ? `dtv1.card//IM_GROUP.${conversationId}`
-        : `dtv1.card//IM_ROBOT.${conversationId}`,
+        ? `dtv1.card//IM_GROUP.${spaceId}`
+        : `dtv1.card//IM_ROBOT.${spaceId}`,
       userIdType: 1,
       imGroupOpenDeliverModel: isGroup
         ? { robotCode: config.robotCode || config.clientId }
         : undefined,
-      imRobotOpenDeliverModel: !isGroup ? { spaceType: "IM_ROBOT" } : undefined,
+      imRobotOpenDeliverModel: !isGroup
+        ? { spaceType: "IM_ROBOT", robotCode: config.robotCode || config.clientId }
+        : undefined,
     };
 
     if (isGroup && !config.robotCode) {
@@ -274,6 +280,7 @@ export async function streamAICard(
     );
 
     card.lastUpdated = Date.now();
+    card.lastStreamedContent = content;
     if (finished) {
       card.state = AICardStatus.FINISHED;
     } else if (card.state === AICardStatus.PROCESSING) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,6 +16,7 @@ import {
   detectMediaTypeFromExtension,
   sendMessage,
   sendProactiveMedia,
+  sendProactiveTextOrMarkdown,
   sendBySession,
   uploadMedia,
 } from "./send-service";
@@ -170,22 +171,18 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
     sendText: async ({ cfg, to, text, accountId, log }: any) => {
       const config = getConfig(cfg, accountId);
       try {
-        const result = await sendMessage(config, to, text, { log, accountId });
-        getLogger()?.debug?.(`[DingTalk] sendText: "${text}" result: ${JSON.stringify(result)}`);
-        if (result.ok) {
-          const data = result.data as any;
-          const messageId = String(data?.processQueryKey || data?.messageId || randomUUID());
-          return {
-            channel: "dingtalk",
-            messageId,
-            meta: result.data
-              ? { data: result.data as unknown as Record<string, unknown> }
-              : undefined,
-          };
-        }
-        throw new Error(
-          typeof result.error === "string" ? result.error : JSON.stringify(result.error),
-        );
+        // Proactive messages must bypass sendMessage's card-streaming path so they
+        // are delivered as independent markdown messages and do not overwrite the
+        // AI card that is concurrently streaming the reply to the same conversation.
+        const result = await sendProactiveTextOrMarkdown(config, to, text, { log, accountId });
+        getLogger()?.debug?.(`[DingTalk] sendText: "${text}" sent as proactive markdown`);
+        const data = result as any;
+        const messageId = String(data?.processQueryKey || data?.messageId || randomUUID());
+        return {
+          channel: "dingtalk",
+          messageId,
+          meta: result ? { data: result as unknown as Record<string, unknown> } : undefined,
+        };
       } catch (err: any) {
         if (err?.response?.data !== undefined) {
           log?.error?.(formatDingTalkErrorPayloadLog("outbound.sendText", err.response.data));

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -4,6 +4,7 @@ import { getAccessToken } from "./auth";
 import {
   cleanupCardCache,
   createAICard,
+  deleteActiveCardByTarget,
   finishAICard,
   formatContentForCard,
   getActiveCardIdByTarget,
@@ -417,11 +418,36 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     const existingCardId = getActiveCardIdByTarget(targetKey);
     const existingCard = existingCardId ? getCardById(existingCardId) : undefined;
 
-    // Reuse active non-terminal card to keep one card per conversation.
-    if (existingCard && !isCardInTerminalState(existingCard.state)) {
-      currentAICard = existingCard;
-      log?.debug?.("[DingTalk] Reusing existing active AI card for this conversation.");
-    } else {
+    // Check for stale cards (stuck in non-terminal state for > 5 minutes) and force-close them
+    // to prevent permanently spinning cards that block new responses on the same conversation.
+    const CARD_STALE_THRESHOLD_MS = 5 * 60 * 1000;
+    if (existingCard) {
+      if (!isCardInTerminalState(existingCard.state)) {
+        const cardAge = Date.now() - existingCard.createdAt;
+        if (cardAge > CARD_STALE_THRESHOLD_MS) {
+          log?.warn?.(
+            `[DingTalk] Stale card detected (age=${Math.floor(cardAge / 1000)}s), forcing close`,
+          );
+          try {
+            await streamAICard(existingCard, "会话超时", true, log);
+          } catch (err: any) {
+            log?.debug?.(`[DingTalk] Failed to close stale card: ${err.message}`);
+          }
+          existingCard.state = AICardStatus.FAILED;
+          existingCard.lastUpdated = Date.now();
+          deleteActiveCardByTarget(targetKey);
+        } else {
+          // Valid active card, reuse it.
+          currentAICard = existingCard;
+          log?.debug?.("[DingTalk] Reusing existing active AI card for this conversation.");
+        }
+      } else {
+        // Card is terminal; clean up stale mapping so a new card can be created.
+        deleteActiveCardByTarget(targetKey);
+      }
+    }
+
+    if (!currentAICard) {
       try {
         const aiCard = await createAICard(dingtalkConfig, to, data, accountId, log);
         if (aiCard) {
@@ -499,11 +525,33 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             const toolText = formatContentForCard(textToSend, "tool");
             if (toolText) {
               await streamAICard(currentAICard, toolText, false, log);
+              // Track tool output as fallback final content so finalization doesn't
+              // replace it with the "✅ Done" placeholder when there is no direct AI text.
+              lastCardContent = toolText;
               return;
             }
           }
 
           lastCardContent = textToSend;
+
+          // In card mode, stream directly to the AI card to avoid sendMessage's markdown
+          // fallback path which would send a duplicate text message alongside the card.
+          if (useCardMode && currentAICard && !isCardInTerminalState(currentAICard.state)) {
+            try {
+              await streamAICard(currentAICard, textToSend, false, log);
+            } catch (streamErr: any) {
+              log?.error?.(`[DingTalk] Card stream update failed: ${(streamErr as Error).message}`);
+              if ((streamErr as any)?.response?.data !== undefined) {
+                log?.error?.(
+                  formatDingTalkErrorPayloadLog("inbound.replyDeliver.stream", (streamErr as any).response.data),
+                );
+              }
+              currentAICard.state = AICardStatus.FAILED;
+              currentAICard.lastUpdated = Date.now();
+            }
+            return;
+          }
+
           await sendMessage(dingtalkConfig, to, textToSend, {
             sessionWebhook,
             atUserId: !isDirect ? senderId : null,
@@ -581,11 +629,21 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         const finalContent = finalContentCandidate;
         await finishAICard(currentAICard, finalContent, log);
       } else {
-        const defaultFinalContent = "✅ Done";
-        log?.debug?.(
-          "[DingTalk] No textual content was produced; finalizing AI Card with default completion content.",
-        );
-        await finishAICard(currentAICard, defaultFinalContent, log);
+        // No text from deliver callback — but the card may have received content via sendMessage
+        // (e.g. proactive notifications sent through a tool call). Use lastStreamedContent tracked
+        // on the card instance itself as the final content so it isn't replaced with "✅ Done".
+        const lastStreamed = currentAICard.lastStreamedContent;
+        if (lastStreamed && lastStreamed.trim().length > 0) {
+          log?.debug?.(
+            `[DingTalk] No deliver-callback text; using lastStreamedContent (len=${lastStreamed.length}) as final card content.`,
+          );
+          await finishAICard(currentAICard, lastStreamed, log);
+        } else {
+          log?.debug?.(
+            "[DingTalk] No textual content was produced; finalizing AI Card with default completion content.",
+          );
+          await finishAICard(currentAICard, "✅ Done", log);
+        }
       }
     } catch (err: any) {
       log?.debug?.(`[DingTalk] AI Card finalization failed: ${err.message}`);

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -362,12 +362,14 @@ export async function sendMessage(
             await streamAICard(activeCard, text, false, log);
             return { ok: true };
           } catch (err: any) {
-            // Mark failed and continue to markdown fallback to avoid message loss.
-            log?.warn?.(
-              `[DingTalk] AI Card streaming failed, fallback to markdown: ${err.message}`,
+            // In card mode do NOT fall through to markdown — that would produce a duplicate text
+            // message alongside the still-visible card.  Return an error so callers can decide.
+            log?.error?.(
+              `[DingTalk] AI Card streaming failed: ${err.message}`,
             );
             activeCard.state = AICardStatus.FAILED;
             activeCard.lastUpdated = Date.now();
+            return { ok: false, error: err.message };
           }
         } else {
           deleteActiveCardByTarget(targetKey);

--- a/src/types.ts
+++ b/src/types.ts
@@ -446,6 +446,7 @@ export interface AICardInstance {
   lastUpdated: number;
   state: AICardState; // Current card state: PROCESSING, INPUTING, FINISHED, FAILED
   config?: DingTalkConfig; // Store config reference for token refresh
+  lastStreamedContent?: string; // Last content successfully streamed, used as finalization fallback
 }
 
 /**


### PR DESCRIPTION
## 问题描述

**根本原因**：`sendText`（主动通知发送路径）调用了 `sendMessage()`，该函数会尝试将内容流式写入当前活跃的 AI 卡片。当主动通知发送时，同一张卡片正在并发地流式输出 AI 回复，通知内容先被写入卡片，随后被 deliver 回调中的 AI 回复覆盖，最终卡片以 `✅ Done` 收尾——用户完全看不到通知内容。

## 修复内容

### 1. `channel.ts` — 主要修复
`sendText` 改为直接调用 `sendProactiveTextOrMarkdown()`，完全绕过 `sendMessage` 的卡片流式路径。主动通知以独立的 Markdown 消息发出，AI 卡片专用于 AI 回复。

### 2. `card-service.ts` — 卡片创建修复
- `cardParamMap` 由 `{}` 改为 `{ content: "" }`，修复空 map 导致后续 `PUT /v1.0/card/streaming` 报 `param.empty` 错误的问题
- IM_ROBOT 单聊场景 `openSpaceId` 改用 `senderStaffId/senderId`（原来错误地使用了 `conversationId`）
- `imRobotOpenDeliverModel` 补充 `robotCode` 字段
- 成功 stream 后记录 `lastStreamedContent`

### 3. `inbound-handler.ts` — 稳健性修复
- 新增**僵尸卡片检测**：非终态卡片超过 5 分钟自动强制关闭，防止永久旋转
- 卡片模式下 deliver 回调直接调用 `streamAICard()`，不再经过 `sendMessage`，避免卡片旁边出现重复的文本消息
- 工具输出也记录到 `lastCardContent`，防止 finalize 时被 `✅ Done` 替换
- finalize 时以 `lastStreamedContent` 作为兜底内容

### 4. `send-service.ts`
卡片模式下流式失败不再 fallback 到 Markdown，避免与仍可见的卡片并排出现重复消息。

### 5. `types.ts`
`AICardInstance` 新增 `lastStreamedContent` 字段，记录最后一次成功推送到卡片的内容，用于 finalize 兜底。

## 验证

已在本地部署验证：发送主动通知后，通知以独立消息显示，不再被 AI 卡片回复覆盖。