### PR TITLE
fix: align onboarding cardTemplateKey default with runtime default

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -47,7 +47,7 @@ const DingTalkAccountConfigSchema = z.object({
   cardTemplateId: z.string().optional(),
 
   /** Card template key for streaming updates
-   * Default: 'msgContent' - maps to the content field in the card template
+   * Default: 'content' - maps to the content field in the card template
    * This key is used in the streaming API to update specific fields in the card.
    */
   cardTemplateKey: z.string().optional().default("content"),

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -275,10 +275,10 @@ export const dingtalkOnboardingAdapter: ChannelOnboardingAdapter = {
         String(
           await prompter.text({
             message: "Card Template Key (content field name)",
-            placeholder: "msgContent",
-            initialValue: resolved.cardTemplateKey ?? "msgContent",
+            placeholder: "content",
+            initialValue: resolved.cardTemplateKey ?? "content",
           }),
-        ).trim() || "msgContent";
+        ).trim() || "content";
 
       messageType = "card";
     }

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -26,7 +26,7 @@ describe('dingtalkOnboardingAdapter', () => {
             .mockResolvedValueOnce('ding_corp')
             .mockResolvedValueOnce('12345')
             .mockResolvedValueOnce('tmpl.schema')
-            .mockResolvedValueOnce('msgContent')
+            .mockResolvedValueOnce('')
             .mockResolvedValueOnce('user_a, user_b')
             .mockResolvedValueOnce('7')
             .mockResolvedValueOnce('20');
@@ -62,7 +62,7 @@ describe('dingtalkOnboardingAdapter', () => {
         expect(dingtalkConfig.robotCode).toBe('ding_robot');
         expect(dingtalkConfig.messageType).toBe('card');
         expect(dingtalkConfig.cardTemplateId).toBe('tmpl.schema');
-        expect(dingtalkConfig.cardTemplateKey).toBe('msgContent');
+        expect(dingtalkConfig.cardTemplateKey).toBe('content');
         expect(dingtalkConfig.allowFrom).toEqual(['user_a', 'user_b']);
         expect(dingtalkConfig.maxReconnectCycles).toBe(7);
         expect(dingtalkConfig.mediaMaxMb).toBe(20);


### PR DESCRIPTION
## Summary
This PR fixes an inconsistency in DingTalk onboarding where `cardTemplateKey` still defaulted to `msgContent`, while runtime/schema defaults were already `content`.

## Changes
- Updated onboarding prompt defaults for card template key:
  - placeholder: `content`
  - initial value fallback: `content`
  - empty input fallback: `content`
- Updated config schema comment to reflect the actual default (`content`).
- Adjusted unit test to verify empty onboarding input falls back to `content`.

## Why
This removes confusion during setup and keeps onboarding behavior consistent with runtime card streaming behavior and documented defaults.

## Verification
- `pnpm test tests/unit/onboarding.test.ts`
- `npm run type-check`
