### PR TITLE
fix(dingtalk): preserve quoted media and parse chatRecord payload

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -22,6 +22,7 @@ import {
 } from "./proactive-risk-registry";
 import { getDingTalkRuntime } from "./runtime";
 import { sendBySession, sendMessage } from "./send-service";
+import { appendQuoteJournalEntry, findQuoteJournalEntryByMsgId } from "./quote-journal";
 import type { DingTalkConfig, HandleDingTalkMessageParams, MediaFile } from "./types";
 import { AICardStatus } from "./types";
 import { formatDingTalkErrorPayloadLog, maskSensitiveData } from "./utils";
@@ -197,7 +198,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     return;
   }
 
-  const content = extractMessageContent(data);
+  let content = extractMessageContent(data);
   if (!content.text) {
     return;
   }
@@ -329,6 +330,56 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     agentId: route.agentId,
   });
 
+  const replyMeta = (data.text as any)?.repliedMsg as any;
+  const replyMsgType = String(replyMeta?.msgType || "").trim();
+  const replyMsgId = String(replyMeta?.msgId || data.originalMsgId || "").trim();
+  const replyHasReadableBody =
+    Boolean(replyMeta?.content?.text) ||
+    (Array.isArray(replyMeta?.content?.richText) && replyMeta.content.richText.length > 0);
+
+  const isOriginalMsgReply =
+    Boolean((data.text as any)?.isReplyMsg) &&
+    Boolean(replyMsgId) &&
+    (!Boolean((data.text as any)?.repliedMsg) || !replyHasReadableBody || replyMsgType === "unknownMsgType");
+  if (isOriginalMsgReply && replyMsgId) {
+    try {
+      const quoted = await findQuoteJournalEntryByMsgId({
+        storePath,
+        accountId,
+        conversationId: groupId,
+        msgId: replyMsgId,
+      });
+      if (quoted) {
+        const prefixRegex = /^(\[这是一条引用消息，原消息ID:[^\]]+\]|\[引用消息不可见:[^\]]+\])\s*/;
+        const bodyText = content.text.replace(prefixRegex, "").trim();
+
+        let resolvedQuoted = quoted;
+        const nestedMatch = (quoted.text || "").match(/\[这是一条引用消息，原消息ID:\s*([^\]]+)\]/);
+        if (nestedMatch?.[1]) {
+          const nested = await findQuoteJournalEntryByMsgId({
+            storePath,
+            accountId,
+            conversationId: groupId,
+            msgId: nestedMatch[1].trim(),
+          });
+          if (nested) {
+            resolvedQuoted = nested;
+          }
+        }
+
+        const quotedText = resolvedQuoted.text?.trim() || `[${resolvedQuoted.messageType || "消息"}]`;
+        content = {
+          ...content,
+          text: `[引用消息: "${quotedText}"]\n\n${bodyText}`,
+          mediaPath: content.mediaPath || resolvedQuoted.mediaPath,
+          mediaType: content.mediaType || resolvedQuoted.mediaType,
+        };
+      }
+    } catch (err) {
+      log?.debug?.(`[DingTalk] Quote journal resolve failed: ${String(err)}`);
+    }
+  }
+
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
   if (content.mediaPath && dingtalkConfig.robotCode) {
@@ -338,6 +389,43 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       mediaType = media.mimeType;
     }
   }
+
+  const quoteWithoutImage =
+    content.text.includes("[引用消息:") &&
+    /图|图片|看下|感想/.test(content.text) &&
+    !content.mediaPath &&
+    !mediaPath;
+  if (quoteWithoutImage) {
+    content = {
+      ...content,
+      text: `${content.text}\n\n[系统提示] 当前仅拿到引用文本，未拿到图片文件本体。禁止臆测图片内容，请先请用户补发原图后再分析。`,
+    };
+  }
+
+  const quoteUnavailable = content.text.includes("[引用消息不可见:");
+  if (quoteUnavailable) {
+    content = {
+      ...content,
+      text: `${content.text}\n\n[系统提示] 当前没有拿到被引用消息的正文/附件，只拿到引用占位信息。禁止根据历史聊天臆测“引用内容”。请先明确告知用户：未收到引用原文，请粘贴原文或转发该消息后再总结。`,
+    };
+  }
+
+  try {
+    await appendQuoteJournalEntry({
+      storePath,
+      accountId,
+      conversationId: groupId,
+      msgId: data.msgId,
+      messageType: content.messageType,
+      text: content.text,
+      mediaPath: content.mediaPath,
+      mediaType: content.mediaType,
+      createdAt: data.createAt,
+    });
+  } catch (err) {
+    log?.debug?.(`[DingTalk] Quote journal append failed: ${String(err)}`);
+  }
+
   const envelopeOptions = rt.channel.reply.resolveEnvelopeFormatOptions(cfg);
   const previousTimestamp = rt.channel.session.readSessionUpdatedAt({
     storePath,

--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -47,7 +47,7 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
     const textField = data.text as any;
 
     if (textField?.isReplyMsg && textField?.repliedMsg) {
-      const repliedMsg = textField.repliedMsg;
+      const repliedMsg = textField.repliedMsg as any;
       const content = repliedMsg?.content;
 
       if (content?.text) {
@@ -76,6 +76,13 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
         if (quoteText) {
           return `[引用消息: "${quoteText}"]\n\n`;
         }
+      }
+
+      const repliedMsgType = String(repliedMsg?.msgType || "").trim();
+      const repliedMsgId = String(repliedMsg?.msgId || data.originalMsgId || "").trim();
+      if (repliedMsgType === "unknownMsgType" || repliedMsgType) {
+        const idPart = repliedMsgId ? `，原消息ID: ${repliedMsgId}` : "";
+        return `[引用消息不可见: msgType=${repliedMsgType || "unknown"}${idPart}]\n\n`;
       }
     }
 
@@ -169,6 +176,40 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
       mediaType: "file",
       messageType: "file",
     };
+  }
+
+  if (msgtype === "chatRecord") {
+    const summary = String((data.content as any)?.summary || "").trim();
+    const rawRecord = (data.content as any)?.chatRecord;
+    let parsedLines: string[] = [];
+
+    if (typeof rawRecord === "string" && rawRecord.trim()) {
+      try {
+        const arr = JSON.parse(rawRecord);
+        if (Array.isArray(arr)) {
+          parsedLines = arr
+            .map((it: any) => {
+              const sender = String(it?.senderName || it?.senderNick || it?.senderId || "某人").trim();
+              const content = String(it?.content || it?.text || "").trim();
+              return content ? `${sender}: ${content}` : "";
+            })
+            .filter(Boolean)
+            .slice(0, 20);
+        }
+      } catch {
+        // ignore parse errors and fallback to summary only
+      }
+    }
+
+    const parts: string[] = [];
+    if (summary) {
+      parts.push(`[聊天记录摘要] ${summary}`);
+    }
+    if (parsedLines.length > 0) {
+      parts.push(`[聊天记录内容]\n${parsedLines.join("\n")}`);
+    }
+    const text = parts.join("\n\n") || "[chatRecord消息: 无可读内容]";
+    return { text, messageType: "chatRecord" };
   }
 
   // Fallback: preserve unknown msgtype as readable marker.

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,8 @@ export interface DingTalkInboundMessage {
       downloadCode?: string; // For picture type in richText
     }>;
     quoteContent?: string; // 替代引用格式
+    summary?: string; // chatRecord 摘要
+    chatRecord?: string; // chatRecord 明细(JSON字符串)
   };
   // Legacy 引用格式
   quoteMessage?: {

--- a/tests/unit/message-utils.test.ts
+++ b/tests/unit/message-utils.test.ts
@@ -49,4 +49,48 @@ describe('message-utils', () => {
         expect(content.text).toContain('被引用内容');
         expect(content.text).toContain('当前消息');
     });
+
+    it('marks quote as unavailable when repliedMsg has unknownMsgType and no body', () => {
+        const message = {
+            msgtype: 'text',
+            originalMsgId: 'msg_xxx',
+            text: {
+                content: '聊天记录里面说了啥',
+                isReplyMsg: true,
+                repliedMsg: {
+                    msgType: 'unknownMsgType',
+                    msgId: 'msg_xxx',
+                },
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.text).toContain('引用消息不可见');
+        expect(content.text).toContain('unknownMsgType');
+        expect(content.text).toContain('msg_xxx');
+        expect(content.text).toContain('聊天记录里面说了啥');
+    });
+
+    it('parses chatRecord payload into readable lines', () => {
+        const message = {
+            msgtype: 'chatRecord',
+            content: {
+                summary: '["晴月:音乐现在是不是最少","溯煜:对"]',
+                chatRecord: JSON.stringify([
+                    { senderName: '晴月', content: '音乐现在是不是最少，我看才4个，可以招个10个左右吧' },
+                    { senderName: '晴月', content: '音乐都是啊水在看是吧' },
+                    { senderName: '溯煜', content: '对' },
+                ]),
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.messageType).toBe('chatRecord');
+        expect(content.text).toContain('聊天记录摘要');
+        expect(content.text).toContain('聊天记录内容');
+        expect(content.text).toContain('晴月: 音乐现在是不是最少');
+        expect(content.text).toContain('溯煜: 对');
+    });
 });


### PR DESCRIPTION
## Summary
- preserve quoted image/media metadata in reply extraction (`text.repliedMsg.content.richText`)
- parse `msgtype=chatRecord` payload into readable content (summary + sender/content lines), instead of degrading to placeholder
- improve reply fallback when only message-id metadata is available (`unknownMsgType` / no readable body)
- add regression tests for `chatRecord` parsing and quote fallback behavior

## Why
Two real regressions were observed in DingTalk flows:
1. quoted image exists in payload but was not carried into normalized content
2. forwarded chat record (`chatRecord`) had usable data but was treated as `[chatRecord消息]`

Both caused the assistant to miss available context and answer incorrectly.

## Validation
- `npm test --silent`
- targeted regression:
  - `npm test --silent -- tests/unit/message-utils.test.ts -t "parses chatRecord payload into readable lines"`

## Security / Privacy Check
- reviewed changed files for secret/credential patterns (private keys/tokens/passwords)
- no secrets, private keys, or personal sensitive data introduced in this PR
