### PR TITLE
fix(dingtalk): degrade gracefully on media send failure and split long markdown

### DIFF
--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -50,6 +50,29 @@ function composeCardContentForAppend(previous: string | undefined, incoming: str
   return `${prev}${incoming}`;
 }
 
+const DINGTALK_TEXT_CHUNK_LIMIT = 3800;
+
+function splitMarkdownChunks(text: string, limit = DINGTALK_TEXT_CHUNK_LIMIT): string[] {
+  if (!text || text.length <= limit) return [text];
+  const chunks: string[] = [];
+  let buf = "";
+  const lines = text.split("\n");
+  let inCode = false;
+
+  for (const line of lines) {
+    const fenceCount = (line.match(/```/g) || []).length;
+    if (buf.length + line.length + 1 > limit && buf.length > 0) {
+      if (inCode) buf += "\n```";
+      chunks.push(buf);
+      buf = inCode ? "```\n" : "";
+    }
+    buf += (buf ? "\n" : "") + line;
+    if (fenceCount % 2 === 1) inCode = !inCode;
+  }
+  if (buf) chunks.push(buf);
+  return chunks;
+}
+
 function extractErrorCodeFromResponseData(data: unknown): string | null {
   if (!data || typeof data !== "object") {
     return null;
@@ -306,7 +329,20 @@ export async function sendProactiveMedia(
       log?.error?.(`[DingTalk] Proactive media response${statusLabel}${proactiveRiskTag}`);
       log?.error?.(formatDingTalkErrorPayloadLog("send.proactiveMedia", err.response.data));
     }
-    return { ok: false, error: err.message };
+
+    // Fallback: ensure user still gets a usable link/path text.
+    const fallback = await sendProactiveTextOrMarkdown(
+      config,
+      target,
+      `📎 媒体发送失败，兜底链接/路径：${mediaPath}`,
+      options,
+    ).catch((fallbackErr: any) => ({ __fallbackError: fallbackErr }));
+
+    if ((fallback as any)?.__fallbackError) {
+      return { ok: false, error: `${err.message}; fallback failed: ${(fallback as any).__fallbackError?.message || "unknown"}` };
+    }
+
+    return { ok: true, data: fallback, messageId: (fallback as any)?.processQueryKey || (fallback as any)?.messageId };
   }
 }
 
@@ -346,35 +382,42 @@ export async function sendBySession(
         return result.data;
       }
     } else {
+      const mediaHint = options.mediaUrl || options.mediaPath || options.filePath || "(媒体发送失败)";
+      text = `${text}\n\n📎 媒体发送失败，兜底链接/路径：${mediaHint}`.trim();
       log?.warn?.("[DingTalk] Media upload failed, falling back to text description");
     }
   }
 
   // Fallback to text/markdown reply payload.
   const { useMarkdown, title } = detectMarkdownAndExtractTitle(text, options, "Clawdbot 消息");
+  const chunks = splitMarkdownChunks(text, DINGTALK_TEXT_CHUNK_LIMIT);
 
-  let body: SessionWebhookResponse;
-  if (useMarkdown) {
-    let finalText = text;
-    if (options.atUserId) {
-      finalText = `${finalText} @${options.atUserId}`;
+  let lastResult: any = null;
+  for (const [idx, chunk] of chunks.entries()) {
+    let body: SessionWebhookResponse;
+    if (useMarkdown) {
+      let finalText = chunk;
+      if (options.atUserId && idx === chunks.length - 1) {
+        finalText = `${finalText} @${options.atUserId}`;
+      }
+      body = { msgtype: "markdown", markdown: { title: chunks.length > 1 ? `${title} (${idx + 1}/${chunks.length})` : title, text: finalText } };
+    } else {
+      body = { msgtype: "text", text: { content: chunk } };
     }
-    body = { msgtype: "markdown", markdown: { title, text: finalText } };
-  } else {
-    body = { msgtype: "text", text: { content: text } };
-  }
 
-  if (options.atUserId) {
-    body.at = { atUserIds: [options.atUserId], isAtAll: false };
-  }
+    if (options.atUserId && idx === chunks.length - 1) {
+      body.at = { atUserIds: [options.atUserId], isAtAll: false };
+    }
 
-  const result = await axios({
-    url: sessionWebhook,
-    method: "POST",
-    data: body,
-    headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
-  });
-  return result.data;
+    const result = await axios({
+      url: sessionWebhook,
+      method: "POST",
+      data: body,
+      headers: { "x-acs-dingtalk-access-token": token, "Content-Type": "application/json" },
+    });
+    lastResult = result.data;
+  }
+  return lastResult;
 }
 
 export async function sendMessage(

--- a/tests/unit/send-service-media.test.ts
+++ b/tests/unit/send-service-media.test.ts
@@ -61,7 +61,10 @@ describe('send-service media branches', () => {
         );
 
         const req = mockedAxios.mock.calls[0]?.[0] as any;
-        expect(req.data).toEqual({ msgtype: 'text', text: { content: 'fallback text' } });
+        expect(req.data).toEqual({
+            msgtype: 'text',
+            text: { content: 'fallback text\n\n📎 媒体发送失败，兜底链接/路径：/tmp/a.png' },
+        });
     });
 
     it('sendProactiveMedia returns upload failure when media upload fails', async () => {


### PR DESCRIPTION
## Summary
- fallback to text link/path when proactive media send fails
- append media fallback hint in session webhook send path
- split long markdown messages into safe chunks (~3800 chars) to reduce send failures
- keep @mention only on final chunk

## Test
- updated unit test: tests/unit/send-service-media.test.ts
- local run: npx vitest run tests/unit/message-utils.test.ts tests/unit/send-service-media.test.ts
