### PR TITLE
fix(dingtalk): explicit hint when forwarded chatRecord payload is empty

### DIFF
--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -151,6 +151,25 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
     };
   }
 
+  if (msgtype === "chatRecord") {
+    const summary = String((data.content as any)?.summary || "").trim();
+    const rawRecord = (data.content as any)?.chatRecord;
+    if (
+      summary === "[]" ||
+      (typeof rawRecord === "string" && rawRecord.trim() === "[]") ||
+      (Array.isArray(rawRecord) && rawRecord.length === 0)
+    ) {
+      return {
+        text: "[系统提示] 没有读到引用记录（chatRecord 为空）。请改用逐条转发、复制原文，或重新转发非空聊天记录。",
+        messageType: "chatRecord",
+      };
+    }
+    if (summary) {
+      return { text: `[聊天记录摘要] ${summary}`, messageType: "chatRecord" };
+    }
+    return { text: "[chatRecord消息: 无可读内容]", messageType: "chatRecord" };
+  }
+
   // Fallback: preserve unknown msgtype as readable marker.
   return { text: data.text?.content?.trim() || `[${msgtype}消息]`, messageType: msgtype };
 }


### PR DESCRIPTION
## Summary
- add explicit fallback text for `msgtype=chatRecord` when payload is empty
- detect empty forwarded records via:
  - `content.summary == "[]"`
  - `content.chatRecord == "[]"`
  - empty `chatRecord` array

## Why
In some DingTalk clients, merged-forward chatRecord callbacks may arrive with empty payloads.
Without an explicit hint, users may think parsing failed silently.

## Test
- replayed with sample payload:
  - `msgtype=chatRecord`
  - `summary=[]`
  - `chatRecord=[]`
- verified extractor returns clear system hint instead of ambiguous summary text
