### PR TITLE
feat(dingtalk): add config flag to bypass proxy for outbound send APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ openclaw gateway restart
 | `initialReconnectDelay` | number   | `1000`       | 初始重连延迟（毫秒）                        |
 | `maxReconnectDelay`     | number   | `60000`      | 最大重连延迟（毫秒）                        |
 | `reconnectJitter`       | number   | `0.3`        | 重连延迟抖动因子（0-1）                     |
+| `bypassProxyForSend`    | boolean  | `false`      | 仅对 send/card/upload 出站请求绕过系统 HTTP(S) 代理 |
 
 ### 连接鲁棒性配置
 
@@ -375,6 +376,7 @@ openclaw gateway restart
 - **initialReconnectDelay**: 第一次重连的初始延迟（毫秒），后续重连会按指数增长。
 - **maxReconnectDelay**: 重连延迟的上限（毫秒），防止等待时间过长。
 - **reconnectJitter**: 延迟抖动因子，在延迟基础上增加随机变化（±30%），避免多个客户端同时重连。
+- **bypassProxyForSend**: 仅作用于发送链路（session send / proactive send / AI card / media upload），不影响如 `getAccessToken` 之类的其他出站请求。
 
 重连延迟计算公式：`delay = min(initialDelay × 2^attempt, maxDelay) × (1 ± jitter)`
 

--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -6,7 +6,7 @@ import { getAccessToken } from "./auth";
 import { stripTargetPrefix } from "./config";
 import { resolveOriginalPeerId } from "./peer-id-registry";
 import { readNamespaceJson, resolveNamespacePath, writeNamespaceJsonAtomic } from "./persistence-store";
-import { formatDingTalkErrorPayloadLog } from "./utils";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 import type {
   AICardInstance,
   AICardStreamingRequest,
@@ -58,10 +58,6 @@ interface PendingCardStateFile {
   version: number;
   updatedAt: number;
   pendingCards: PendingCardRecord[];
-}
-
-function getProxyBypassOption(config: DingTalkConfig): { proxy: false } | Record<string, never> {
-  return config.bypassProxyForSend ? { proxy: false } : {};
 }
 
 function getCardStateFilePath(storePath?: string): string | null {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -90,7 +90,7 @@ const DingTalkAccountConfigSchema = z.object({
   /** Maximum inbound media file size in MB (overrides runtime default when set) */
   mediaMaxMb: z.number().int().min(1).optional(),
 
-  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send APIs */
+  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send/card/upload APIs */
   bypassProxyForSend: z.boolean().optional().default(false),
 
   proactivePermissionHint: z

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -15,7 +15,7 @@ import { BlockList, isIP } from "node:net";
 import axios from "axios";
 import FormData from "form-data";
 import type { DingTalkConfig, Logger } from "./types";
-import { formatDingTalkErrorPayloadLog } from "./utils";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 
 /**
  * Calculate MP3 duration in seconds by parsing MPEG frame headers
@@ -618,7 +618,7 @@ export async function uploadMedia(
       headers: form.getHeaders(),
       maxBodyLength: Infinity,
       maxContentLength: Infinity,
-      ...(config.bypassProxyForSend ? { proxy: false } : {}),
+      ...getProxyBypassOption(config),
     });
 
     if (response.data?.errcode === 0 && response.data?.media_id) {

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -16,7 +16,7 @@ import {
   getProactiveRiskObservation,
   recordProactiveRiskObservation,
 } from "./proactive-risk-registry";
-import { formatDingTalkErrorPayloadLog } from "./utils";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 import type {
   AICardInstance,
   AxiosResponse,
@@ -48,19 +48,6 @@ function composeCardContentForAppend(previous: string | undefined, incoming: str
     return `${prev}${incoming}`;
   }
   return `${prev}${incoming}`;
-}
-
-function getProxyBypassOption(config: DingTalkConfig): { proxy: false } | Record<string, never> {
-  return config.bypassProxyForSend ? { proxy: false } : {};
-}
-
-function extractOutboundMessageId(payload: unknown): string | undefined {
-  if (!payload || typeof payload !== "object") {
-    return undefined;
-  }
-  const data = payload as Record<string, unknown>;
-  const value = data.processQueryKey ?? data.messageId ?? data.msgid;
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function extractErrorCodeFromResponseData(data: unknown): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,9 +61,7 @@ export interface DingTalkConfig extends OpenClawConfig {
   useConnectionManager?: boolean;
   /** Maximum inbound media file size in MB (overrides runtime default when set) */
   mediaMaxMb?: number;
-  /** Whether to enable underlying stream keepAlive heartbeat (default: false for stability) */
-  keepAlive?: boolean;
-  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send APIs */
+  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send/card/upload APIs */
   bypassProxyForSend?: boolean;
   proactivePermissionHint?: {
     enabled?: boolean;
@@ -104,9 +102,7 @@ export interface DingTalkChannelConfig {
   useConnectionManager?: boolean;
   /** Maximum inbound media file size in MB (overrides runtime default when set) */
   mediaMaxMb?: number;
-  /** Whether to enable underlying stream keepAlive heartbeat (default: false for stability) */
-  keepAlive?: boolean;
-  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send APIs */
+  /** Bypass system/global HTTP(S) proxy for DingTalk outbound send/card/upload APIs */
   bypassProxyForSend?: boolean;
   proactivePermissionHint?: {
     enabled?: boolean;
@@ -631,6 +627,7 @@ export function resolveDingTalkAccount(
       maxReconnectCycles: dingtalk?.maxReconnectCycles,
       useConnectionManager: dingtalk?.useConnectionManager,
       mediaMaxMb: dingtalk?.mediaMaxMb,
+      bypassProxyForSend: dingtalk?.bypassProxyForSend,
       proactivePermissionHint: dingtalk?.proactivePermissionHint,
     };
     return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,10 @@ export function formatDingTalkErrorPayloadLog(
   return `${prefix}[ErrorPayload][${scope}] ${formatDingTalkErrorPayload(payload)}`;
 }
 
+export function getProxyBypassOption(config?: { bypassProxyForSend?: boolean }): { proxy: false } | Record<string, never> {
+  return config?.bypassProxyForSend ? { proxy: false } : {};
+}
+
 function getHeaderCaseInsensitive(headers: unknown, key: string): string | undefined {
   if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
     return undefined;

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -97,6 +97,24 @@ describe('card-service', () => {
         expect(body.imRobotOpenDeliverModel).toEqual({ spaceType: 'IM_ROBOT', robotCode: 'robot_1' });
     });
 
+    it('createAICard bypasses proxy when configured', async () => {
+        mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { ok: true } });
+
+        await createAICard(
+            {
+                clientId: 'id',
+                clientSecret: 'sec',
+                cardTemplateId: 'tmpl.schema',
+                robotCode: 'robot_1',
+                bypassProxyForSend: true,
+            } as any,
+            'manager123'
+        );
+
+        const requestConfig = mockedAxios.post.mock.calls[0]?.[2];
+        expect(requestConfig?.proxy).toBe(false);
+    });
+
     it('createAICard returns null when templateId is missing', async () => {
         const card = await createAICard(
             { clientId: 'id', clientSecret: 'sec' } as any,

--- a/tests/unit/send-service-media.test.ts
+++ b/tests/unit/send-service-media.test.ts
@@ -64,6 +64,21 @@ describe('send-service media branches', () => {
         expect(req.data).toEqual({ msgtype: 'text', text: { content: 'fallback text' } });
     });
 
+    it('sendBySession bypasses proxy when configured', async () => {
+        mockedUploadMedia.mockResolvedValueOnce('media_img_proxy');
+        mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
+
+        await sendBySession(
+            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', bypassProxyForSend: true } as any,
+            'https://session.webhook',
+            'ignored text',
+            { mediaPath: '/tmp/a.png', mediaType: 'image' }
+        );
+
+        const req = mockedAxios.mock.calls[0]?.[0] as any;
+        expect(req.proxy).toBe(false);
+    });
+
     it('sendProactiveMedia returns upload failure when media upload fails', async () => {
         mockedUploadMedia.mockResolvedValueOnce(null);
 
@@ -111,5 +126,20 @@ describe('send-service media branches', () => {
         expect(req.data.msgKey).toBe('sampleAudio');
         expect(JSON.parse(req.data.msgParam)).toEqual({ mediaId: 'media_voice_1', duration: '1000' });
         expect(result.ok).toBe(true);
+    });
+
+    it('sendProactiveMedia bypasses proxy when configured', async () => {
+        mockedUploadMedia.mockResolvedValueOnce('media_voice_proxy');
+        mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_proxy' } } as any);
+
+        await sendProactiveMedia(
+            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', bypassProxyForSend: true } as any,
+            'user_123',
+            '/tmp/a.amr',
+            'voice'
+        );
+
+        const req = mockedAxios.mock.calls[0]?.[0] as any;
+        expect(req.proxy).toBe(false);
     });
 });

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -74,11 +74,29 @@ describe('types helpers', () => {
                     clientId: 'cli',
                     clientSecret: 'sec',
                     mediaMaxMb: 50,
+                    bypassProxyForSend: true,
                 },
             },
         } as any;
 
         const account = resolveDingTalkAccount(cfg, 'default');
         expect(account.mediaMaxMb).toBe(50);
+        expect(account.bypassProxyForSend).toBe(true);
+    });
+
+    it('resolves named account with inherited bypassProxyForSend default', () => {
+        const cfg = {
+            channels: {
+                dingtalk: {
+                    bypassProxyForSend: true,
+                    accounts: {
+                        main: { clientId: 'cli_main', clientSecret: 'sec_main' },
+                    },
+                },
+            },
+        } as any;
+
+        const account = resolveDingTalkAccount(cfg, 'main');
+        expect(account.bypassProxyForSend).toBe(true);
     });
 });


### PR DESCRIPTION
Summary
- add a bypassProxyForSend config flag for DingTalk outbound send APIs
- apply proxy bypass consistently across proactive send, card send, and media upload paths
- keep the behavior opt-in so existing deployments are unchanged by default

Why
Some DingTalk send flows are more reliable when outbound API calls do not inherit the host's global HTTP proxy settings. This makes that workaround explicit and configurable.

Scope
Atomic outbound transport/config change only.

Verification
- cherry-pick resolved cleanly against current main
- local automated tests could not be run in this worktree because vitest is not installed in the current environment