### PR TITLE
fix(dingtalk): add explicit hint when chatRecord payload is empty

### DIFF
--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -183,5 +183,25 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
     };
   }
 
+  if (msgtype === "chatRecord") {
+    const summary = String((data.content as any)?.summary || "").trim();
+    const rawRecord = (data.content as any)?.chatRecord;
+    if (
+      summary === "[]" ||
+      (typeof rawRecord === "string" && rawRecord.trim() === "[]") ||
+      (Array.isArray(rawRecord) && rawRecord.length === 0)
+    ) {
+      return {
+        text: "[系统提示] 没有读到引用记录（chatRecord 为空）。请改用逐条转发、复制原文，或重新转发非空聊天记录。",
+        messageType: "chatRecord",
+        quoted: quoted ?? undefined,
+      };
+    }
+    if (summary) {
+      return { text: `[聊天记录摘要] ${summary}`, messageType: "chatRecord", quoted: quoted ?? undefined };
+    }
+    return { text: "[chatRecord消息: 无可读内容]", messageType: "chatRecord", quoted: quoted ?? undefined };
+  }
+
   return { text: data.text?.content?.trim() || `[${msgtype}消息]`, messageType: msgtype, quoted: quoted ?? undefined };
 }


### PR DESCRIPTION
Summary
- add a clear user-facing hint when DingTalk chatRecord payloads are empty
- keep the existing quoted-message parsing behavior unchanged

Why
Empty chatRecord payloads currently degrade into vague fallback text. This makes the failure mode explicit so users know to resend the original content in a readable form.

Scope
Atomic message parsing fix in src/message-utils.ts only.

Verification
- cherry-pick resolved cleanly against current main
- local automated tests were not run in this worktree