### PR TITLE
fix(dingtalk): normalize Windows absolute media paths safely

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export function resolveRelativePath(input: string): string {
   }
 
   const segments = (value: string): string[] => value.split(/[\\/]+/).filter(Boolean);
+  const isWindowsDriveAbsolute = /^[a-zA-Z]:[\\/]/.test(trimmed);
 
   // Expand bare "~" and "~/" or "~\\" prefixes into the user home directory.
   if (trimmed === "~") {
@@ -61,6 +62,22 @@ export function resolveRelativePath(input: string): string {
   }
   if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
     return path.resolve(os.homedir(), ...segments(trimmed.slice(2)));
+  }
+
+  // Keep Windows drive-absolute input stable across platforms.
+  if (isWindowsDriveAbsolute) {
+    return path.win32.normalize(trimmed);
+  }
+
+  // OpenClaw on Windows may pass root-absolute workspace paths without the
+  // leading "\" (for example: Users\name\.openclaw\workspace\file.png).
+  if (
+    process.platform === "win32" &&
+    /^Users[\\/]/i.test(trimmed) &&
+    /[\\/]\.openclaw(?:[\\/]|$)/i.test(trimmed)
+  ) {
+    const driveRoot = path.parse(process.cwd()).root;
+    return path.win32.resolve(driveRoot, trimmed);
   }
 
   // Treat both "/" and "\\" as absolute root prefixes for cross-platform input.

--- a/tests/unit/config-advanced.test.ts
+++ b/tests/unit/config-advanced.test.ts
@@ -107,6 +107,23 @@ describe('config advanced', () => {
         expect(resolveRelativePath('./tmp/x')).toBe(path.resolve(process.cwd(), 'tmp', 'x'));
         expect(resolveRelativePath('../tmp/x')).toBe(path.resolve(process.cwd(), '..', 'tmp', 'x'));
         expect(resolveRelativePath('..\\tmp\\x')).toBe(path.resolve(process.cwd(), '..', 'tmp', 'x'));
+        expect(resolveRelativePath('C:\\Users\\angel\\a\\b.png')).toBe(
+            path.win32.normalize('C:\\Users\\angel\\a\\b.png'),
+        );
+        expect(resolveRelativePath('C:/Users/angel/a/b.png')).toBe(
+            path.win32.normalize('C:/Users/angel/a/b.png'),
+        );
+    });
+
+    it('resolveRelativePath recovers stripped leading slash for .openclaw workspace paths on Windows', () => {
+        if (process.platform !== 'win32') {
+            expect(true).toBe(true);
+            return;
+        }
+
+        const input = 'Users\\angel\\.openclaw\\workspace\\card.png';
+        const expected = path.win32.resolve(path.parse(process.cwd()).root, input);
+        expect(resolveRelativePath(input)).toBe(expected);
     });
 
     it('resolveUserPath remains as backward-compatible alias', () => {


### PR DESCRIPTION
## Summary
- fix Windows drive-absolute path handling in `resolveRelativePath` (`C:\\...` / `C:/...`)
- recover Windows workspace paths when leading slash is stripped in runtime input (`Users\\...\\.openclaw\\workspace\\...`)
- keep account config inheritance logic unchanged (no behavior change to `getConfig`)

## Why
In some Windows deployments, outbound media paths can be parsed as relative paths, which leads to wrong resolved paths and media upload failures.

This PR focuses only on path normalization and intentionally avoids unrelated refactors.

## Scope
- `src/config.ts`
- `tests/unit/config-advanced.test.ts`

## Verification
- `pnpm vitest run tests/unit/config-advanced.test.ts tests/unit/config.test.ts`
- `pnpm test`

Result on local branch:
- config tests passed
- full suite passed (`214 passed`)

## Risk
Low.
- only adds targeted path resolution branches
- no changes to channel routing/session/config merge semantics

## Rollback
Revert this commit:
- `a44307b`

## References
- Refs #204
