### PR TITLE
feat(dingtalk): add learn clear-all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ node scripts/feedback-learning-debug.mjs --storePath /path/to/session-store.json
   - `/learn list`
   - `/learn disable <ruleId>`
   - `/learn delete <ruleId>`
+  - `/learn clear all confirm`
 
 #### 真实可直接照抄的例子
 
@@ -559,6 +560,12 @@ node scripts/feedback-learning-debug.mjs --storePath /path/to/session-store.json
 1. 先用 `/learn list` 找到 `ruleId`
 2. 先执行 `/learn disable <ruleId>`
 3. 确认问题消失后，再决定是否 `/learn delete <ruleId>`
+
+#### 一键清空学习状态
+
+- owner 发：`/learn clear all confirm`
+- 会清空当前账号下的手工规则、目标规则、目标组、会话笔记与反馈痕迹
+- 这是高破坏性操作，所以必须显式带 `confirm`
 
 ## 安全策略
 

--- a/src/feedback-learning-service.ts
+++ b/src/feedback-learning-service.ts
@@ -4,6 +4,7 @@ import {
   appendOutboundReplySnapshot,
   appendReflectionRecord,
   appendSessionLearningNote,
+  clearAllLearningState,
   deleteScopedRule,
   FeedbackKind,
   FeedbackEventRecord,
@@ -611,6 +612,19 @@ export function listScopedLearningRules(params: {
   accountId: string;
 }): ScopedLearnedRuleRecord[] {
   return listAllScopedRules(params);
+}
+
+export function clearAllManualLearningState(params: {
+  storePath?: string;
+  accountId: string;
+}): {
+  globalRules: number;
+  targetRules: number;
+  targetSets: number;
+  sessionNotes: number;
+  feedbackArtifacts: number;
+} {
+  return clearAllLearningState(params);
 }
 
 export function normalizeManualTriggerText(input: string | undefined): string {

--- a/src/feedback-learning-store.ts
+++ b/src/feedback-learning-store.ts
@@ -14,6 +14,7 @@ const SESSION_NOTES_NAMESPACE = "feedback.session-notes";
 const LEARNED_RULES_NAMESPACE = "feedback.learned-rules";
 const TARGET_RULES_NAMESPACE = "feedback.target-rules";
 const TARGET_RULE_INDEX_NAMESPACE = "feedback.target-rules-index";
+const TARGET_ACTIVITY_INDEX_NAMESPACE = "feedback.target-activity-index";
 const TARGET_SETS_NAMESPACE = "feedback.target-sets";
 
 export type FeedbackKind = "explicit_positive" | "explicit_negative" | "implicit_negative";
@@ -98,6 +99,11 @@ interface TargetRuleIndexBucket {
   targetIds: string[];
 }
 
+interface TargetActivityIndexBucket {
+  updatedAt: number;
+  targetIds: string[];
+}
+
 export interface TargetSetRecord {
   name: string;
   targetIds: string[];
@@ -151,12 +157,26 @@ function writeListBucket<T>(
   });
 }
 
+function clearListBucket(
+  namespace: string,
+  params: { storePath?: string; accountId: string; targetId: string },
+): number {
+  if (!params.storePath) {
+    return 0;
+  }
+  const existing = readListBucket<unknown>(namespace, params);
+  const cleared = existing.entries.length;
+  writeListBucket(namespace, { ...params, entries: [] });
+  return cleared;
+}
+
 export function appendFeedbackEvent(
   params: { storePath?: string; accountId: string; targetId: string; event: FeedbackEventRecord },
 ): void {
   const bucket = readListBucket<FeedbackEventRecord>(EVENTS_NAMESPACE, params);
   bucket.entries = trimNewest([...bucket.entries, params.event], MAX_EVENTS);
   writeListBucket(EVENTS_NAMESPACE, { ...params, entries: bucket.entries });
+  touchTargetActivityIndex(params);
 }
 
 export function listFeedbackEvents(
@@ -171,6 +191,7 @@ export function appendOutboundReplySnapshot(
   const bucket = readListBucket<OutboundReplySnapshot>(SNAPSHOTS_NAMESPACE, params);
   bucket.entries = trimNewest([...bucket.entries, params.snapshot], MAX_SNAPSHOTS);
   writeListBucket(SNAPSHOTS_NAMESPACE, { ...params, entries: bucket.entries });
+  touchTargetActivityIndex(params);
 }
 
 export function listOutboundReplySnapshots(
@@ -185,6 +206,7 @@ export function appendReflectionRecord(
   const bucket = readListBucket<ReflectionRecord>(REFLECTIONS_NAMESPACE, params);
   bucket.entries = trimNewest([...bucket.entries, params.reflection], MAX_REFLECTIONS);
   writeListBucket(REFLECTIONS_NAMESPACE, { ...params, entries: bucket.entries });
+  touchTargetActivityIndex(params);
 }
 
 export function listReflectionRecords(
@@ -214,6 +236,7 @@ export function appendSessionLearningNote(
     ...params,
     entries: trimNewest(retained, MAX_SESSION_NOTES),
   });
+  touchTargetActivityIndex(params);
 }
 
 export function listActiveSessionLearningNotes(
@@ -351,6 +374,48 @@ function writeTargetRuleIndex(
       updatedAt: Date.now(),
       targetIds: [...new Set(params.targetIds.filter((targetId) => targetId.trim()))],
     } satisfies TargetRuleIndexBucket,
+  });
+}
+
+function readTargetActivityIndex(
+  params: { storePath?: string; accountId: string },
+): TargetActivityIndexBucket {
+  if (!params.storePath) {
+    return { updatedAt: 0, targetIds: [] };
+  }
+  return readNamespaceJson<TargetActivityIndexBucket>(TARGET_ACTIVITY_INDEX_NAMESPACE, {
+    storePath: params.storePath,
+    scope: { accountId: params.accountId },
+    format: "json",
+    fallback: { updatedAt: 0, targetIds: [] },
+  });
+}
+
+function writeTargetActivityIndex(
+  params: { storePath?: string; accountId: string; targetIds: string[] },
+): void {
+  if (!params.storePath) {
+    return;
+  }
+  writeNamespaceJsonAtomic(TARGET_ACTIVITY_INDEX_NAMESPACE, {
+    storePath: params.storePath,
+    scope: { accountId: params.accountId },
+    format: "json",
+    data: {
+      updatedAt: Date.now(),
+      targetIds: [...new Set(params.targetIds.filter((targetId) => targetId.trim()))],
+    } satisfies TargetActivityIndexBucket,
+  });
+}
+
+function touchTargetActivityIndex(
+  params: { storePath?: string; accountId: string; targetId: string },
+): void {
+  const bucket = readTargetActivityIndex(params);
+  writeTargetActivityIndex({
+    storePath: params.storePath,
+    accountId: params.accountId,
+    targetIds: [...bucket.targetIds, params.targetId],
   });
 }
 
@@ -540,4 +605,99 @@ export function listTargetSets(
     fallback: { updatedAt: 0, sets: {} },
   });
   return Object.values(bucket.sets).toSorted((left, right) => right.updatedAt - left.updatedAt);
+}
+
+export function clearAllLearningState(
+  params: { storePath?: string; accountId: string },
+): {
+  globalRules: number;
+  targetRules: number;
+  targetSets: number;
+  sessionNotes: number;
+  feedbackArtifacts: number;
+} {
+  if (!params.storePath) {
+    return { globalRules: 0, targetRules: 0, targetSets: 0, sessionNotes: 0, feedbackArtifacts: 0 };
+  }
+
+  const globalRules = listLearnedRules(params).length;
+  writeNamespaceJsonAtomic(LEARNED_RULES_NAMESPACE, {
+    storePath: params.storePath,
+    scope: { accountId: params.accountId },
+    format: "json",
+    data: { updatedAt: Date.now(), rules: {} } satisfies LearnedRuleBucket,
+  });
+
+  const targetSetBucket = readNamespaceJson<TargetSetBucket>(TARGET_SETS_NAMESPACE, {
+    storePath: params.storePath,
+    scope: { accountId: params.accountId },
+    format: "json",
+    fallback: { updatedAt: 0, sets: {} },
+  });
+  const targetSets = Object.keys(targetSetBucket.sets).length;
+  writeNamespaceJsonAtomic(TARGET_SETS_NAMESPACE, {
+    storePath: params.storePath,
+    scope: { accountId: params.accountId },
+    format: "json",
+    data: { updatedAt: Date.now(), sets: {} } satisfies TargetSetBucket,
+  });
+
+  const targetIds = [...new Set([
+    ...readTargetRuleIndex(params).targetIds,
+    ...readTargetActivityIndex(params).targetIds,
+  ].filter(Boolean))];
+  let targetRules = 0;
+  let sessionNotes = 0;
+  let feedbackArtifacts = 0;
+
+  for (const targetId of targetIds) {
+    const targetRuleBucket = readTargetRuleBucket({ ...params, targetId });
+    targetRules += Object.keys(targetRuleBucket.rules).length;
+    writeTargetRuleBucket({
+      storePath: params.storePath,
+      accountId: params.accountId,
+      targetId,
+      bucket: { updatedAt: Date.now(), rules: {} },
+    });
+
+    sessionNotes += clearListBucket(SESSION_NOTES_NAMESPACE, {
+      storePath: params.storePath,
+      accountId: params.accountId,
+      targetId,
+    });
+    feedbackArtifacts += clearListBucket(EVENTS_NAMESPACE, {
+      storePath: params.storePath,
+      accountId: params.accountId,
+      targetId,
+    });
+    feedbackArtifacts += clearListBucket(SNAPSHOTS_NAMESPACE, {
+      storePath: params.storePath,
+      accountId: params.accountId,
+      targetId,
+    });
+    feedbackArtifacts += clearListBucket(REFLECTIONS_NAMESPACE, {
+      storePath: params.storePath,
+      accountId: params.accountId,
+      targetId,
+    });
+  }
+
+  writeTargetRuleIndex({
+    storePath: params.storePath,
+    accountId: params.accountId,
+    targetIds: [],
+  });
+  writeTargetActivityIndex({
+    storePath: params.storePath,
+    accountId: params.accountId,
+    targetIds: [],
+  });
+
+  return {
+    globalRules,
+    targetRules,
+    targetSets,
+    sessionNotes,
+    feedbackArtifacts,
+  };
 }

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -14,6 +14,7 @@ import { formatGroupMembers, noteGroupMember } from "./group-members-store";
 import { setCurrentLogger } from "./logger-context";
 import {
   formatLearnAppliedReply,
+  formatLearnClearedReply,
   formatLearnCommandHelp,
   formatLearnDeletedReply,
   formatLearnDisabledReply,
@@ -47,6 +48,7 @@ import {
   applyManualSessionLearningNote,
   applyTargetSetLearningRule,
   buildLearningContextBlock,
+  clearAllManualLearningState,
   createOrUpdateTargetSet,
   deleteManualRule,
   disableManualRule,
@@ -421,6 +423,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       || parsedLearnCommand.scope === "list"
       || parsedLearnCommand.scope === "disable"
       || parsedLearnCommand.scope === "delete"
+      || parsedLearnCommand.scope === "clear"
       || parsedLearnCommand.scope === "target-set-create"
       || parsedLearnCommand.scope === "target-set-apply")
     && !isOwner
@@ -620,6 +623,26 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           existed: result.existed,
           scope: result.scope,
           targetId: result.targetId,
+        }),
+        { log },
+      );
+      return;
+    }
+    if (parsedLearnCommand.scope === "clear" && parsedLearnCommand.clearScope === "all") {
+      const result = clearAllManualLearningState({
+        storePath: accountStorePath,
+        accountId,
+      });
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatLearnClearedReply({
+          scope: "all",
+          globalRules: result.globalRules,
+          targetRules: result.targetRules,
+          targetSets: result.targetSets,
+          sessionNotes: result.sessionNotes,
+          feedbackArtifacts: result.feedbackArtifacts,
         }),
         { log },
       );

--- a/src/learning-command-service.ts
+++ b/src/learning-command-service.ts
@@ -12,6 +12,7 @@ export interface ParsedLearnCommand {
     | "list"
     | "disable"
     | "delete"
+    | "clear"
     | "whoami"
     | "whereami"
     | "owner-status"
@@ -20,6 +21,7 @@ export interface ParsedLearnCommand {
     | "unknown";
   instruction?: string;
   ruleId?: string;
+  clearScope?: "all";
   targetId?: string;
   targetIds?: string[];
   setName?: string;
@@ -74,6 +76,9 @@ export function parseLearnCommand(text: string | undefined): ParsedLearnCommand 
   if (normalized.startsWith("/learn delete ")) {
     const ruleId = raw.slice("/learn delete ".length).trim();
     return ruleId ? { scope: "delete", ruleId } : { scope: "unknown" };
+  }
+  if (normalized === "/learn clear all confirm") {
+    return { scope: "clear", clearScope: "all" };
   }
   if (normalized.startsWith("/learn global ")) {
     return { scope: "global", instruction: raw.slice("/learn global ".length).trim() };
@@ -222,6 +227,7 @@ export function formatLearnCommandHelp(): string {
     "- /learn list：查看当前全局规则、目标规则与目标组摘要",
     "- /learn disable <ruleId>：停用一条规则，停止继续命中，但保留记录",
     "- /learn delete <ruleId>：彻底删除一条规则或目标规则",
+    "- /learn clear all confirm：清空当前账号下的手工规则、目标规则、目标组、会话笔记与反馈痕迹",
     "",
     "权限说明：",
     "- 只有 owner 才能真正执行 /learn 的写操作和控制操作。",
@@ -312,6 +318,26 @@ export function formatLearnDeletedReply(params: {
     "",
     `- ruleId: \`${params.ruleId}\``,
     params.scope === "target" && params.targetId ? `- scope: target (\`${params.targetId}\`)` : "- scope: global",
+  ].join("\n");
+}
+
+export function formatLearnClearedReply(params: {
+  scope: "all";
+  globalRules: number;
+  targetRules: number;
+  targetSets: number;
+  sessionNotes: number;
+  feedbackArtifacts: number;
+}): string {
+  return [
+    "已清空学习状态。",
+    "",
+    `- scope: ${params.scope}`,
+    `- globalRules: ${params.globalRules}`,
+    `- targetRules: ${params.targetRules}`,
+    `- targetSets: ${params.targetSets}`,
+    `- sessionNotes: ${params.sessionNotes}`,
+    `- feedbackArtifacts: ${params.feedbackArtifacts}`,
   ].join("\n");
 }
 

--- a/tests/unit/feedback-learning-service.test.ts
+++ b/tests/unit/feedback-learning-service.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
     analyzeImplicitNegativeFeedback,
     buildLearningContextBlock,
+    clearAllManualLearningState,
+    createOrUpdateTargetSet,
     recordExplicitFeedbackLearning,
     recordOutboundReplyForLearning,
 } from "../../src/feedback-learning-service";
@@ -14,6 +16,7 @@ import {
     listLearnedRules,
     listOutboundReplySnapshots,
     listReflectionRecords,
+    listTargetSets,
 } from "../../src/feedback-learning-store";
 import type { MessageContent } from "../../src/types";
 
@@ -155,5 +158,69 @@ describe("feedback-learning-service", () => {
         expect(events[0]?.kind).toBe("implicit_negative");
         expect(reflections[0]?.category).toBe("quoted_context_missing");
         expect(notes[0]?.instruction).toContain("禁止根据上下文臆测引用内容");
+    });
+
+    it("clears manual learning state across global rules, target rules, target sets, notes and feedback artifacts", () => {
+        const storePath = createStorePath();
+
+        recordOutboundReplyForLearning({
+            enabled: true,
+            storePath,
+            accountId: "main",
+            targetId: "chat-a",
+            sessionKey: "session-a",
+            question: "看下这张图",
+            answer: "这是服务器状态图",
+            mode: "markdown",
+        });
+        recordExplicitFeedbackLearning({
+            enabled: true,
+            autoApply: true,
+            storePath,
+            accountId: "main",
+            targetId: "chat-a",
+            feedbackType: "feedback_down",
+            noteTtlMs: 60_000,
+        });
+        recordExplicitFeedbackLearning({
+            enabled: true,
+            autoApply: true,
+            storePath,
+            accountId: "main",
+            targetId: "chat-b",
+            feedbackType: "feedback_down",
+            noteTtlMs: 60_000,
+        });
+        createOrUpdateTargetSet({
+            storePath,
+            accountId: "main",
+            name: "ops",
+            targetIds: ["chat-a", "chat-b"],
+        });
+
+        const beforeSets = buildLearningContextBlock({
+            enabled: true,
+            storePath,
+            accountId: "main",
+            targetId: "chat-a",
+            content: createContent({ text: "帮我看图总结一下" }),
+        });
+        expect(beforeSets).toContain("高优先级学习约束");
+
+        const result = clearAllManualLearningState({
+            storePath,
+            accountId: "main",
+        });
+
+        expect(result.globalRules).toBeGreaterThanOrEqual(1);
+        expect(result.targetSets).toBe(1);
+        expect(result.sessionNotes).toBeGreaterThanOrEqual(1);
+        expect(result.feedbackArtifacts).toBeGreaterThanOrEqual(1);
+        expect(listLearnedRules({ storePath, accountId: "main" })).toEqual([]);
+        expect(listActiveSessionLearningNotes({ storePath, accountId: "main", targetId: "chat-a" })).toEqual([]);
+        expect(listOutboundReplySnapshots({ storePath, accountId: "main", targetId: "chat-a" })).toEqual([]);
+        expect(listFeedbackEvents({ storePath, accountId: "main", targetId: "chat-a" })).toEqual([]);
+        expect(listReflectionRecords({ storePath, accountId: "main", targetId: "chat-a" })).toEqual([]);
+        expect(listTargetSets({ storePath, accountId: "main" })).toEqual([]);
     });
 });

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -647,6 +647,85 @@ describe('inbound-handler', () => {
         expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已向目标组批量注入规则');
     });
 
+    it('handleDingTalkMessage clears manual learning state with confirm', async () => {
+        const nowMs = Date.now();
+        const storePath = path.join(fs.mkdtempSync('/tmp/dt-clear-learning-'), 'store.json');
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi.fn().mockReturnValue(storePath);
+        shared.getRuntimeMock.mockReturnValue(runtime);
+        shared.extractMessageContentMock
+            .mockReturnValueOnce({ text: '/learn global 汉堡王是麦当劳的孙子', messageType: 'text' })
+            .mockReturnValueOnce({ text: '/learn target-set create 测试组 #@# cid_a,cid_b', messageType: 'text' })
+            .mockReturnValueOnce({ text: '/learn clear all confirm', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_clear_1',
+                msgtype: 'text',
+                text: { content: '/learn global 汉堡王是麦当劳的孙子' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                senderNick: '宿主',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: nowMs - 2_000,
+            },
+        } as any);
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_clear_2',
+                msgtype: 'text',
+                text: { content: '/learn target-set create 测试组 #@# cid_a,cid_b' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                senderNick: '宿主',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: nowMs - 1_000,
+            },
+        } as any);
+
+        shared.sendBySessionMock.mockClear();
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_clear_3',
+                msgtype: 'text',
+                text: { content: '/learn clear all confirm' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                senderNick: '宿主',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: nowMs,
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已清空学习状态');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('globalRules: 1');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('targetSets: 1');
+    });
+
     it('injects normal learning rules into upstream system context before agent dispatch', async () => {
         const storePath = path.join(fs.mkdtempSync('/tmp/dt-learning-'), 'store.json');
         const runtime = buildRuntime();

--- a/tests/unit/learning-command-service.test.ts
+++ b/tests/unit/learning-command-service.test.ts
@@ -9,4 +9,14 @@ describe("learning-command-service", () => {
       instruction: "引用规则",
     });
   });
+
+  it("parses destructive clear command only with confirm", () => {
+    expect(parseLearnCommand("/learn clear all confirm")).toEqual({
+      scope: "clear",
+      clearScope: "all",
+    });
+    expect(parseLearnCommand("/learn clear all")).toEqual({
+      scope: "unknown",
+    });
+  });
 });


### PR DESCRIPTION
## 变更说明
- 新增 `/learn clear all confirm`，支持 owner 一键清空当前账号下的手工规则、目标规则、目标组、会话笔记与反馈痕迹
- 保持高破坏性操作的显式确认要求：必须带 `all confirm`
- 补充 target activity 索引，确保 clear 不只是清规则，也能真正清掉 session notes 和 feedback artifacts
- 同步更新 README、命令帮助与回归测试

## 验证
- `pnpm vitest run tests/unit/learning-command-service.test.ts tests/unit/feedback-learning-service.test.ts tests/unit/inbound-handler.test.ts tests/unit/config-schema.test.ts tests/unit/types.test.ts`
- `pnpm tsc -p tsconfig.json --noEmit`
- `pnpm run lint`
