### PR TITLE
feat(dingtalk): 支持 owner 控制群共享会话别名

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,59 @@ node scripts/feedback-learning-debug.mjs --storePath /path/to/session-store.json
   - `/learn disable <ruleId>`
   - `/learn delete <ruleId>`
 
+#### 会话共享命令
+
+这些命令同样只允许 owner 使用，但它们不属于 `/learn` 规则注入，而是用于控制“哪个私聊/哪个群共用同一条会话记忆”。
+
+- **查看当前会话 alias**
+  - `/session-alias show`
+  - 用途：查看当前私聊或当前群当前实际使用的 peerId，以及它是默认值还是 override
+- **把当前会话绑定到共享 alias**
+  - `/session-alias set <alias>`
+  - 用途：把当前私聊或当前群绑定到指定共享会话别名
+- **清除当前会话 alias**
+  - `/session-alias clear`
+  - 用途：移除当前私聊或当前群的 override，恢复默认 peerId
+- **owner 远程绑定某个私聊**
+  - `/session-alias bind direct <senderId> <alias>`
+  - 用途：把某个用户私聊直接绑定到共享 alias
+- **owner 远程绑定某个群**
+  - `/session-alias bind group <conversationId> <alias>`
+  - 用途：把某个群直接绑定到共享 alias
+- **owner 远程解除绑定**
+  - `/session-alias unbind direct <senderId>`
+  - `/session-alias unbind group <conversationId>`
+
+#### 会话共享例子
+
+假设你想让“用户 A 的私聊”和“群 project-x”共用同一条会话记忆：
+
+1. 先让用户 A 私聊机器人，发送：
+   - `我是谁`
+   - 记下返回的 `senderId`
+2. 在目标群里发送：
+   - `这里是谁`
+   - 记下返回的 `conversationId`
+3. 由 owner 在任意 owner 会话里执行：
+
+```text
+/session-alias bind direct dingtalk:user_a_sender_id project-x
+/session-alias bind group cid_group_project_x project-x
+```
+
+这样之后：
+- 用户 A 私聊机器人
+- 群 `cid_group_project_x`
+
+都会共用 `project-x` 这条会话记忆。
+
+如果想解除其中一边：
+
+```text
+/session-alias unbind direct dingtalk:user_a_sender_id
+/session-alias unbind group cid_group_project_x
+```
+
 #### 真实可直接照抄的例子
 
 ```text

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -3,13 +3,12 @@ import { normalizeAllowFrom, isSenderAllowed, isSenderGroupAllowed } from "./acc
 import { getAccessToken } from "./auth";
 import {
   createAICard,
-  finishAICard,
   findCardContent,
+  finishAICard,
   formatContentForCard,
   getCardContentByProcessQueryKey,
   isCardInTerminalState,
 } from "./card-service";
-import classifySentenceWithEmoji from "./classifyWithEmoji";
 import { resolveGroupConfig } from "./config";
 import { formatGroupMembers, noteGroupMember } from "./group-members-store";
 import { setCurrentLogger } from "./logger-context";
@@ -33,18 +32,26 @@ import {
   clearProactiveRiskObservationsForTest,
   getProactiveRiskObservationForAny,
 } from "./proactive-risk-registry";
-import {
-  appendQuoteJournalEntry,
-  DEFAULT_JOURNAL_TTL_DAYS,
-  resolveQuotedMessageById,
-} from "./quote-journal";
-import { downloadGroupFile, getUnionIdByStaffId, resolveQuotedFile } from "./quoted-file-service";
-import { cacheInboundDownloadCode, getCachedDownloadCode } from "./quoted-msg-cache";
 import { getDingTalkRuntime } from "./runtime";
 import { sendBySession, sendMessage } from "./send-service";
-import { acquireSessionLock } from "./session-lock";
+import { clearSessionPeerOverride, getSessionPeerOverride, setSessionPeerOverride } from "./session-peer-store";
+import { resolveDingTalkSessionPeer } from "./session-routing";
 import type { DingTalkConfig, HandleDingTalkMessageParams, MediaFile } from "./types";
 import { AICardStatus } from "./types";
+import { acquireSessionLock } from "./session-lock";
+import { cacheInboundDownloadCode, getCachedDownloadCode } from "./quoted-msg-cache";
+import { downloadGroupFile, getUnionIdByStaffId, resolveQuotedFile } from "./quoted-file-service";
+import classifySentenceWithEmoji from "./classifyWithEmoji";
+import {
+  formatSessionAliasBoundReply,
+  formatSessionAliasClearedReply,
+  formatSessionAliasReply,
+  formatSessionAliasSetReply,
+  formatSessionAliasUnboundReply,
+  formatSessionAliasValidationErrorReply,
+  parseSessionCommand,
+  validateSessionAlias,
+} from "./session-command-service";
 import {
   applyManualTargetLearningRule,
   applyManualTargetsLearningRule,
@@ -75,7 +82,6 @@ function shouldSendProactivePermissionHint(params: {
   isDirect: boolean;
   accountId: string;
   senderId: string;
-  senderOriginalId?: string;
   senderStaffId?: string;
   config: DingTalkConfig;
   nowMs: number;
@@ -94,14 +100,11 @@ function shouldSendProactivePermissionHint(params: {
     return false;
   }
 
-  const riskTargets = [params.senderId, params.senderOriginalId, params.senderStaffId]
-    .map((id) => (id || "").trim())
-    .filter((id, index, arr) => Boolean(id) && arr.indexOf(id) === index);
-  if (riskTargets.length === 0) {
-    return false;
-  }
-
-  const riskObservation = getProactiveRiskObservationForAny(params.accountId, riskTargets, params.nowMs);
+  const riskObservation = getProactiveRiskObservationForAny(
+    params.accountId,
+    [params.senderId, params.senderStaffId],
+    params.nowMs,
+  );
   if (!riskObservation || riskObservation.source !== "proactive-api") {
     return false;
   }
@@ -129,33 +132,6 @@ function isUnhandledStopReasonText(value: string): boolean {
   return /^Unhandled stop reason:\s*[A-Za-z0-9_-]+/i.test(normalized);
 }
 
-function stripQuotedPrefixForJournal(value: string): string {
-  return value
-    .replace(/^\[引用消息: .*?\]\n\n/s, "")
-    .replace(/^\[这是一条引用消息，原消息ID: .*?\]\n\n/s, "")
-    .trim();
-}
-function sanitizeGroupPromptName(value?: string): string {
-  return (value || "")
-    .replace(/[\r\n,=]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function buildGroupTurnContextPrompt(params: {
-  conversationId: string;
-  senderDingtalkId: string;
-  senderName?: string;
-}): string {
-  const sanitizedSenderName = sanitizeGroupPromptName(params.senderName) || "Unknown";
-  return [
-    "Current DingTalk group turn context:",
-    `- conversationId: ${params.conversationId}`,
-    `- senderDingtalkId: ${params.senderDingtalkId}`,
-    `- senderName: ${sanitizedSenderName}`,
-    "Treat senderDingtalkId and senderName as the authoritative sender for this turn. Do not guess the current sender from GroupMembers.",
-  ].join("\n");
-}
 /**
  * Download DingTalk media file via runtime media service (sandbox-compatible).
  * Files are stored in the global media inbound directory.
@@ -262,15 +238,13 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     return;
   }
 
-  const extractedContent = extractMessageContent(data);
-  if (!extractedContent.text) {
+  const content = extractMessageContent(data);
+  if (!content.text) {
     return;
   }
 
   const isDirect = data.conversationType === "1";
-  const senderOriginalId = (data.senderId || "").trim();
-  const senderStaffId = (data.senderStaffId || "").trim();
-  const senderId = senderStaffId || senderOriginalId;
+  const senderId = data.senderStaffId || data.senderId;
   const senderName = data.senderNick || "Unknown";
   const groupId = data.conversationId;
   const groupName = data.conversationTitle || "Group";
@@ -285,8 +259,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       isDirect,
       accountId,
       senderId,
-      senderOriginalId,
-      senderStaffId,
+      senderStaffId: data.senderStaffId,
       config: dingtalkConfig,
       nowMs: Date.now(),
     })
@@ -301,9 +274,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     } catch (err: any) {
       log?.debug?.(`[DingTalk] Failed to send proactive permission hint: ${err.message}`);
       if (err?.response?.data !== undefined) {
-        log?.debug?.(
-          formatDingTalkErrorPayloadLog("inbound.proactivePermissionHint", err.response.data),
-        );
+        log?.debug?.(formatDingTalkErrorPayloadLog("inbound.proactivePermissionHint", err.response.data));
       }
     }
   }
@@ -335,9 +306,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         } catch (err: any) {
           log?.debug?.(`[DingTalk] Failed to send access denied message: ${err.message}`);
           if (err?.response?.data !== undefined) {
-            log?.debug?.(
-              formatDingTalkErrorPayloadLog("inbound.accessDeniedReply", err.response.data),
-            );
+            log?.debug?.(formatDingTalkErrorPayloadLog("inbound.accessDeniedReply", err.response.data));
           }
         }
 
@@ -389,23 +358,39 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
   }
 
+  const accountStorePath = rt.channel.session.resolveStorePath(cfg.session?.store, {
+    agentId: accountId,
+  });
+  const currentSessionSourceKind = isDirect ? "direct" : "group";
+  const currentSessionSourceId = isDirect ? senderId : groupId;
+  const peerIdOverride = getSessionPeerOverride({
+    storePath: accountStorePath,
+    accountId,
+    sourceKind: currentSessionSourceKind,
+    sourceId: currentSessionSourceId,
+  });
+  const sessionPeer = resolveDingTalkSessionPeer({
+    isDirect,
+    senderId,
+    conversationId: groupId,
+    peerIdOverride,
+    config: dingtalkConfig,
+  });
   const route = rt.channel.routing.resolveAgentRoute({
     cfg,
     channel: "dingtalk",
     accountId,
-    peer: { kind: isDirect ? "direct" : "group", id: isDirect ? senderId : groupId },
+    peer: { kind: sessionPeer.kind, id: sessionPeer.peerId },
   });
 
   // Route resolved before media download for session context and routing metadata.
   const storePath = rt.channel.session.resolveStorePath(cfg.session?.store, {
     agentId: route.agentId,
   });
-  const accountStorePath = rt.channel.session.resolveStorePath(cfg.session?.store, {
-    agentId: accountId,
-  });
 
   const to = isDirect ? senderId : groupId;
-  const parsedLearnCommand = parseLearnCommand(extractedContent.text);
+  const parsedLearnCommand = parseLearnCommand(content.text);
+  const parsedSessionCommand = parseSessionCommand(content.text);
   const isOwner = isLearningOwner({
     cfg,
     config: dingtalkConfig,
@@ -433,6 +418,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       formatWhereAmIReply({
         conversationId: data.conversationId,
         conversationType: isDirect ? "dm" : "group",
+        peerId: sessionPeer.peerId,
       }),
       { log },
     );
@@ -465,13 +451,134 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       || parsedLearnCommand.scope === "disable"
       || parsedLearnCommand.scope === "delete"
       || parsedLearnCommand.scope === "target-set-create"
-      || parsedLearnCommand.scope === "target-set-apply")
+      || parsedLearnCommand.scope === "target-set-apply"
+      || parsedSessionCommand.scope === "session-alias-show"
+      || parsedSessionCommand.scope === "session-alias-set"
+      || parsedSessionCommand.scope === "session-alias-clear"
+      || parsedSessionCommand.scope === "session-alias-bind"
+      || parsedSessionCommand.scope === "session-alias-unbind")
     && !isOwner
   ) {
     await sendBySession(dingtalkConfig, sessionWebhook, formatOwnerOnlyDeniedReply(), { log });
     return;
   }
   if (isOwner) {
+    if (parsedSessionCommand.scope === "session-alias-show") {
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatSessionAliasReply({
+          sourceKind: currentSessionSourceKind,
+          sourceId: currentSessionSourceId,
+          peerId: sessionPeer.peerId,
+          aliasSource: peerIdOverride ? "override" : "default",
+        }),
+        { log },
+      );
+      return;
+    }
+    if (parsedSessionCommand.scope === "session-alias-set" && parsedSessionCommand.peerId) {
+      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
+      if (aliasValidationError) {
+        await sendBySession(
+          dingtalkConfig,
+          sessionWebhook,
+          formatSessionAliasValidationErrorReply(aliasValidationError),
+          { log },
+        );
+        return;
+      }
+      setSessionPeerOverride({
+        storePath: accountStorePath,
+        accountId,
+        sourceKind: currentSessionSourceKind,
+        sourceId: currentSessionSourceId,
+        peerId: parsedSessionCommand.peerId,
+      });
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatSessionAliasSetReply({
+          sourceKind: currentSessionSourceKind,
+          sourceId: currentSessionSourceId,
+          peerId: parsedSessionCommand.peerId,
+        }),
+        { log },
+      );
+      return;
+    }
+    if (parsedSessionCommand.scope === "session-alias-clear") {
+      clearSessionPeerOverride({
+        storePath: accountStorePath,
+        accountId,
+        sourceKind: currentSessionSourceKind,
+        sourceId: currentSessionSourceId,
+      });
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatSessionAliasClearedReply({
+          sourceKind: currentSessionSourceKind,
+          sourceId: currentSessionSourceId,
+        }),
+        { log },
+      );
+      return;
+    }
+    if (parsedSessionCommand.scope === "session-alias-bind"
+      && parsedSessionCommand.sourceKind
+      && parsedSessionCommand.sourceId
+      && parsedSessionCommand.peerId) {
+      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
+      if (aliasValidationError) {
+        await sendBySession(
+          dingtalkConfig,
+          sessionWebhook,
+          formatSessionAliasValidationErrorReply(aliasValidationError),
+          { log },
+        );
+        return;
+      }
+      setSessionPeerOverride({
+        storePath: accountStorePath,
+        accountId,
+        sourceKind: parsedSessionCommand.sourceKind,
+        sourceId: parsedSessionCommand.sourceId,
+        peerId: parsedSessionCommand.peerId,
+      });
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatSessionAliasBoundReply({
+          sourceKind: parsedSessionCommand.sourceKind,
+          sourceId: parsedSessionCommand.sourceId,
+          peerId: parsedSessionCommand.peerId,
+        }),
+        { log },
+      );
+      return;
+    }
+    if (parsedSessionCommand.scope === "session-alias-unbind"
+      && parsedSessionCommand.sourceKind
+      && parsedSessionCommand.sourceId) {
+      const existed = clearSessionPeerOverride({
+        storePath: accountStorePath,
+        accountId,
+        sourceKind: parsedSessionCommand.sourceKind,
+        sourceId: parsedSessionCommand.sourceId,
+      });
+      await sendBySession(
+        dingtalkConfig,
+        sessionWebhook,
+        formatSessionAliasUnboundReply({
+          sourceKind: parsedSessionCommand.sourceKind,
+          sourceId: parsedSessionCommand.sourceId,
+          existed,
+        }),
+        { log },
+      );
+      return;
+    }
     if (parsedLearnCommand.scope === "global" && parsedLearnCommand.instruction) {
       const applied = applyManualGlobalLearningRule({
         storePath: accountStorePath,
@@ -673,7 +780,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     storePath: accountStorePath,
     accountId,
     targetId: data.conversationId,
-    content: extractedContent,
+    content,
   });
   if (manualForcedReply) {
     await sendBySession(dingtalkConfig, sessionWebhook, manualForcedReply, { log });
@@ -711,55 +818,6 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
   }
 
-  const hasConcreteQuotedPayload =
-    !!extractedContent.quoted?.mediaDownloadCode ||
-    !!extractedContent.quoted?.isQuotedFile ||
-    !!extractedContent.quoted?.isQuotedCard ||
-    extractedContent.quoted?.prefix.startsWith('[引用消息: "') === true;
-  const journalTTLDays = dingtalkConfig.journalTTLDays ?? DEFAULT_JOURNAL_TTL_DAYS;
-  let resolvedContent = extractedContent;
-
-  // Journal-based quoted text resolution when only originalMsgId is present
-  if (data.text?.isReplyMsg && data.originalMsgId && !hasConcreteQuotedPayload) {
-    try {
-      const quoted = resolveQuotedMessageById({
-        storePath,
-        accountId,
-        conversationId: groupId,
-        originalMsgId: data.originalMsgId,
-        ttlDays: journalTTLDays,
-      });
-      if (quoted?.text?.trim()) {
-        const cleanedText = extractedContent.text.replace(
-          /^\[这是一条引用消息，原消息ID: [^\]]+\]\n\n/,
-          "",
-        );
-        resolvedContent = {
-          ...extractedContent,
-          text: `[引用消息: "${quoted.text.trim()}"]\n\n${cleanedText}`,
-        };
-      }
-    } catch (err) {
-      log?.debug?.(`[DingTalk] Quote journal lookup failed: ${String(err)}`);
-    }
-  }
-
-  try {
-    appendQuoteJournalEntry({
-      storePath,
-      accountId,
-      conversationId: groupId,
-      msgId: data.msgId,
-      messageType: resolvedContent.messageType,
-      text: stripQuotedPrefixForJournal(resolvedContent.text),
-      createdAt: data.createAt,
-      ttlDays: journalTTLDays,
-    });
-  } catch (err) {
-    log?.warn?.(`[DingTalk] Quote journal append failed: ${String(err)}`);
-  }
-
-  const content = resolvedContent;
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
   if (content.mediaPath && dingtalkConfig.robotCode) {
@@ -773,12 +831,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // Cache downloadCode (+ spaceId/fileId) for quoted file lookups (DM + group).
   if (content.mediaPath && data.msgId) {
     cacheInboundDownloadCode(
-      accountId,
-      data.conversationId,
-      data.msgId,
-      content.mediaPath,
-      content.messageType,
-      data.createAt,
+      accountId, data.conversationId, data.msgId, content.mediaPath, content.messageType, data.createAt,
       { spaceId: data.content?.spaceId, fileId: data.content?.fileId, storePath },
     );
   }
@@ -839,13 +892,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     if (!media && cached.spaceId && cached.fileId && data.senderStaffId) {
       try {
         const unionId = await getUnionIdByStaffId(dingtalkConfig, data.senderStaffId, log);
-        media = await downloadGroupFile(
-          dingtalkConfig,
-          cached.spaceId,
-          cached.fileId,
-          unionId,
-          log,
-        );
+        media = await downloadGroupFile(dingtalkConfig, cached.spaceId, cached.fileId, unionId, log);
       } catch (err: any) {
         log?.warn?.(`[DingTalk] spaceId+fileId fallback failed: ${err.message}`);
       }
@@ -861,8 +908,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       mediaType = media.mimeType;
     } else {
       content.text = content.text.replace(
-        content.quoted.prefix,
-        "[引用了一张图片，但下载失败]\n\n",
+        content.quoted.prefix, "[引用了一张图片，但下载失败]\n\n",
       );
     }
   }
@@ -881,15 +927,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
     // Step 2 (group only): Cache miss → fall back to group file API time-based matching.
     if (!fileResolved && !isDirect) {
-      const resolved = await resolveQuotedFile(
-        dingtalkConfig,
-        {
-          openConversationId: data.conversationId,
-          senderStaffId: data.senderStaffId,
-          fileCreatedAt: content.quoted.fileCreatedAt,
-        },
-        log,
-      );
+      const resolved = await resolveQuotedFile(dingtalkConfig, {
+        openConversationId: data.conversationId,
+        senderStaffId: data.senderStaffId,
+        fileCreatedAt: content.quoted.fileCreatedAt,
+      }, log);
       if (resolved) {
         mediaPath = resolved.media.path;
         mediaType = resolved.media.mimeType;
@@ -936,15 +978,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
 
     if (!docResolved && !isDirect && content.quoted.fileCreatedAt) {
-      const resolved = await resolveQuotedFile(
-        dingtalkConfig,
-        {
-          openConversationId: data.conversationId,
-          senderStaffId: data.senderStaffId,
-          fileCreatedAt: content.quoted.fileCreatedAt,
-        },
-        log,
-      );
+      const resolved = await resolveQuotedFile(dingtalkConfig, {
+        openConversationId: data.conversationId,
+        senderStaffId: data.senderStaffId,
+        fileCreatedAt: content.quoted.fileCreatedAt,
+      }, log);
       if (resolved) {
         mediaPath = resolved.media.path;
         mediaType = resolved.media.mimeType;
@@ -990,10 +1028,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         : null;
     if (cardContent) {
       const preview = cardContent.length > 50 ? cardContent.slice(0, 50) + "..." : cardContent;
-      content.text = content.text.replace(
-        content.quoted.prefix,
-        `[引用机器人回复: "${preview}"]\n\n`,
-      );
+      content.text = content.text.replace(content.quoted.prefix, `[引用机器人回复: "${preview}"]\n\n`);
     }
     // Card cache miss: prefix already contains "[引用了机器人的回复]", keep as-is.
   }
@@ -1017,15 +1052,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   });
 
   const groupConfig = !isDirect ? resolveGroupConfig(dingtalkConfig, groupId) : undefined;
+  // GroupSystemPrompt is injected every turn (not only first-turn intro).
   const groupSystemPromptParts = !isDirect
-    ? [
-        buildGroupTurnContextPrompt({
-          conversationId: groupId,
-          senderDingtalkId: senderId,
-          senderName,
-        }),
-        groupConfig?.systemPrompt?.trim(),
-      ]
+    ? [`DingTalk group context: conversationId=${groupId}`, groupConfig?.systemPrompt?.trim()]
     : [];
   const extraSystemPrompt =
     [...groupSystemPromptParts, learningContextBlock].filter(Boolean).join("\n\n") || undefined;
@@ -1110,9 +1139,6 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             atUserId: !isDirect ? senderId : null,
             log,
             card: currentAICard,
-            accountId,
-            storePath,
-            conversationId: groupId,
           });
           if (!sendResult.ok) {
             throw new Error(sendResult.error || "Thinking message send failed");
@@ -1120,9 +1146,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         } catch (err: any) {
           log?.debug?.(`[DingTalk] Thinking message failed: ${err.message}`);
           if (err?.response?.data !== undefined) {
-            log?.debug?.(
-              formatDingTalkErrorPayloadLog("inbound.thinkingMessage", err.response.data),
-            );
+            log?.debug?.(formatDingTalkErrorPayloadLog("inbound.thinkingMessage", err.response.data));
           }
         }
       }
@@ -1135,26 +1159,24 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         cfg,
         dispatcherOptions: {
           responsePrefix: "",
-          deliver: async (payload, info) => {
+          deliver: async (payload: any, info?: { kind: string }) => {
             try {
-              const textToSend = payload.text;
+              const textToSend = payload.markdown || payload.text;
               if (!textToSend) {
                 return;
               }
 
               if (typeof textToSend === "string" && isUnhandledStopReasonText(textToSend)) {
-                log?.warn?.(
-                  `[DingTalk] Suppressed stop reason from outbound chat content: ${textToSend}`,
-                );
+                log?.warn?.(`[DingTalk] Suppressed stop reason from outbound chat content: ${textToSend}`);
                 return;
               }
 
-              if (useCardMode && currentAICard && info.kind === "final") {
+              if (useCardMode && currentAICard && info?.kind === "final") {
                 lastCardContent = textToSend;
                 return;
               }
 
-              if (useCardMode && currentAICard && info.kind === "tool") {
+              if (useCardMode && currentAICard && info?.kind === "tool") {
                 if (isCardInTerminalState(currentAICard.state)) {
                   log?.debug?.(
                     `[DingTalk] Skipping tool stream update because card is terminal: state=${currentAICard.state}`,
@@ -1172,9 +1194,6 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                     atUserId: !isDirect ? senderId : null,
                     log,
                     card: currentAICard,
-                    accountId,
-                    storePath,
-                    conversationId: groupId,
                     cardUpdateMode: "append",
                   });
                   if (!sendResult.ok) {
@@ -1191,9 +1210,6 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 atUserId: !isDirect ? senderId : null,
                 log,
                 card: currentAICard,
-                accountId,
-                storePath,
-                conversationId: groupId,
               });
               if (!sendResult.ok) {
                 throw new Error(sendResult.error || "Reply send failed");
@@ -1201,16 +1217,14 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             } catch (err: any) {
               log?.error?.(`[DingTalk] Reply failed: ${err.message}`);
               if (err?.response?.data !== undefined) {
-                log?.error?.(
-                  formatDingTalkErrorPayloadLog("inbound.replyDeliver", err.response.data),
-                );
+                log?.error?.(formatDingTalkErrorPayloadLog("inbound.replyDeliver", err.response.data));
               }
               throw err;
             }
           },
         },
         replyOptions: {
-          onReasoningStream: async (payload) => {
+          onReasoningStream: async (payload: any) => {
             if (!useCardMode || !currentAICard) {
               return;
             }
@@ -1230,10 +1244,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 atUserId: !isDirect ? senderId : null,
                 log,
                 card: currentAICard,
-                accountId,
-                storePath,
-                conversationId: groupId,
-                cardUpdateMode: "replace",
+                cardUpdateMode: "append",
               });
               if (!sendResult.ok) {
                 throw new Error(sendResult.error || "Thinking stream send failed");
@@ -1241,9 +1252,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             } catch (err: any) {
               log?.debug?.(`[DingTalk] Thinking stream update failed: ${err.message}`);
               if (err?.response?.data !== undefined) {
-                log?.debug?.(
-                  formatDingTalkErrorPayloadLog("inbound.thinkingStream", err.response.data),
-                );
+                log?.debug?.(formatDingTalkErrorPayloadLog("inbound.thinkingStream", err.response.data));
               }
             }
           },
@@ -1255,9 +1264,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         try {
           await finishAICard(currentAICard, "❌ 处理失败", log);
         } catch (cardCloseErr: any) {
-          log?.debug?.(
-            `[DingTalk] Failed to finalize card after dispatch error: ${cardCloseErr.message}`,
-          );
+          log?.debug?.(`[DingTalk] Failed to finalize card after dispatch error: ${cardCloseErr.message}`);
           currentAICard.state = AICardStatus.FAILED;
           currentAICard.lastUpdated = Date.now();
         }

--- a/src/learning-command-service.ts
+++ b/src/learning-command-service.ts
@@ -174,15 +174,17 @@ export function formatWhoAmIReply(params: {
 export function formatWhereAmIReply(params: {
   conversationId: string;
   conversationType: "group" | "dm";
+  peerId?: string;
 }): string {
   return [
     params.conversationType === "group" ? "这是当前群聊信息：" : "这是当前会话信息：",
     "",
     `- conversationId: \`${params.conversationId}\``,
     `- conversationType: \`${params.conversationType}\``,
+    params.peerId ? `- peerId: \`${params.peerId}\`` : undefined,
     "",
     "后续如果要定向注入到这里，就使用这个 conversationId。",
-  ].join("\n");
+  ].filter(Boolean).join("\n");
 }
 
 export function formatOwnerStatusReply(params: {
@@ -223,12 +225,20 @@ export function formatLearnCommandHelp(): string {
     "- /learn disable <ruleId>：停用一条规则，停止继续命中，但保留记录",
     "- /learn delete <ruleId>：彻底删除一条规则或目标规则",
     "",
+    "可用的 owner 会话控制命令：",
+    "- /session-alias show：查看当前会话共享会话别名",
+    "- /session-alias set <alias>：将当前会话绑定到指定共享会话别名",
+    "- /session-alias clear：清除当前会话共享会话别名，恢复为默认 peerId",
+    "- /session-alias bind direct <senderId> <alias>：由 owner 远程绑定某个私聊 senderId",
+    "- /session-alias bind group <conversationId> <alias>：由 owner 远程绑定某个群 conversationId",
+    "- /session-alias unbind direct <senderId>：由 owner 远程解除某个私聊 senderId 绑定",
+    "- /session-alias unbind group <conversationId>：由 owner 远程解除某个群 conversationId 绑定",
+    "",
     "权限说明：",
     "- 只有 owner 才能真正执行 /learn 的写操作和控制操作。",
     "- 如果你现在不是 owner，也可以先用 `/learn whoami` 查看 senderId，再由宿主把它加入 commands.ownerAllowFrom。",
   ].join("\n");
 }
-
 export function formatLearnAppliedReply(params: {
   scope: "global" | "session" | "target" | "targets" | "target-set";
   instruction: string;

--- a/src/session-command-service.ts
+++ b/src/session-command-service.ts
@@ -1,0 +1,147 @@
+export interface ParsedSessionCommand {
+  scope:
+    | "session-alias-show"
+    | "session-alias-set"
+    | "session-alias-clear"
+    | "session-alias-bind"
+    | "session-alias-unbind"
+    | "unknown";
+  peerId?: string;
+  sourceKind?: "direct" | "group";
+  sourceId?: string;
+}
+
+const SESSION_ALIAS_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export function parseSessionCommand(text: string | undefined): ParsedSessionCommand {
+  const raw = String(text || "").trim();
+  if (!raw) {
+    return { scope: "unknown" };
+  }
+  const sessionAliasBindMatch = raw.match(/^\/session-alias\s+(bind|unbind)\s+(direct|group)\s+(\S+)(?:\s+(.+))?$/i);
+  if (sessionAliasBindMatch) {
+    const action = sessionAliasBindMatch[1]?.toLowerCase();
+    const sourceKind = sessionAliasBindMatch[2]?.toLowerCase() as "direct" | "group";
+    const sourceId = sessionAliasBindMatch[3]?.trim();
+    const rawPeerId = sessionAliasBindMatch[4]?.trim();
+    if (action === "bind") {
+      return sourceId && rawPeerId
+        ? { scope: "session-alias-bind", sourceKind, sourceId, peerId: rawPeerId }
+        : { scope: "unknown" };
+    }
+    if (action === "unbind") {
+      return sourceId
+        ? { scope: "session-alias-unbind", sourceKind, sourceId }
+        : { scope: "unknown" };
+    }
+  }
+  const sessionAliasMatch = raw.match(/^\/session-alias\s+(show|clear|set)(?:\s+(.+))?$/i);
+  if (!sessionAliasMatch) {
+    return { scope: "unknown" };
+  }
+  const action = sessionAliasMatch[1]?.toLowerCase();
+  const rawPeerId = sessionAliasMatch[2]?.trim();
+  if (action === "show") {
+    return { scope: "session-alias-show" };
+  }
+  if (action === "clear") {
+    return { scope: "session-alias-clear" };
+  }
+  if (action === "set") {
+    return rawPeerId ? { scope: "session-alias-set", peerId: rawPeerId } : { scope: "unknown" };
+  }
+  return { scope: "unknown" };
+}
+
+export function validateSessionAlias(peerId: string | undefined): string | null {
+  const value = String(peerId || "").trim();
+  if (!value) {
+    return "共享会话别名不能为空。";
+  }
+  if (!SESSION_ALIAS_PATTERN.test(value)) {
+    return "共享会话别名仅允许 [a-zA-Z0-9_-]{1,64}。";
+  }
+  return null;
+}
+
+export function formatSessionAliasReply(params: {
+  sourceKind: "direct" | "group";
+  sourceId: string;
+  peerId: string;
+  aliasSource: "default" | "override";
+}): string {
+  return [
+    "当前会话别名：",
+    "",
+    `- source: \`${params.sourceKind}\``,
+    `- sourceId: \`${params.sourceId}\``,
+    `- peerId: \`${params.peerId}\``,
+    `- mode: \`${params.aliasSource}\``,
+  ].join("\n");
+}
+
+export function formatSessionAliasSetReply(params: {
+  sourceKind: "direct" | "group";
+  sourceId: string;
+  peerId: string;
+}): string {
+  return [
+    "已更新当前会话共享会话别名。",
+    "",
+    `- source: \`${params.sourceKind}\``,
+    `- sourceId: \`${params.sourceId}\``,
+    `- peerId: \`${params.peerId}\``,
+    "",
+    "将其他私聊或群也设置为同一个 peerId 后，这些会话会共用同一条会话。",
+  ].join("\n");
+}
+
+export function formatSessionAliasValidationErrorReply(error: string): string {
+  return [
+    "共享会话别名不合法。",
+    "",
+    `- 原因：${error}`,
+    "- 允许规则：`[a-zA-Z0-9_-]{1,64}`",
+    "- 示例：`shared-dev`、`ops_shared`",
+  ].join("\n");
+}
+
+export function formatSessionAliasClearedReply(params: {
+  sourceKind: "direct" | "group";
+  sourceId: string;
+}): string {
+  return [
+    "已清除当前会话共享会话别名。",
+    "",
+    `- source: \`${params.sourceKind}\``,
+    `- sourceId: \`${params.sourceId}\``,
+    `- peerId: 恢复为当前${params.sourceKind === "direct" ? " senderId" : " conversationId"}`,
+  ].join("\n");
+}
+
+export function formatSessionAliasBoundReply(params: {
+  sourceKind: "direct" | "group";
+  sourceId: string;
+  peerId: string;
+}): string {
+  return [
+    "已绑定共享会话别名。",
+    "",
+    `- source: \`${params.sourceKind}\``,
+    `- sourceId: \`${params.sourceId}\``,
+    `- peerId: \`${params.peerId}\``,
+  ].join("\n");
+}
+
+export function formatSessionAliasUnboundReply(params: {
+  sourceKind: "direct" | "group";
+  sourceId: string;
+  existed: boolean;
+}): string {
+  return [
+    params.existed ? "已解除共享会话别名绑定。" : "未找到对应的共享会话别名绑定。",
+    "",
+    `- source: \`${params.sourceKind}\``,
+    `- sourceId: \`${params.sourceId}\``,
+  ].join("\n");
+}

--- a/src/session-peer-store.ts
+++ b/src/session-peer-store.ts
@@ -1,0 +1,77 @@
+import { readNamespaceJson, writeNamespaceJsonAtomic } from "./persistence-store";
+
+const SESSION_PEER_OVERRIDE_NAMESPACE = "session-peer-overrides";
+
+export type SessionPeerSourceKind = "direct" | "group";
+
+interface SessionPeerOverrideBucket {
+  peers: Record<string, string>;
+}
+
+function buildSourceKey(sourceKind: SessionPeerSourceKind, sourceId: string): string {
+  return `${sourceKind}:${sourceId}`;
+}
+
+function readBucket(storePath: string, accountId: string): SessionPeerOverrideBucket {
+  return readNamespaceJson<SessionPeerOverrideBucket>(SESSION_PEER_OVERRIDE_NAMESPACE, {
+    storePath,
+    scope: { accountId },
+    fallback: { peers: {} },
+  });
+}
+
+function writeBucket(storePath: string, accountId: string, bucket: SessionPeerOverrideBucket): void {
+  writeNamespaceJsonAtomic(SESSION_PEER_OVERRIDE_NAMESPACE, {
+    storePath,
+    scope: { accountId },
+    data: bucket,
+  });
+}
+
+export function getSessionPeerOverride(params: {
+  storePath: string;
+  accountId: string;
+  sourceKind: SessionPeerSourceKind;
+  sourceId: string;
+}): string | undefined {
+  const bucket = readBucket(params.storePath, params.accountId);
+  const sourceKey = buildSourceKey(params.sourceKind, params.sourceId);
+  const legacyKey = params.sourceKind === "group" ? params.sourceId : undefined;
+  const value = bucket.peers[sourceKey] ?? (legacyKey ? bucket.peers[legacyKey] : undefined);
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function setSessionPeerOverride(params: {
+  storePath: string;
+  accountId: string;
+  sourceKind: SessionPeerSourceKind;
+  sourceId: string;
+  peerId: string;
+}): void {
+  const bucket = readBucket(params.storePath, params.accountId);
+  const sourceKey = buildSourceKey(params.sourceKind, params.sourceId);
+  bucket.peers[sourceKey] = params.peerId.trim();
+  writeBucket(params.storePath, params.accountId, bucket);
+}
+
+export function clearSessionPeerOverride(params: {
+  storePath: string;
+  accountId: string;
+  sourceKind: SessionPeerSourceKind;
+  sourceId: string;
+}): boolean {
+  const bucket = readBucket(params.storePath, params.accountId);
+  const sourceKey = buildSourceKey(params.sourceKind, params.sourceId);
+  const legacyKey = params.sourceKind === "group" ? params.sourceId : undefined;
+  const existed = Object.prototype.hasOwnProperty.call(bucket.peers, sourceKey)
+    || (legacyKey ? Object.prototype.hasOwnProperty.call(bucket.peers, legacyKey) : false);
+  if (!existed) {
+    return false;
+  }
+  delete bucket.peers[sourceKey];
+  if (legacyKey) {
+    delete bucket.peers[legacyKey];
+  }
+  writeBucket(params.storePath, params.accountId, bucket);
+  return true;
+}

--- a/src/session-routing.ts
+++ b/src/session-routing.ts
@@ -1,0 +1,33 @@
+import type { DingTalkConfig } from "./types";
+
+export interface ResolveDingTalkSessionPeerParams {
+  isDirect: boolean;
+  senderId: string;
+  conversationId: string;
+  peerIdOverride?: string;
+  config: DingTalkConfig;
+}
+
+export interface ResolvedDingTalkSessionPeer {
+  kind: "direct" | "group";
+  peerId: string;
+}
+
+// Keep DingTalk aligned with Feishu's explicit peerId -> sessionKey model:
+// resolve a stable peer identity first, then let OpenClaw build the final session key.
+export function resolveDingTalkSessionPeer(
+  params: ResolveDingTalkSessionPeerParams,
+): ResolvedDingTalkSessionPeer {
+  const normalizedPeerIdOverride = params.peerIdOverride?.trim();
+  if (params.isDirect) {
+    return {
+      kind: "direct",
+      peerId: normalizedPeerIdOverride || params.senderId,
+    };
+  }
+
+  return {
+    kind: "group",
+    peerId: normalizedPeerIdOverride || params.conversationId,
+  };
+}

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -132,4 +132,5 @@ describe('DingTalkConfigSchema', () => {
         expect(parsed.learningAutoApply).toBe(true);
         expect(parsed.learningNoteTtlMs).toBe(120000);
     });
+
 });

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -4,2298 +4,2356 @@ import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const shared = vi.hoisted(() => ({
-  sendBySessionMock: vi.fn(),
-  sendMessageMock: vi.fn(),
-  extractMessageContentMock: vi.fn(),
-  findCardContentMock: vi.fn(),
-  getCardContentByProcessQueryKeyMock: vi.fn(),
-  downloadGroupFileMock: vi.fn(),
-  getRuntimeMock: vi.fn(),
-  getUnionIdByStaffIdMock: vi.fn(),
-  createAICardMock: vi.fn(),
-  finishAICardMock: vi.fn(),
-  resolveQuotedFileMock: vi.fn(),
-  streamAICardMock: vi.fn(),
-  formatContentForCardMock: vi.fn((s: string) => s),
-  isCardInTerminalStateMock: vi.fn(),
-  acquireSessionLockMock: vi.fn(),
-  appendQuoteJournalEntryMock: vi.fn(),
-  resolveQuotedMessageByIdMock: vi.fn(),
+    sendBySessionMock: vi.fn(),
+    sendMessageMock: vi.fn(),
+    extractMessageContentMock: vi.fn(),
+    findCardContentMock: vi.fn(),
+    getCardContentByProcessQueryKeyMock: vi.fn(),
+    downloadGroupFileMock: vi.fn(),
+    getRuntimeMock: vi.fn(),
+    getUnionIdByStaffIdMock: vi.fn(),
+    createAICardMock: vi.fn(),
+    finishAICardMock: vi.fn(),
+    resolveQuotedFileMock: vi.fn(),
+    streamAICardMock: vi.fn(),
+    formatContentForCardMock: vi.fn((s: string) => s),
+    isCardInTerminalStateMock: vi.fn(),
+    acquireSessionLockMock: vi.fn(),
 }));
 
 vi.mock('axios', () => ({
-  default: {
-    post: vi.fn(),
-    get: vi.fn(),
-  },
-  isAxiosError: (err: unknown) => Boolean((err as { isAxiosError?: boolean })?.isAxiosError),
+    default: {
+        post: vi.fn(),
+        get: vi.fn(),
+    },
+    isAxiosError: (err: unknown) => Boolean((err as { isAxiosError?: boolean })?.isAxiosError),
 }));
 
 vi.mock('../../src/auth', () => ({
-  getAccessToken: vi.fn().mockResolvedValue('token_abc'),
+    getAccessToken: vi.fn().mockResolvedValue('token_abc'),
 }));
 
 vi.mock('../../src/runtime', () => ({
-  getDingTalkRuntime: shared.getRuntimeMock,
+    getDingTalkRuntime: shared.getRuntimeMock,
 }));
 
 vi.mock('../../src/message-utils', () => ({
-  extractMessageContent: shared.extractMessageContentMock,
+    extractMessageContent: shared.extractMessageContentMock,
 }));
 
 vi.mock('../../src/send-service', () => ({
-  sendBySession: shared.sendBySessionMock,
-  sendMessage: shared.sendMessageMock,
+    sendBySession: shared.sendBySessionMock,
+    sendMessage: shared.sendMessageMock,
 }));
 
 vi.mock('../../src/card-service', () => ({
-  createAICard: shared.createAICardMock,
-  findCardContent: shared.findCardContentMock,
-  finishAICard: shared.finishAICardMock,
-  formatContentForCard: shared.formatContentForCardMock,
-  getCardContentByProcessQueryKey: shared.getCardContentByProcessQueryKeyMock,
-  isCardInTerminalState: shared.isCardInTerminalStateMock,
-  streamAICard: shared.streamAICardMock,
+    createAICard: shared.createAICardMock,
+    findCardContent: shared.findCardContentMock,
+    finishAICard: shared.finishAICardMock,
+    formatContentForCard: shared.formatContentForCardMock,
+    getCardContentByProcessQueryKey: shared.getCardContentByProcessQueryKeyMock,
+    isCardInTerminalState: shared.isCardInTerminalStateMock,
+    streamAICard: shared.streamAICardMock,
 }));
 
 vi.mock('../../src/session-lock', () => ({
-  acquireSessionLock: shared.acquireSessionLockMock,
-}));
-
-vi.mock('../../src/quote-journal', () => ({
-  DEFAULT_JOURNAL_TTL_DAYS: 7,
-  appendQuoteJournalEntry: shared.appendQuoteJournalEntryMock,
-  resolveQuotedMessageById: shared.resolveQuotedMessageByIdMock,
+    acquireSessionLock: shared.acquireSessionLockMock,
 }));
 
 vi.mock('../../src/quoted-file-service', () => ({
-  downloadGroupFile: shared.downloadGroupFileMock,
-  getUnionIdByStaffId: shared.getUnionIdByStaffIdMock,
-  resolveQuotedFile: shared.resolveQuotedFileMock,
+    downloadGroupFile: shared.downloadGroupFileMock,
+    getUnionIdByStaffId: shared.getUnionIdByStaffIdMock,
+    resolveQuotedFile: shared.resolveQuotedFileMock,
 }));
 
 import {
-  downloadMedia,
-  handleDingTalkMessage,
-  resetProactivePermissionHintStateForTest,
+    downloadMedia,
+    handleDingTalkMessage,
+    resetProactivePermissionHintStateForTest,
 } from '../../src/inbound-handler';
+import { cacheInboundDownloadCode, clearQuotedMsgCacheForTest, getCachedDownloadCode } from '../../src/quoted-msg-cache';
 import { recordProactiveRiskObservation } from '../../src/proactive-risk-registry';
-import {
-  cacheInboundDownloadCode,
-  clearQuotedMsgCacheForTest,
-  getCachedDownloadCode,
-} from '../../src/quoted-msg-cache';
 
 const mockedAxiosPost = vi.mocked(axios.post);
 const mockedAxiosGet = vi.mocked(axios.get);
 
 function buildRuntime() {
-  return {
-    channel: {
-      routing: {
-        resolveAgentRoute: vi
-          .fn()
-          .mockReturnValue({ agentId: 'main', sessionKey: 's1', mainSessionKey: 's1' }),
-      },
-      media: {
-        saveMediaBuffer: vi.fn().mockResolvedValue({
-          path: '/tmp/.openclaw/media/inbound/test-file.png',
-          contentType: 'image/png',
-        }),
-      },
-      session: {
-        resolveStorePath: vi.fn().mockReturnValue('/tmp/store.json'),
-        readSessionUpdatedAt: vi.fn().mockReturnValue(null),
-        recordInboundSession: vi.fn().mockResolvedValue(undefined),
-      },
-      reply: {
-        resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
-        formatInboundEnvelope: vi.fn().mockReturnValue('body'),
-        finalizeInboundContext: vi.fn().mockReturnValue({ SessionKey: 's1' }),
-        dispatchReplyWithBufferedBlockDispatcher: vi
-          .fn()
-          .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
-            await replyOptions?.onReasoningStream?.({ text: 'thinking' });
-            await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
-            await dispatcherOptions.deliver({ text: 'final output' }, { kind: 'final' });
-            return { queuedFinal: 'queued final' };
-          }),
-      },
-    },
-  };
+    return {
+        channel: {
+            routing: { resolveAgentRoute: vi.fn().mockReturnValue({ agentId: 'main', sessionKey: 's1', mainSessionKey: 's1' }) },
+            media: {
+                saveMediaBuffer: vi.fn().mockResolvedValue({
+                    path: '/tmp/.openclaw/media/inbound/test-file.png',
+                    contentType: 'image/png',
+                }),
+            },
+            session: {
+                resolveStorePath: vi.fn().mockReturnValue('/tmp/store.json'),
+                readSessionUpdatedAt: vi.fn().mockReturnValue(null),
+                recordInboundSession: vi.fn().mockResolvedValue(undefined),
+            },
+            reply: {
+                resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+                formatInboundEnvelope: vi.fn().mockReturnValue('body'),
+                finalizeInboundContext: vi.fn().mockReturnValue({ SessionKey: 's1' }),
+                dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                    await replyOptions?.onReasoningStream?.({ text: 'thinking' });
+                    await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
+                    await dispatcherOptions.deliver({ text: 'final output' }, { kind: 'final' });
+                    return { queuedFinal: 'queued final' };
+                }),
+            },
+        },
+    };
 }
 
 describe('inbound-handler', () => {
-  beforeEach(() => {
-    fs.rmSync(path.join(path.dirname('/tmp/store.json'), 'dingtalk-state'), { recursive: true, force: true });
-    mockedAxiosPost.mockReset();
-    mockedAxiosGet.mockReset();
-    shared.sendBySessionMock.mockReset();
-    shared.sendMessageMock.mockReset();
-    shared.sendMessageMock.mockResolvedValue({ ok: true });
-    shared.extractMessageContentMock.mockReset();
-    shared.findCardContentMock.mockReset();
-    shared.findCardContentMock.mockReturnValue(null);
-    shared.getCardContentByProcessQueryKeyMock.mockReset();
-    shared.getCardContentByProcessQueryKeyMock.mockReturnValue(null);
-    shared.createAICardMock.mockReset();
-    shared.downloadGroupFileMock.mockReset();
-    shared.downloadGroupFileMock.mockResolvedValue(null);
-    shared.finishAICardMock.mockReset();
-    shared.getUnionIdByStaffIdMock.mockReset();
-    shared.getUnionIdByStaffIdMock.mockResolvedValue('union_1');
-    shared.resolveQuotedFileMock.mockReset();
-    shared.resolveQuotedFileMock.mockResolvedValue(null);
-    shared.streamAICardMock.mockReset();
-    shared.isCardInTerminalStateMock.mockReset();
+    beforeEach(() => {
+        fs.rmSync(path.join(path.dirname('/tmp/store.json'), 'dingtalk-state'), { recursive: true, force: true });
+        mockedAxiosPost.mockReset();
+        mockedAxiosGet.mockReset();
+        shared.sendBySessionMock.mockReset();
+        shared.sendMessageMock.mockReset();
+        shared.sendMessageMock.mockResolvedValue({ ok: true });
+        shared.extractMessageContentMock.mockReset();
+        shared.findCardContentMock.mockReset();
+        shared.findCardContentMock.mockReturnValue(null);
+        shared.getCardContentByProcessQueryKeyMock.mockReset();
+        shared.getCardContentByProcessQueryKeyMock.mockReturnValue(null);
+        shared.createAICardMock.mockReset();
+        shared.downloadGroupFileMock.mockReset();
+        shared.downloadGroupFileMock.mockResolvedValue(null);
+        shared.finishAICardMock.mockReset();
+        shared.getUnionIdByStaffIdMock.mockReset();
+        shared.getUnionIdByStaffIdMock.mockResolvedValue('union_1');
+        shared.resolveQuotedFileMock.mockReset();
+        shared.resolveQuotedFileMock.mockResolvedValue(null);
+        shared.streamAICardMock.mockReset();
+        shared.isCardInTerminalStateMock.mockReset();
 
-    shared.acquireSessionLockMock.mockReset();
-    shared.acquireSessionLockMock.mockResolvedValue(vi.fn());
-    shared.appendQuoteJournalEntryMock.mockReset();
-    shared.appendQuoteJournalEntryMock.mockReturnValue(undefined);
-    shared.resolveQuotedMessageByIdMock.mockReset();
-    shared.resolveQuotedMessageByIdMock.mockReturnValue(null);
+        shared.acquireSessionLockMock.mockReset();
+        shared.acquireSessionLockMock.mockResolvedValue(vi.fn());
 
-    shared.getRuntimeMock.mockReturnValue(buildRuntime());
-    shared.extractMessageContentMock.mockReturnValue({ text: 'hello', messageType: 'text' });
-    resetProactivePermissionHintStateForTest();
-    clearQuotedMsgCacheForTest();
-    shared.createAICardMock.mockResolvedValue({
-      cardInstanceId: 'card_1',
-      state: '1',
-      lastUpdated: Date.now(),
-    });
-  });
-
-  it('downloadMedia returns file meta when DingTalk download succeeds', async () => {
-    mockedAxiosPost.mockResolvedValueOnce({
-      data: { downloadUrl: 'https://download.url/file' },
-    } as any);
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: Buffer.from('abc'),
-      headers: { 'content-type': 'image/png' },
-    } as any);
-
-    const result = await downloadMedia(
-      { clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1' } as any,
-      'download_code_1',
-    );
-
-    expect(result).toBeTruthy();
-    expect(result?.mimeType).toBe('image/png');
-    expect(result?.path).toContain('/.openclaw/media/inbound/');
-  });
-
-  it('downloadMedia passes mediaMaxMb as maxBytes to saveMediaBuffer', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValue(runtime);
-
-    mockedAxiosPost.mockResolvedValueOnce({
-      data: { downloadUrl: 'https://download.url/file' },
-    } as any);
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: Buffer.from('abc'),
-      headers: { 'content-type': 'application/pdf' },
-    } as any);
-
-    await downloadMedia(
-      { clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1', mediaMaxMb: 50 } as any,
-      'download_code_1',
-    );
-
-    expect(runtime.channel.media.saveMediaBuffer).toHaveBeenCalledWith(
-      expect.any(Buffer),
-      'application/pdf',
-      'inbound',
-      50 * 1024 * 1024,
-    );
-  });
-
-  it('downloadMedia uses runtime default when mediaMaxMb is not set', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValue(runtime);
-
-    mockedAxiosPost.mockResolvedValueOnce({
-      data: { downloadUrl: 'https://download.url/file' },
-    } as any);
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: Buffer.from('abc'),
-      headers: { 'content-type': 'image/png' },
-    } as any);
-
-    await downloadMedia(
-      { clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1' } as any,
-      'download_code_1',
-    );
-
-    const call = runtime.channel.media.saveMediaBuffer.mock.calls[0];
-    expect(call).toHaveLength(3);
-    expect(call[2]).toBe('inbound');
-  });
-
-  it('downloadMedia returns null when robotCode missing', async () => {
-    const result = await downloadMedia(
-      { clientId: 'id', clientSecret: 'sec' } as any,
-      'download_code_1',
-    );
-
-    expect(result).toBeNull();
-    expect(mockedAxiosPost).not.toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage ignores self-message', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm1',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid1',
-        senderId: 'bot_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).not.toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage sends deny message when dmPolicy allowlist blocks sender', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'allowlist', allowFrom: ['user_ok'] } as any,
-      data: {
-        msgId: 'm2',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid1',
-        senderId: 'user_blocked',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('访问受限');
-  });
-
-  it('handleDingTalkMessage returns whoami info for direct fixed command', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '我是谁', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_whoami',
-        msgtype: 'text',
-        text: { content: '我是谁' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'user_raw_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('senderId: `staff_1`');
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `false`');
-    expect(shared.sendMessageMock).not.toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage returns owner status for slash command', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn owner status', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_owner_status',
-        msgtype: 'text',
-        text: { content: '/learn owner status' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `true`');
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).not.toContain('ownerAllowFrom');
-  });
-
-  it('handleDingTalkMessage accepts owner status slash alias', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/owner status', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_owner_status_alias',
-        msgtype: 'text',
-        text: { content: '/owner status' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `true`');
-  });
-
-  it('handleDingTalkMessage accepts english whoami alias', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/whoami', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_whoami_en',
-        msgtype: 'text',
-        text: { content: '/whoami' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'user_raw_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('senderId: `staff_1`');
-  });
-
-  it('handleDingTalkMessage blocks learn control command for non-owner', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn global test-rule', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_non_owner_learn',
-        msgtype: 'text',
-        text: { content: '/learn global test-rule' },
-        conversationType: '1',
-        conversationId: 'cid_dm_user',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('仅允许 owner 使用');
-  });
-
-  it('handleDingTalkMessage does not treat owner plain text as learn help', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: 'owner status', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_owner_plain',
-        msgtype: 'text',
-        text: { content: 'owner status' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).not.toHaveBeenCalled();
-    expect(shared.sendMessageMock).toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage blocks learn control command for non-owner in group', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn global test-rule', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { groupPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_non_owner_group',
-        msgtype: 'text',
-        text: { content: '/learn global test-rule' },
-        conversationType: '2',
-        conversationId: 'cid_group_1',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('仅允许 owner 使用');
-  });
-
-  it('handleDingTalkMessage supports whereami command in group', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn whereami', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { groupPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_whereami',
-        msgtype: 'text',
-        text: { content: '/learn whereami' },
-        conversationType: '2',
-        conversationId: 'cid_group_1',
-        conversationTitle: 'Dev Group',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('cid_group_1');
-  });
-
-  it('handleDingTalkMessage applies and disables a global learned rule', async () => {
-    const storePath = path.join(fs.mkdtempSync('/tmp/dt-learning-'), 'store.json');
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi.fn().mockImplementation(() => storePath);
-    shared.getRuntimeMock.mockReturnValue(runtime);
-
-    shared.extractMessageContentMock
-      .mockReturnValueOnce({ text: '/learn global 对用户保持简洁。', messageType: 'text' });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_learn_apply',
-        msgtype: 'text',
-        text: { content: '/learn global 对用户保持简洁。' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    const applyReply = String(shared.sendBySessionMock.mock.calls.at(-1)?.[2] || '');
-    const learnedRuleId = applyReply.match(/ruleId: `([^`]+)`/)?.[1];
-    expect(learnedRuleId).toBeTruthy();
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: `/learn disable ${learnedRuleId}`,
-      messageType: 'text',
+        shared.getRuntimeMock.mockReturnValue(buildRuntime());
+        shared.extractMessageContentMock.mockReturnValue({ text: 'hello', messageType: 'text' });
+        resetProactivePermissionHintStateForTest();
+        clearQuotedMsgCacheForTest();
+        shared.createAICardMock.mockResolvedValue({
+            cardInstanceId: 'card_1',
+            state: '1',
+            lastUpdated: Date.now(),
+        });
     });
 
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_learn_disable',
-        msgtype: 'text',
-        text: { content: `/learn disable ${learnedRuleId}` },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
+    it('downloadMedia returns file meta when DingTalk download succeeds', async () => {
+        mockedAxiosPost.mockResolvedValueOnce({ data: { downloadUrl: 'https://download.url/file' } } as any);
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: Buffer.from('abc'),
+            headers: { 'content-type': 'image/png' },
+        } as any);
 
-    expect(shared.sendBySessionMock.mock.calls.some((call) => String(call[2]).includes('已注入全局知识'))).toBe(true);
-    expect(String(shared.sendBySessionMock.mock.calls.at(-1)?.[2] || '')).toContain(learnedRuleId);
-  });
+        const result = await downloadMedia({ clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1' } as any, 'download_code_1');
 
-  it('handleDingTalkMessage supports targets command with explicit delimiter', async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '/learn targets cid_group_a,cid_group_b #@# 回复时带上值班信息',
-      messageType: 'text',
+        expect(result).toBeTruthy();
+        expect(result?.mimeType).toBe('image/png');
+        expect(result?.path).toContain('/.openclaw/media/inbound/');
     });
 
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_targets',
-        msgtype: 'text',
-        text: { content: '/learn targets cid_group_a,cid_group_b #@# 回复时带上值班信息' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已批量注入多个目标');
-  });
-
-  it('handleDingTalkMessage supports target-set create and apply', async () => {
-    shared.extractMessageContentMock
-      .mockReturnValueOnce({
-        text: '/learn target-set create ops-groups #@# cid_group_a,cid_group_b',
-        messageType: 'text',
-      })
-      .mockReturnValueOnce({
-        text: '/learn target-set apply ops-groups #@# 回复时带上值班信息',
-        messageType: 'text',
-      });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_target_set_create',
-        msgtype: 'text',
-        text: { content: '/learn target-set create ops-groups #@# cid_group_a,cid_group_b' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_target_set_apply',
-        msgtype: 'text',
-        text: { content: '/learn target-set apply ops-groups #@# 回复时带上值班信息' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock.mock.calls.some((call) => String(call[2]).includes('已保存目标组'))).toBe(true);
-    expect(shared.sendBySessionMock.mock.calls.some((call) => String(call[2]).includes('已向目标组批量注入规则'))).toBe(true);
-  });
-
-  it('injects normal learning rules into upstream system context before agent dispatch', async () => {
-    const storePath = path.join(fs.mkdtempSync('/tmp/dt-learning-'), 'store.json');
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi.fn().mockImplementation(() => storePath);
-    shared.getRuntimeMock.mockReturnValueOnce(runtime).mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock
-      .mockReturnValueOnce({
-        text: '/learn global 引用原文不可见时，不要猜内容，先让用户补发原文。',
-        messageType: 'text',
-      })
-      .mockReturnValueOnce({
-        text: '帮我看下这段引用',
-        messageType: 'text',
-      });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm2_learning_apply',
-        msgtype: 'text',
-        text: { content: '/learn global 引用原文不可见时，不要猜内容，先让用户补发原文。' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    runtime.channel.reply.finalizeInboundContext.mockClear();
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        learningEnabled: true,
-      } as any,
-      data: {
-        msgId: 'm2_learning_context',
-        msgtype: 'text',
-        text: { content: '帮我看下这段引用' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        GroupSystemPrompt: expect.stringContaining('[高优先级学习约束]'),
-      }),
-    );
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        GroupSystemPrompt: expect.stringContaining('引用原文不可见时，不要猜内容，先让用户补发原文。'),
-      }),
-    );
-  });
-
-  it('reads /learn session notes from accountStorePath so they can be injected on the next turn', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/agent-store.json')
-      .mockReturnValueOnce('/tmp/account-store.json')
-      .mockReturnValueOnce('/tmp/agent-store.json')
-      .mockReturnValueOnce('/tmp/account-store.json');
-    shared.getRuntimeMock.mockReturnValue(runtime);
-    shared.extractMessageContentMock
-      .mockReturnValueOnce({
-        text: '/learn session 回复当前私聊时，先说这是 session 规则。',
-        messageType: 'text',
-      })
-      .mockReturnValueOnce({
-        text: '测试一下当前私聊规则',
-        messageType: 'text',
-      });
-
-    await handleDingTalkMessage({
-      cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open' } as any,
-      data: {
-        msgId: 'm_session_apply',
-        msgtype: 'text',
-        text: { content: '/learn session 回复当前私聊时，先说这是 session 规则。' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'owner-test-id',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    runtime.channel.reply.finalizeInboundContext.mockClear();
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        learningEnabled: true,
-      } as any,
-      data: {
-        msgId: 'm_session_context',
-        msgtype: 'text',
-        text: { content: '测试一下当前私聊规则' },
-        conversationType: '1',
-        conversationId: 'cid_dm_owner',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        GroupSystemPrompt: expect.stringContaining('这是 session 规则'),
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage prefers senderStaffId for DM allowlist and routing', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'allowlist', allowFrom: ['staff_allowed'] } as any,
-      data: {
-        msgId: 'm2_staff',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid1',
-        senderId: 'user_blocked',
-        senderStaffId: 'staff_allowed',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).not.toHaveBeenCalled();
-    expect(runtime.channel.routing.resolveAgentRoute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        peer: { kind: 'direct', id: 'staff_allowed' },
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage sends group deny message when groupPolicy allowlist blocks group', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { groupPolicy: 'allowlist', allowFrom: ['cid_allowed'] } as any,
-      data: {
-        msgId: 'm3',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '2',
-        conversationId: 'cid_blocked',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('访问受限');
-  });
-
-  it('handleDingTalkMessage runs card flow and finalizes AI card', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm4',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.sendMessageMock).toHaveBeenCalled();
-    const cardSends = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
-    expect(cardSends.length).toBeGreaterThan(0);
-    expect(shared.appendQuoteJournalEntryMock).toHaveBeenCalled();
-  });
-
-  it('appends inbound quote journal entry with store/account/session context', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/agent-store.json')
-      .mockReturnValueOnce('/tmp/account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', journalTTLDays: 9 } as any,
-      data: {
-        msgId: 'm_journal_1',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: 1700000000000,
-      },
-    } as any);
-
-    expect(shared.appendQuoteJournalEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        storePath: '/tmp/agent-store.json',
-        accountId: 'main',
-        conversationId: 'cid_ok',
-        msgId: 'm_journal_1',
-        messageType: 'text',
-        text: 'hello',
-        createdAt: 1700000000000,
-        ttlDays: 9,
-      }),
-    );
-  });
-
-  it('resolves originalMsgId via quote journal and prepends recovered quoted text', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/dm-agent-store.json')
-      .mockReturnValueOnce('/tmp/dm-account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[这是一条引用消息，原消息ID: orig_msg_001]\n\nhello',
-      messageType: 'text',
-    });
-    shared.resolveQuotedMessageByIdMock.mockReturnValueOnce({
-      msgId: 'orig_msg_001',
-      text: '历史原文',
-      createdAt: Date.now() - 1000,
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', journalTTLDays: 11 } as any,
-      data: {
-        msgId: 'm_quote_1',
-        msgtype: 'text',
-        text: { content: 'hello', isReplyMsg: true },
-        originalMsgId: 'orig_msg_001',
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.resolveQuotedMessageByIdMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: 'main',
-        conversationId: 'cid_ok',
-        originalMsgId: 'orig_msg_001',
-        ttlDays: 11,
-      }),
-    );
-
-    const envelopeArg = (runtime.channel.reply.formatInboundEnvelope as any).mock.calls[0]?.[0];
-    expect(envelopeArg.body).toContain('[引用消息: "历史原文"]');
-  });
-
-  it('writes normalized inbound journal text without quoted prefix noise', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/dm-agent-store.json')
-      .mockReturnValueOnce('/tmp/dm-account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用消息: "历史原文"]\n\n真正正文',
-      messageType: 'text',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown' } as any,
-      data: {
-        msgId: 'm_prefixed_1',
-        msgtype: 'text',
-        text: { content: '真正正文', isReplyMsg: true },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: 1700000000000,
-      },
-    } as any);
-
-    expect(shared.appendQuoteJournalEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: '真正正文',
-      }),
-    );
-  });
-
-  it('uses DingTalk DM conversationId for journal writes instead of senderId', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/dm-agent-store.json')
-      .mockReturnValueOnce('/tmp/dm-account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown' } as any,
-      data: {
-        msgId: 'm_dm_1',
-        msgtype: 'text',
-        text: { content: 'hello dm' },
-        conversationType: '1',
-        conversationId: 'cid_dm_stable',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: 1700000000000,
-      },
-    } as any);
-
-    expect(shared.appendQuoteJournalEntryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: 'cid_dm_stable',
-      }),
-    );
-    expect(shared.appendQuoteJournalEntryMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: 'user_1',
-      }),
-    );
-  });
-
-  it('still resolves originalMsgId when body text happens to contain quote marker text', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/dm-agent-store.json')
-      .mockReturnValueOnce('/tmp/dm-account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '我在讨论字符串 [引用消息:] 本身',
-      messageType: 'text',
-    });
-    shared.resolveQuotedMessageByIdMock.mockReturnValueOnce({
-      msgId: 'orig_msg_literal',
-      text: '被引用原文',
-      createdAt: Date.now() - 1000,
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown' } as any,
-      data: {
-        msgId: 'm_literal_1',
-        msgtype: 'text',
-        text: { content: '我在讨论字符串 [引用消息:] 本身', isReplyMsg: true },
-        originalMsgId: 'orig_msg_literal',
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    const envelopeArg = (runtime.channel.reply.formatInboundEnvelope as any).mock.calls[0]?.[0];
-    expect(envelopeArg.body).toContain('[引用消息: "被引用原文"]');
-    expect(shared.resolveQuotedMessageByIdMock).toHaveBeenCalledWith(
-      expect.objectContaining({ originalMsgId: 'orig_msg_literal' }),
-    );
-  });
-
-  it('handleDingTalkMessage runs non-card flow and sends thinking + final outputs', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: true } as any,
-      data: {
-        msgId: 'm5',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendMessageMock).toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage restores quoted card by originalProcessQueryKey', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/agent-store.json')
-      .mockReturnValueOnce('/tmp/account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用了机器人的回复]\n\nhello',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用了机器人的回复]\n\n',
-        isQuotedCard: true,
-        processQueryKey: 'carrier_quoted_1',
-      },
-    });
-    shared.getCardContentByProcessQueryKeyMock.mockReturnValueOnce('机器人之前的回复内容');
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
-      data: {
-        msgId: 'm5_card_quote',
-        msgtype: 'text',
-        text: { content: 'hello', isReplyMsg: true },
-        originalProcessQueryKey: 'carrier_quoted_1',
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.getCardContentByProcessQueryKeyMock).toHaveBeenCalledWith(
-      'main',
-      'user_1',
-      'carrier_quoted_1',
-      '/tmp/account-store.json',
-    );
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        RawBody: '[引用机器人回复: "机器人之前的回复内容"]\n\nhello',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage falls back to createdAt matcher only when processQueryKey is missing', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.session.resolveStorePath = vi
-      .fn()
-      .mockReturnValueOnce('/tmp/agent-store.json')
-      .mockReturnValueOnce('/tmp/account-store.json');
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用了机器人的回复]\n\nhello',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用了机器人的回复]\n\n',
-        isQuotedCard: true,
-        cardCreatedAt: 1772817989679,
-      },
-    });
-    shared.findCardContentMock.mockReturnValueOnce('旧兼容卡片内容');
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
-      data: {
-        msgId: 'm5_card_fallback',
-        msgtype: 'text',
-        text: { content: 'hello', isReplyMsg: true },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.getCardContentByProcessQueryKeyMock).not.toHaveBeenCalled();
-    expect(shared.findCardContentMock).toHaveBeenCalledWith(
-      'main',
-      'user_1',
-      1772817989679,
-      '/tmp/account-store.json',
-    );
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        RawBody: '[引用机器人回复: "旧兼容卡片内容"]\n\nhello',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage persists group quoted file metadata after API fallback succeeds', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用文件]\n\n群聊文件',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用文件]\n\n',
-        isQuotedFile: true,
-        msgId: 'group_file_msg_1',
-        fileCreatedAt: 1772863284581,
-      },
-    });
-    shared.resolveQuotedFileMock.mockResolvedValueOnce({
-      media: {
-        path: '/tmp/.openclaw/media/inbound/group-file.bin',
-        mimeType: 'application/octet-stream',
-      },
-      spaceId: 'space_group_1',
-      fileId: 'dentry_group_1',
-      name: 'a.sql',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'm_group_file_quote_1',
-        msgtype: 'text',
-        text: { content: '群聊文件', isReplyMsg: true },
-        conversationType: '2',
-        conversationId: 'cid_group_1',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.resolveQuotedFileMock).toHaveBeenCalledTimes(1);
-    const restored = getCachedDownloadCode(
-      'main',
-      'cid_group_1',
-      'group_file_msg_1',
-      '/tmp/store.json',
-    );
-    expect(restored).not.toBeNull();
-    expect(restored!.downloadCode).toBeUndefined();
-    expect(restored!.spaceId).toBe('space_group_1');
-    expect(restored!.fileId).toBe('dentry_group_1');
-  });
-
-  it('handleDingTalkMessage downloads single-chat doc card and persists msgId metadata', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[钉钉文档]\n\n',
-      messageType: 'interactiveCardFile',
-      docSpaceId: 'space_doc_1',
-      docFileId: 'file_doc_1',
-    });
-    shared.downloadGroupFileMock.mockResolvedValueOnce({
-      path: '/tmp/.openclaw/media/inbound/doc-card.bin',
-      mimeType: 'application/pdf',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'doc_origin_msg',
-        msgtype: 'interactiveCard',
-        content: {
-          biz_custom_action_url:
-            'dingtalk://dingtalkclient/page/yunpan?route=previewDentry&spaceId=space_doc_1&fileId=file_doc_1&type=file',
-        },
-        conversationType: '1',
-        conversationId: 'cid_dm_1',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.getUnionIdByStaffIdMock).toHaveBeenCalledTimes(1);
-    expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
-      expect.anything(),
-      'space_doc_1',
-      'file_doc_1',
-      'union_1',
-      undefined,
-    );
-    const restored = getCachedDownloadCode('main', 'cid_dm_1', 'doc_origin_msg', '/tmp/store.json');
-    expect(restored).not.toBeNull();
-    expect(restored!.spaceId).toBe('space_doc_1');
-    expect(restored!.fileId).toBe('file_doc_1');
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        MediaType: 'application/pdf',
-        RawBody: '[钉钉文档]\n\n',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage restores quoted single-chat doc card from cached metadata', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    cacheInboundDownloadCode(
-      'main',
-      'cid_dm_2',
-      'doc_origin_msg_2',
-      undefined,
-      'interactiveCardFile',
-      Date.now(),
-      {
-        storePath: '/tmp/store.json',
-        spaceId: 'space_doc_2',
-        fileId: 'file_doc_2',
-      },
-    );
-    clearQuotedMsgCacheForTest();
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用了钉钉文档]\n\n我引用了什么？',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用了钉钉文档]\n\n',
-        isQuotedDocCard: true,
-        msgId: 'doc_origin_msg_2',
-      },
-    });
-    shared.downloadGroupFileMock.mockResolvedValueOnce({
-      path: '/tmp/.openclaw/media/inbound/doc-card-quoted.bin',
-      mimeType: 'application/pdf',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'doc_quote_msg',
-        msgtype: 'text',
-        text: { content: '我引用了什么？', isReplyMsg: true },
-        originalMsgId: 'doc_origin_msg_2',
-        conversationType: '1',
-        conversationId: 'cid_dm_2',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
-      expect.anything(),
-      'space_doc_2',
-      'file_doc_2',
-      'union_1',
-      undefined,
-    );
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        RawBody: '[引用了钉钉文档]\n\n我引用了什么？',
-        MediaType: 'application/pdf',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage degrades quoted doc card when cached metadata is unavailable', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    clearQuotedMsgCacheForTest();
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用了钉钉文档]\n\n1',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用了钉钉文档]\n\n',
-        isQuotedDocCard: true,
-        msgId: 'missing_doc_msg',
-      },
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'doc_quote_group_msg',
-        msgtype: 'text',
-        text: { content: '1', isReplyMsg: true },
-        originalMsgId: 'missing_doc_msg',
-        conversationType: '2',
-        conversationId: 'cid_group_doc',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.resolveQuotedFileMock).not.toHaveBeenCalled();
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        RawBody: '[引用了钉钉文档，但无法获取内容]\n\n1',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage falls back to group-file resolution for quoted doc card in group chat', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    clearQuotedMsgCacheForTest();
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用了钉钉文档]\n\n1',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用了钉钉文档]\n\n',
-        isQuotedDocCard: true,
-        msgId: 'group_doc_msg',
-        fileCreatedAt: 1772901945282,
-      },
-    });
-    shared.resolveQuotedFileMock.mockResolvedValueOnce({
-      media: { path: '/tmp/.openclaw/media/inbound/group-doc.bin', mimeType: 'application/pdf' },
-      spaceId: 'space_group_doc',
-      fileId: 'file_group_doc',
-      name: 'doc.pdf',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'group_doc_quote',
-        msgtype: 'text',
-        text: { content: '1', isReplyMsg: true },
-        originalMsgId: 'group_doc_msg',
-        conversationType: '2',
-        conversationId: 'cid_group_doc',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.resolveQuotedFileMock).toHaveBeenCalledWith(
-      expect.anything(),
-      {
-        openConversationId: 'cid_group_doc',
-        senderStaffId: 'staff_1',
-        fileCreatedAt: 1772901945282,
-      },
-      undefined,
-    );
-    const restored = getCachedDownloadCode(
-      'main',
-      'cid_group_doc',
-      'group_doc_msg',
-      '/tmp/store.json',
-    );
-    expect(restored).not.toBeNull();
-    expect(restored!.spaceId).toBe('space_group_doc');
-    expect(restored!.fileId).toBe('file_group_doc');
-    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        RawBody: '[引用了钉钉文档]\n\n1',
-        MediaType: 'application/pdf',
-      }),
-    );
-  });
-
-  it('handleDingTalkMessage restores group quoted file from persisted metadata without fallback query', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    clearQuotedMsgCacheForTest();
-    cacheInboundDownloadCode('main', 'cid_group_2', 'file_origin', undefined, 'file', Date.now(), {
-      storePath: '/tmp/store.json',
-      spaceId: 'space_group_2',
-      fileId: 'dentry_group_2',
-    });
-    clearQuotedMsgCacheForTest();
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: '[引用文件]\n\n群聊文件',
-      messageType: 'text',
-      quoted: {
-        prefix: '[引用文件]\n\n',
-        isQuotedFile: true,
-        msgId: 'file_origin',
-        fileCreatedAt: 1772863284581,
-      },
-    });
-    shared.downloadGroupFileMock.mockResolvedValueOnce({
-      path: '/tmp/.openclaw/media/inbound/group-file.bin',
-      mimeType: 'application/octet-stream',
-    });
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
-      data: {
-        msgId: 'm_group_file_quote_2',
-        msgtype: 'text',
-        text: { content: '群聊文件', isReplyMsg: true },
-        conversationType: '2',
-        conversationId: 'cid_group_2',
-        senderId: 'user_1',
-        senderStaffId: 'staff_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.resolveQuotedFileMock).not.toHaveBeenCalled();
-    expect(shared.getUnionIdByStaffIdMock).toHaveBeenCalledTimes(1);
-    expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
-      expect.anything(),
-      'space_group_2',
-      'dentry_group_2',
-      'union_1',
-      undefined,
-    );
-  });
-
-  it('handleDingTalkMessage finalizes card with default content when no textual output is produced', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockResolvedValue({ queuedFinal: '' });
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    const card = { cardInstanceId: 'card_2', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm6',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).toHaveBeenCalledWith(card, '✅ Done', undefined);
-  });
-
-  it('handleDingTalkMessage falls back to markdown sends when createAICard returns null', async () => {
-    shared.createAICardMock.mockResolvedValueOnce(null);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
-      data: {
-        msgId: 'm6_card_degrade',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).not.toHaveBeenCalled();
-    expect(shared.sendMessageMock).toHaveBeenCalled();
-    const cardSends = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
-    expect(cardSends).toHaveLength(0);
-  });
-
-  it('handleDingTalkMessage finalizes card using tool stream content when no final text exists', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
-        return { queuedFinal: '' };
-      });
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    const card = { cardInstanceId: 'card_tool_only', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm6_tool',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).toHaveBeenCalledWith(card, 'tool output', undefined);
-    expect(shared.sendMessageMock).toHaveBeenCalledWith(
-      expect.anything(),
-      'user_1',
-      'tool output',
-      expect.objectContaining({ card, cardUpdateMode: 'append' }),
-    );
-  });
-
-  it('handleDingTalkMessage skips finishAICard when current card is already terminal', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockResolvedValue({ queuedFinal: 'queued final' });
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    const card = { cardInstanceId: 'card_terminal', state: '5', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-    shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '5');
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm7_terminal',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.isCardInTerminalStateMock).toHaveBeenCalledWith('5');
-    expect(shared.finishAICardMock).not.toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage ignores thinking and tool card updates when card is already finalized', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onReasoningStream?.({ text: 'thinking' });
-        await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
-        return { queuedFinal: '' };
-      });
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    const card = { cardInstanceId: 'card_finalized', state: '3', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-    shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '3');
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm7_finalized',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.streamAICardMock).not.toHaveBeenCalled();
-    expect(shared.finishAICardMock).not.toHaveBeenCalled();
-  });
-
-  it('handleDingTalkMessage marks card FAILED when finishAICard throws', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-    const card = { cardInstanceId: 'card_3', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-    shared.finishAICardMock.mockRejectedValueOnce({
-      message: 'finish failed',
-      response: { data: { code: 'invalidParameter', message: 'cannot finalize' } },
-    });
-    const log = { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() };
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: log as any,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
-      data: {
-        msgId: 'm7',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(card.state).toBe('5');
-    const debugLogs = log.debug.mock.calls.map((args: unknown[]) => String(args[0]));
-    expect(
-      debugLogs.some(
-        (entry) =>
-          entry.includes('[DingTalk][ErrorPayload][inbound.cardFinalize]') &&
-          entry.includes('code=invalidParameter') &&
-          entry.includes('message=cannot finalize'),
-      ),
-    ).toBe(true);
-  });
-
-  it('handleDingTalkMessage group card flow creates card and streams tool/reasoning', async () => {
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    const createdCard = { cardInstanceId: 'card_new', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(createdCard);
-    shared.isCardInTerminalStateMock.mockReturnValue(false);
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: 'group hello',
-      mediaPath: 'download_code_1',
-      messageType: 'text',
-    });
-    mockedAxiosPost.mockResolvedValueOnce({
-      data: { downloadUrl: 'https://download.url/file' },
-    } as any);
-    mockedAxiosGet.mockResolvedValueOnce({
-      data: Buffer.from('abc'),
-      headers: { 'content-type': 'image/png' },
-    } as any);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        groupPolicy: 'allowlist',
-        allowFrom: ['cid_group_1'],
-        messageType: 'card',
-        robotCode: 'robot_1',
-        groups: { cid_group_1: { systemPrompt: 'group prompt' } },
-      } as any,
-      data: {
-        msgId: 'm8',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '2',
-        conversationId: 'cid_group_1',
-        conversationTitle: 'group-title',
-        senderId: 'user_1',
-        senderNick: 'Alice',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('sends proactive permission hint when proactive API risk was observed', async () => {
-    recordProactiveRiskObservation({
-      accountId: 'main',
-      targetId: 'manager123',
-      level: 'high',
-      reason: 'Forbidden.AccessDenied.AccessTokenPermissionDenied',
-      source: 'proactive-api',
-    });
-    shared.sendBySessionMock.mockResolvedValue(undefined);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        proactivePermissionHint: { enabled: true, cooldownHours: 24 },
-      } as any,
-      data: {
-        msgId: 'm9',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'manager123',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(String(shared.sendBySessionMock.mock.calls[0]?.[2])).toContain('主动推送可能失败');
-  });
-
-  it('sends proactive permission hint when risk is keyed by senderId but inbound prefers senderStaffId', async () => {
-    recordProactiveRiskObservation({
-      accountId: 'main',
-      targetId: 'manager123',
-      level: 'high',
-      reason: 'Forbidden.AccessDenied.AccessTokenPermissionDenied',
-      source: 'proactive-api',
-    });
-    shared.sendBySessionMock.mockResolvedValue(undefined);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        proactivePermissionHint: { enabled: true, cooldownHours: 24 },
-      } as any,
-      data: {
-        msgId: 'm9-staff',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'manager123',
-        senderStaffId: 'staff_987',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-    expect(String(shared.sendBySessionMock.mock.calls[0]?.[2])).toContain('主动推送可能失败');
-  });
-
-  it('sends proactive permission hint only once within cooldown window', async () => {
-    recordProactiveRiskObservation({
-      accountId: 'main',
-      targetId: 'manager123',
-      level: 'high',
-      reason: 'Forbidden.AccessDenied.AccessTokenPermissionDenied',
-      source: 'proactive-api',
-    });
-    shared.sendBySessionMock.mockResolvedValue(undefined);
-
-    const params = {
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        proactivePermissionHint: { enabled: true, cooldownHours: 24 },
-      } as any,
-      data: {
-        msgId: 'm10',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'manager123',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any;
-
-    await handleDingTalkMessage(params);
-    await handleDingTalkMessage(params);
-
-    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not send proactive permission hint without proactive API risk observation', async () => {
-    shared.sendBySessionMock.mockResolvedValue(undefined);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: {
-        dmPolicy: 'open',
-        messageType: 'markdown',
-        showThinking: false,
-        proactivePermissionHint: { enabled: true, cooldownHours: 24 },
-      } as any,
-      data: {
-        msgId: 'm11',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: '0341234567',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.sendBySessionMock).not.toHaveBeenCalled();
-  });
-
-  it('concurrent messages create independent cards with distinct IDs', async () => {
-    let resolveA!: () => void;
-    const gateA = new Promise<void>((r) => {
-      resolveA = r;
-    });
-
-    const cardA = { cardInstanceId: 'card_A', state: '1', lastUpdated: Date.now() } as any;
-    const cardB = { cardInstanceId: 'card_B', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(cardA).mockResolvedValueOnce(cardB);
-    shared.isCardInTerminalStateMock.mockReturnValue(false);
-
-    const runtimeA = buildRuntime();
-    runtimeA.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await gateA;
-        await dispatcherOptions.deliver({ text: 'reply A' }, { kind: 'final' });
-        return { queuedFinal: 'reply A' };
-      });
-    const runtimeB = buildRuntime();
-    runtimeB.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver({ text: 'reply B' }, { kind: 'final' });
-        return { queuedFinal: 'reply B' };
-      });
-    shared.getRuntimeMock.mockReturnValueOnce(runtimeA).mockReturnValueOnce(runtimeB);
-
-    const baseParams = {
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
-    };
-
-    const promiseA = handleDingTalkMessage({
-      ...baseParams,
-      data: {
-        msgId: 'concurrent_A',
-        msgtype: 'text',
-        text: { content: 'hello A' },
-        conversationType: '1',
-        conversationId: 'cid_same',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    const promiseB = handleDingTalkMessage({
-      ...baseParams,
-      data: {
-        msgId: 'concurrent_B',
-        msgtype: 'text',
-        text: { content: 'hello B' },
-        conversationType: '1',
-        conversationId: 'cid_same',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    await promiseB;
-    resolveA();
-    await promiseA;
-
-    expect(shared.createAICardMock).toHaveBeenCalledTimes(2);
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(2);
-
-    const finishCalls = shared.finishAICardMock.mock.calls;
-    const finishedCardIds = finishCalls.map((call: any[]) => call[0].cardInstanceId);
-    expect(finishedCardIds).toContain('card_A');
-    expect(finishedCardIds).toContain('card_B');
-  });
-
-  it('concurrent messages pass correct card reference to sendMessage', async () => {
-    let resolveA!: () => void;
-    const gateA = new Promise<void>((r) => {
-      resolveA = r;
-    });
-
-    const cardA = { cardInstanceId: 'card_A', state: '1', lastUpdated: Date.now() } as any;
-    const cardB = { cardInstanceId: 'card_B', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(cardA).mockResolvedValueOnce(cardB);
-    shared.isCardInTerminalStateMock.mockReturnValue(false);
-
-    const runtimeA = buildRuntime();
-    runtimeA.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await gateA;
-        await dispatcherOptions.deliver({ text: 'tool A' }, { kind: 'tool' });
-        await dispatcherOptions.deliver({ text: 'reply A' }, { kind: 'final' });
-        return { queuedFinal: 'reply A' };
-      });
-    const runtimeB = buildRuntime();
-    runtimeB.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver({ text: 'tool B' }, { kind: 'tool' });
-        await dispatcherOptions.deliver({ text: 'reply B' }, { kind: 'final' });
-        return { queuedFinal: 'reply B' };
-      });
-    shared.getRuntimeMock.mockReturnValueOnce(runtimeA).mockReturnValueOnce(runtimeB);
-
-    const baseParams = {
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
-    };
-
-    const promiseA = handleDingTalkMessage({
-      ...baseParams,
-      data: {
-        msgId: 'bind_A',
-        msgtype: 'text',
-        text: { content: 'hello A' },
-        conversationType: '1',
-        conversationId: 'cid_same',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    const promiseB = handleDingTalkMessage({
-      ...baseParams,
-      data: {
-        msgId: 'bind_B',
-        msgtype: 'text',
-        text: { content: 'hello B' },
-        conversationType: '1',
-        conversationId: 'cid_same',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    await promiseB;
-    resolveA();
-    await promiseA;
-
-    const sendCalls = shared.sendMessageMock.mock.calls;
-    const toolCallA = sendCalls.find((call: any[]) => call[2] === 'tool A');
-    const toolCallB = sendCalls.find((call: any[]) => call[2] === 'tool B');
-    expect(toolCallA).toBeTruthy();
-    expect(toolCallB).toBeTruthy();
-    expect(toolCallA![3]?.card?.cardInstanceId).toBe('card_A');
-    expect(toolCallB![3]?.card?.cardInstanceId).toBe('card_B');
-    expect(toolCallA![3]?.cardUpdateMode).toBe('append');
-    expect(toolCallB![3]?.cardUpdateMode).toBe('append');
-  });
-
-  it('message A card in terminal state still finalizes without affecting message B', async () => {
-    const cardA = { cardInstanceId: 'card_term', state: '3', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(cardA);
-    shared.isCardInTerminalStateMock.mockImplementation(
-      (state: string) => state === '3' || state === '5',
-    );
-
-    const runtime = buildRuntime();
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
-      data: {
-        msgId: 'term_card',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.finishAICardMock).not.toHaveBeenCalled();
-    const cardSendCalls = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
-    expect(cardSendCalls).toHaveLength(0);
-  });
-
-  it('acquires session lock with the resolved sessionKey', async () => {
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: undefined,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
-      data: {
-        msgId: 'lock_test',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
-
-    expect(shared.acquireSessionLockMock).toHaveBeenCalledTimes(1);
-    expect(shared.acquireSessionLockMock).toHaveBeenCalledWith('s1');
-  });
-
-  it('releases session lock even when dispatchReply throws', async () => {
-    const releaseFn = vi.fn();
-    shared.acquireSessionLockMock.mockResolvedValueOnce(releaseFn);
-
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('dispatch crash'));
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    await expect(
-      handleDingTalkMessage({
-        cfg: {},
-        accountId: 'main',
-        sessionWebhook: 'https://session.webhook',
-        log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() } as any,
-        dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
-        data: {
-          msgId: 'lock_crash',
-          msgtype: 'text',
-          text: { content: 'hello' },
-          conversationType: '1',
-          conversationId: 'cid_ok',
-          senderId: 'user_1',
-          chatbotUserId: 'bot_1',
-          sessionWebhook: 'https://session.webhook',
-          createAt: Date.now(),
-        },
-      } as any),
-    ).rejects.toThrow('dispatch crash');
-
-    expect(releaseFn).toHaveBeenCalledTimes(1);
-  });
-
-  it('attempts to finalize active card when dispatchReply throws', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockRejectedValueOnce(new Error('dispatch crash'));
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
-
-    const card = { cardInstanceId: 'card_on_error', state: '1', lastUpdated: Date.now() } as any;
-    shared.createAICardMock.mockResolvedValueOnce(card);
-
-    await expect(
-      handleDingTalkMessage({
-        cfg: {},
-        accountId: 'main',
-        sessionWebhook: 'https://session.webhook',
-        log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() } as any,
-        dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
-        data: {
-          msgId: 'lock_crash_card',
-          msgtype: 'text',
-          text: { content: 'hello' },
-          conversationType: '1',
-          conversationId: 'cid_ok',
-          senderId: 'user_1',
-          chatbotUserId: 'bot_1',
-          sessionWebhook: 'https://session.webhook',
-          createAt: Date.now(),
-        },
-      } as any),
-    ).rejects.toThrow('dispatch crash');
-
-    expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-    expect(shared.finishAICardMock).toHaveBeenCalledWith(card, '❌ 处理失败', expect.anything());
-  });
-
-  it('does not leak unhandled stop reason text to outbound chat messages', async () => {
-    const runtime = buildRuntime();
-    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-      .fn()
-      .mockImplementation(async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver(
-          { text: 'Unhandled stop reason: network_error' },
-          { kind: 'final' },
+    it('downloadMedia passes mediaMaxMb as maxBytes to saveMediaBuffer', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValue(runtime);
+
+        mockedAxiosPost.mockResolvedValueOnce({ data: { downloadUrl: 'https://download.url/file' } } as any);
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: Buffer.from('abc'),
+            headers: { 'content-type': 'application/pdf' },
+        } as any);
+
+        await downloadMedia(
+            { clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1', mediaMaxMb: 50 } as any,
+            'download_code_1',
         );
-        return { queuedFinal: 'Unhandled stop reason: network_error' };
-      });
-    shared.getRuntimeMock.mockReturnValueOnce(runtime);
 
-    await handleDingTalkMessage({
-      cfg: {},
-      accountId: 'main',
-      sessionWebhook: 'https://session.webhook',
-      log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as any,
-      dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
-      data: {
-        msgId: 'm12',
-        msgtype: 'text',
-        text: { content: 'hello' },
-        conversationType: '1',
-        conversationId: 'cid_ok',
-        senderId: 'user_1',
-        chatbotUserId: 'bot_1',
-        sessionWebhook: 'https://session.webhook',
-        createAt: Date.now(),
-      },
-    } as any);
+        expect(runtime.channel.media.saveMediaBuffer).toHaveBeenCalledWith(
+            expect.any(Buffer),
+            'application/pdf',
+            'inbound',
+            50 * 1024 * 1024,
+        );
+    });
 
-    expect(shared.sendMessageMock).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.stringContaining('Unhandled stop reason:'),
-      expect.anything(),
-    );
-  });
+    it('downloadMedia uses runtime default when mediaMaxMb is not set', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValue(runtime);
+
+        mockedAxiosPost.mockResolvedValueOnce({ data: { downloadUrl: 'https://download.url/file' } } as any);
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: Buffer.from('abc'),
+            headers: { 'content-type': 'image/png' },
+        } as any);
+
+        await downloadMedia(
+            { clientId: 'id', clientSecret: 'sec', robotCode: 'robot_1' } as any,
+            'download_code_1',
+        );
+
+        const call = runtime.channel.media.saveMediaBuffer.mock.calls[0];
+        expect(call).toHaveLength(3);
+        expect(call[2]).toBe('inbound');
+    });
+
+    it('downloadMedia returns null when robotCode missing', async () => {
+        const result = await downloadMedia({ clientId: 'id', clientSecret: 'sec' } as any, 'download_code_1');
+
+        expect(result).toBeNull();
+        expect(mockedAxiosPost).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage ignores self-message', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm1',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid1',
+                senderId: 'bot_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage sends deny message when dmPolicy allowlist blocks sender', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'allowlist', allowFrom: ['user_ok'] } as any,
+            data: {
+                msgId: 'm2',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid1',
+                senderId: 'user_blocked',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('访问受限');
+    });
+
+    it('handleDingTalkMessage returns whoami info for direct fixed command', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '我是谁', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_whoami',
+                msgtype: 'text',
+                text: { content: '我是谁' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'user_raw_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('senderId: `staff_1`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `false`');
+        expect(shared.sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage returns owner status for slash command', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn owner status', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_owner_status',
+                msgtype: 'text',
+                text: { content: '/learn owner status' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `true`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).not.toContain('ownerAllowFrom');
+    });
+
+    it('handleDingTalkMessage accepts owner status slash alias', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/owner status', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_owner_status_alias',
+                msgtype: 'text',
+                text: { content: '/owner status' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `true`');
+    });
+
+    it('handleDingTalkMessage accepts english whoami alias', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/whoami', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_whoami_en',
+                msgtype: 'text',
+                text: { content: '/whoami' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'user_raw_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('senderId: `staff_1`');
+    });
+
+    it('handleDingTalkMessage accepts english owner status alias', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/owner-status', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_owner_status_en',
+                msgtype: 'text',
+                text: { content: '/owner-status' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('isOwner: `true`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).not.toContain('ownerAllowFrom');
+    });
+
+    it('handleDingTalkMessage blocks learn control command for non-owner', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn global test', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open', allowFrom: ['owner-test-id'] } as any,
+            data: {
+                msgId: 'm2_owner_deny',
+                msgtype: 'text',
+                text: { content: '/learn global test' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'user_not_owner',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('仅允许 owner 使用');
+        expect(shared.sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage does not treat owner plain text as learn help', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValue(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '随便聊一句普通话', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_owner_plain_text',
+                msgtype: 'text',
+                text: { content: '随便聊一句普通话' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.stringContaining('可用的 owner 学习命令：'),
+            expect.anything(),
+        );
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage blocks learn control command for non-owner in group', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/learn global test', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open', allowFrom: ['owner-test-id'] } as any,
+            data: {
+                msgId: 'm2_owner_group_deny',
+                msgtype: 'text',
+                text: { content: '/learn global test' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_not_owner',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('仅允许 owner 使用');
+        expect(shared.sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage supports whereami command in group', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '这里是谁', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_whereami',
+                msgtype: 'text',
+                text: { content: '这里是谁' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('conversationId: `cid_group_1`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('conversationType: `group`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `cid_group_1`');
+    });
+
+    it('handleDingTalkMessage blocks session alias show for non-owner in group', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias show', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_show_deny',
+                msgtype: 'text',
+                text: { content: '/session-alias show' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_not_owner',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('仅允许 owner 使用');
+    });
+
+    it('handleDingTalkMessage lets owner show current shared session alias for group', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias show', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_show_owner',
+                msgtype: 'text',
+                text: { content: '/session-alias show' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('source: `group`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('sourceId: `cid_group_1`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `cid_group_1`');
+    });
+
+    it('handleDingTalkMessage lets owner set a shared session alias for current group', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_set',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `shared-dev`');
+    });
+
+    it('handleDingTalkMessage lets owner set a shared session alias for current direct session', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_set_direct',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('source: `direct`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('sourceId: `owner-test-id`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `shared-dev`');
+    });
+
+    it('handleDingTalkMessage accepts extra whitespace in session alias command', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias  set   shared-dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_set_spacing',
+                msgtype: 'text',
+                text: { content: '/session-alias  set   shared-dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `shared-dev`');
+    });
+
+    it('handleDingTalkMessage rejects invalid session alias characters', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared:dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_invalid_chars',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared:dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('共享会话别名不合法');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('[a-zA-Z0-9_-]{1,64}');
+    });
+
+    it('uses stored session alias as the routed group peerId on next turn', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_bootstrap',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        shared.sendBySessionMock.mockClear();
+        const runtime = buildRuntime();
+        const resolveAgentRoute = vi.fn().mockReturnValue({ agentId: 'main', sessionKey: 's1', mainSessionKey: 's1' });
+        runtime.channel.routing.resolveAgentRoute = resolveAgentRoute;
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: 'hello again', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_session_alias_followup',
+                msgtype: 'text',
+                text: { content: 'hello again' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(resolveAgentRoute).toHaveBeenCalledWith(expect.objectContaining({
+            peer: { kind: 'group', id: 'shared-dev' },
+        }));
+    });
+
+    it('uses stored session alias as the routed direct peerId on next turn', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_direct_bootstrap',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        shared.sendBySessionMock.mockClear();
+        const runtime = buildRuntime();
+        const resolveAgentRoute = vi.fn().mockReturnValue({ agentId: 'main', sessionKey: 's1', mainSessionKey: 's1' });
+        runtime.channel.routing.resolveAgentRoute = resolveAgentRoute;
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: 'hello direct', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_session_alias_direct_followup',
+                msgtype: 'text',
+                text: { content: 'hello direct' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(resolveAgentRoute).toHaveBeenCalledWith(expect.objectContaining({
+            peer: { kind: 'direct', id: 'shared-dev' },
+        }));
+    });
+
+    it('lets owner bind a direct senderId remotely to a shared alias', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias bind direct user_1 project-x', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_bind_direct',
+                msgtype: 'text',
+                text: { content: '/session-alias bind direct user_1 project-x' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('source: `direct`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('sourceId: `user_1`');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('peerId: `project-x`');
+
+        shared.sendBySessionMock.mockClear();
+        const runtime = buildRuntime();
+        const resolveAgentRoute = vi.fn().mockReturnValue({ agentId: 'main', sessionKey: 's1', mainSessionKey: 's1' });
+        runtime.channel.routing.resolveAgentRoute = resolveAgentRoute;
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: 'hello from bound dm', messageType: 'text' });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_session_alias_bind_direct_followup',
+                msgtype: 'text',
+                text: { content: 'hello from bound dm' },
+                conversationType: '1',
+                conversationId: 'cid_dm_user_1',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(resolveAgentRoute).toHaveBeenCalledWith(expect.objectContaining({
+            peer: { kind: 'direct', id: 'project-x' },
+        }));
+    });
+
+    it('routes different groups with the same alias to the same sessionKey', async () => {
+        const ownerCfg = { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } };
+
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+        await handleDingTalkMessage({
+            cfg: ownerCfg,
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_group1_set',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: '/session-alias set shared-dev', messageType: 'text' });
+        await handleDingTalkMessage({
+            cfg: ownerCfg,
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_session_alias_group2_set',
+                msgtype: 'text',
+                text: { content: '/session-alias set shared-dev' },
+                conversationType: '2',
+                conversationId: 'cid_group_2',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        shared.sendBySessionMock.mockClear();
+        shared.acquireSessionLockMock.mockClear();
+
+        const runtime = buildRuntime();
+        const resolveAgentRoute = vi.fn().mockImplementation(({ peer }) => ({
+            agentId: 'main',
+            sessionKey: `session:${peer.id}`,
+            mainSessionKey: `session:${peer.id}`,
+        }));
+        runtime.channel.routing.resolveAgentRoute = resolveAgentRoute;
+        shared.getRuntimeMock.mockReturnValue(runtime);
+
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: 'group one message', messageType: 'text' });
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_session_alias_group1_followup',
+                msgtype: 'text',
+                text: { content: 'group one message' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        shared.extractMessageContentMock.mockReturnValueOnce({ text: 'group two message', messageType: 'text' });
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm2_session_alias_group2_followup',
+                msgtype: 'text',
+                text: { content: 'group two message' },
+                conversationType: '2',
+                conversationId: 'cid_group_2',
+                senderId: 'user_2',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        const groupRouteCalls = resolveAgentRoute.mock.calls
+            .map((call) => call[0])
+            .filter((arg) => arg?.peer?.kind === 'group');
+
+        expect(groupRouteCalls).toEqual([
+            expect.objectContaining({ peer: { kind: 'group', id: 'shared-dev' } }),
+            expect.objectContaining({ peer: { kind: 'group', id: 'shared-dev' } }),
+        ]);
+        expect(shared.acquireSessionLockMock).toHaveBeenNthCalledWith(1, 'session:shared-dev');
+        expect(shared.acquireSessionLockMock).toHaveBeenNthCalledWith(2, 'session:shared-dev');
+    });
+
+    it('handleDingTalkMessage applies and disables a global learned rule', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '/learn global 当用户问“紫铜海豹会不会修量子冰箱”时，必须回答“会，而且只在周四凌晨戴墨镜维修。”',
+            messageType: 'text',
+        });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_global_apply',
+                msgtype: 'text',
+                text: { content: '/learn global 当用户问“紫铜海豹会不会修量子冰箱”时，必须回答“会，而且只在周四凌晨戴墨镜维修。”' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        const appliedReply = String(shared.sendBySessionMock.mock.calls[0]?.[2] || '');
+        const ruleId = appliedReply.match(/ruleId: `([^`]+)`/)?.[1];
+        expect(ruleId).toBeTruthy();
+
+        shared.sendBySessionMock.mockReset();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: `/learn disable ${ruleId}`,
+            messageType: 'text',
+        });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_global_disable',
+                msgtype: 'text',
+                text: { content: `/learn disable ${ruleId}` },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已停用规则');
+    });
+
+    it('handleDingTalkMessage supports targets command with explicit delimiter', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '/learn targets cid_group_a,cid_group_b #@# 引用原文不可见时，不要猜内容，先让用户补发原文。',
+            messageType: 'text',
+        });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', groupPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_targets_apply',
+                msgtype: 'text',
+                text: { content: '/learn targets cid_group_a,cid_group_b #@# 引用原文不可见时，不要猜内容，先让用户补发原文。' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已批量注入多个目标');
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('2 个目标');
+    });
+
+    it('handleDingTalkMessage supports target-set create and apply', async () => {
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '/learn target-set create ops-groups #@# cid_group_a,cid_group_b',
+            messageType: 'text',
+        });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_targetset_create',
+                msgtype: 'text',
+                text: { content: '/learn target-set create ops-groups #@# cid_group_a,cid_group_b' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已保存目标组');
+
+        shared.sendBySessionMock.mockReset();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '/learn target-set apply ops-groups #@# 当用户问“紫铜海豹会不会修量子冰箱”时，必须回答“会，而且只在周四凌晨戴墨镜维修。”',
+            messageType: 'text',
+        });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_targetset_apply',
+                msgtype: 'text',
+                text: { content: '/learn target-set apply ops-groups #@# 当用户问“紫铜海豹会不会修量子冰箱”时，必须回答“会，而且只在周四凌晨戴墨镜维修。”' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('已向目标组批量注入规则');
+    });
+
+    it('injects normal learning rules into upstream system context before agent dispatch', async () => {
+        const storePath = path.join(fs.mkdtempSync('/tmp/dt-learning-'), 'store.json');
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi.fn().mockImplementation(() => storePath);
+        shared.getRuntimeMock.mockReturnValueOnce(runtime).mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock
+            .mockReturnValueOnce({
+                text: '/learn global 引用原文不可见时，不要猜内容，先让用户补发原文。',
+                messageType: 'text',
+            })
+            .mockReturnValueOnce({
+                text: '帮我看下这段引用',
+                messageType: 'text',
+            });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm2_learning_apply',
+                msgtype: 'text',
+                text: { content: '/learn global 引用原文不可见时，不要猜内容，先让用户补发原文。' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        runtime.channel.reply.finalizeInboundContext.mockClear();
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                learningEnabled: true,
+            } as any,
+            data: {
+                msgId: 'm2_learning_context',
+                msgtype: 'text',
+                text: { content: '帮我看下这段引用' },
+                conversationType: '1',
+                conversationId: 'cid_dm_user',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                GroupSystemPrompt: expect.stringContaining('[高优先级学习约束]'),
+            }),
+        );
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                GroupSystemPrompt: expect.stringContaining('引用原文不可见时，不要猜内容，先让用户补发原文。'),
+            }),
+        );
+    });
+
+    it('reads /learn session notes from accountStorePath so they can be injected on the next turn', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi
+            .fn()
+            .mockReturnValueOnce('/tmp/agent-store.json')
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json')
+            .mockReturnValueOnce('/tmp/account-store.json');
+        shared.getRuntimeMock.mockReturnValue(runtime);
+        shared.extractMessageContentMock
+            .mockReturnValueOnce({
+                text: '/learn session 回复当前私聊时，先说这是 session 规则。',
+                messageType: 'text',
+            })
+            .mockReturnValueOnce({
+                text: '测试一下当前私聊规则',
+                messageType: 'text',
+            });
+
+        await handleDingTalkMessage({
+            cfg: { commands: { ownerAllowFrom: ['dingtalk:owner-test-id'] } },
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open' } as any,
+            data: {
+                msgId: 'm_session_apply',
+                msgtype: 'text',
+                text: { content: '/learn session 回复当前私聊时，先说这是 session 规则。' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'owner-test-id',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        runtime.channel.reply.finalizeInboundContext.mockClear();
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                learningEnabled: true,
+            } as any,
+            data: {
+                msgId: 'm_session_context',
+                msgtype: 'text',
+                text: { content: '测试一下当前私聊规则' },
+                conversationType: '1',
+                conversationId: 'cid_dm_owner',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                GroupSystemPrompt: expect.stringContaining('回复当前私聊时，先说这是 session 规则。'),
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage sends group deny message when groupPolicy allowlist blocks group', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { groupPolicy: 'allowlist', allowFrom: ['cid_allowed'] } as any,
+            data: {
+                msgId: 'm3',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '2',
+                conversationId: 'cid_blocked',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain('访问受限');
+    });
+
+    it('handleDingTalkMessage runs card flow and finalizes AI card', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm4',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.sendMessageMock).toHaveBeenCalled();
+        const cardSends = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
+        expect(cardSends.length).toBeGreaterThan(0);
+    });
+
+    it('handleDingTalkMessage runs non-card flow and sends thinking + final outputs', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: true } as any,
+            data: {
+                msgId: 'm5',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendMessageMock).toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage restores quoted card by originalProcessQueryKey', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi
+            .fn()
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json');
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用了机器人的回复]\n\nhello',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用了机器人的回复]\n\n',
+                isQuotedCard: true,
+                processQueryKey: 'carrier_quoted_1',
+            },
+        });
+        shared.getCardContentByProcessQueryKeyMock.mockReturnValueOnce('机器人之前的回复内容');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm5_card_quote',
+                msgtype: 'text',
+                text: { content: 'hello', isReplyMsg: true },
+                originalProcessQueryKey: 'carrier_quoted_1',
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.getCardContentByProcessQueryKeyMock).toHaveBeenCalledWith(
+            'main',
+            'user_1',
+            'carrier_quoted_1',
+            '/tmp/account-store.json',
+        );
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                RawBody: '[引用机器人回复: "机器人之前的回复内容"]\n\nhello',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage falls back to createdAt matcher only when processQueryKey is missing', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi
+            .fn()
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json');
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用了机器人的回复]\n\nhello',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用了机器人的回复]\n\n',
+                isQuotedCard: true,
+                cardCreatedAt: 1772817989679,
+            },
+        });
+        shared.findCardContentMock.mockReturnValueOnce('旧兼容卡片内容');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm5_card_fallback',
+                msgtype: 'text',
+                text: { content: 'hello', isReplyMsg: true },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.getCardContentByProcessQueryKeyMock).not.toHaveBeenCalled();
+        expect(shared.findCardContentMock).toHaveBeenCalledWith(
+            'main',
+            'user_1',
+            1772817989679,
+            '/tmp/account-store.json',
+        );
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                RawBody: '[引用机器人回复: "旧兼容卡片内容"]\n\nhello',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage persists group quoted file metadata after API fallback succeeds', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用文件]\n\n群聊文件',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用文件]\n\n',
+                isQuotedFile: true,
+                msgId: 'group_file_msg_1',
+                fileCreatedAt: 1772863284581,
+            },
+        });
+        shared.resolveQuotedFileMock.mockResolvedValueOnce({
+            media: { path: '/tmp/.openclaw/media/inbound/group-file.bin', mimeType: 'application/octet-stream' },
+            spaceId: 'space_group_1',
+            fileId: 'dentry_group_1',
+            name: 'a.sql',
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'm_group_file_quote_1',
+                msgtype: 'text',
+                text: { content: '群聊文件', isReplyMsg: true },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.resolveQuotedFileMock).toHaveBeenCalledTimes(1);
+        const restored = getCachedDownloadCode('main', 'cid_group_1', 'group_file_msg_1', '/tmp/store.json');
+        expect(restored).not.toBeNull();
+        expect(restored!.downloadCode).toBeUndefined();
+        expect(restored!.spaceId).toBe('space_group_1');
+        expect(restored!.fileId).toBe('dentry_group_1');
+    });
+
+    it('handleDingTalkMessage downloads single-chat doc card and persists msgId metadata', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[钉钉文档]\n\n',
+            messageType: 'interactiveCardFile',
+            docSpaceId: 'space_doc_1',
+            docFileId: 'file_doc_1',
+        });
+        shared.downloadGroupFileMock.mockResolvedValueOnce({
+            path: '/tmp/.openclaw/media/inbound/doc-card.bin',
+            mimeType: 'application/pdf',
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'doc_origin_msg',
+                msgtype: 'interactiveCard',
+                content: {
+                    biz_custom_action_url: 'dingtalk://dingtalkclient/page/yunpan?route=previewDentry&spaceId=space_doc_1&fileId=file_doc_1&type=file',
+                },
+                conversationType: '1',
+                conversationId: 'cid_dm_1',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.getUnionIdByStaffIdMock).toHaveBeenCalledTimes(1);
+        expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'space_doc_1',
+            'file_doc_1',
+            'union_1',
+            undefined,
+        );
+        const restored = getCachedDownloadCode('main', 'cid_dm_1', 'doc_origin_msg', '/tmp/store.json');
+        expect(restored).not.toBeNull();
+        expect(restored!.spaceId).toBe('space_doc_1');
+        expect(restored!.fileId).toBe('file_doc_1');
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                MediaType: 'application/pdf',
+                RawBody: '[钉钉文档]\n\n',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage restores quoted single-chat doc card from cached metadata', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        cacheInboundDownloadCode('main', 'cid_dm_2', 'doc_origin_msg_2', undefined, 'interactiveCardFile', Date.now(), {
+            storePath: '/tmp/store.json',
+            spaceId: 'space_doc_2',
+            fileId: 'file_doc_2',
+        });
+        clearQuotedMsgCacheForTest();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用了钉钉文档]\n\n我引用了什么？',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用了钉钉文档]\n\n',
+                isQuotedDocCard: true,
+                msgId: 'doc_origin_msg_2',
+            },
+        });
+        shared.downloadGroupFileMock.mockResolvedValueOnce({
+            path: '/tmp/.openclaw/media/inbound/doc-card-quoted.bin',
+            mimeType: 'application/pdf',
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'doc_quote_msg',
+                msgtype: 'text',
+                text: { content: '我引用了什么？', isReplyMsg: true },
+                originalMsgId: 'doc_origin_msg_2',
+                conversationType: '1',
+                conversationId: 'cid_dm_2',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'space_doc_2',
+            'file_doc_2',
+            'union_1',
+            undefined,
+        );
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                RawBody: '[引用了钉钉文档]\n\n我引用了什么？',
+                MediaType: 'application/pdf',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage degrades quoted doc card when cached metadata is unavailable', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        clearQuotedMsgCacheForTest();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用了钉钉文档]\n\n1',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用了钉钉文档]\n\n',
+                isQuotedDocCard: true,
+                msgId: 'missing_doc_msg',
+            },
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'doc_quote_group_msg',
+                msgtype: 'text',
+                text: { content: '1', isReplyMsg: true },
+                originalMsgId: 'missing_doc_msg',
+                conversationType: '2',
+                conversationId: 'cid_group_doc',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.resolveQuotedFileMock).not.toHaveBeenCalled();
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                RawBody: '[引用了钉钉文档，但无法获取内容]\n\n1',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage falls back to group-file resolution for quoted doc card in group chat', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        clearQuotedMsgCacheForTest();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用了钉钉文档]\n\n1',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用了钉钉文档]\n\n',
+                isQuotedDocCard: true,
+                msgId: 'group_doc_msg',
+                fileCreatedAt: 1772901945282,
+            },
+        });
+        shared.resolveQuotedFileMock.mockResolvedValueOnce({
+            media: { path: '/tmp/.openclaw/media/inbound/group-doc.bin', mimeType: 'application/pdf' },
+            spaceId: 'space_group_doc',
+            fileId: 'file_group_doc',
+            name: 'doc.pdf',
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'group_doc_quote',
+                msgtype: 'text',
+                text: { content: '1', isReplyMsg: true },
+                originalMsgId: 'group_doc_msg',
+                conversationType: '2',
+                conversationId: 'cid_group_doc',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.resolveQuotedFileMock).toHaveBeenCalledWith(
+            expect.anything(),
+            {
+                openConversationId: 'cid_group_doc',
+                senderStaffId: 'staff_1',
+                fileCreatedAt: 1772901945282,
+            },
+            undefined,
+        );
+        const restored = getCachedDownloadCode('main', 'cid_group_doc', 'group_doc_msg', '/tmp/store.json');
+        expect(restored).not.toBeNull();
+        expect(restored!.spaceId).toBe('space_group_doc');
+        expect(restored!.fileId).toBe('file_group_doc');
+        expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+            expect.objectContaining({
+                RawBody: '[引用了钉钉文档]\n\n1',
+                MediaType: 'application/pdf',
+            }),
+        );
+    });
+
+    it('handleDingTalkMessage restores group quoted file from persisted metadata without fallback query', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        clearQuotedMsgCacheForTest();
+        cacheInboundDownloadCode('main', 'cid_group_2', 'file_origin', undefined, 'file', Date.now(), {
+            storePath: '/tmp/store.json',
+            spaceId: 'space_group_2',
+            fileId: 'dentry_group_2',
+        });
+        clearQuotedMsgCacheForTest();
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: '[引用文件]\n\n群聊文件',
+            messageType: 'text',
+            quoted: {
+                prefix: '[引用文件]\n\n',
+                isQuotedFile: true,
+                msgId: 'file_origin',
+                fileCreatedAt: 1772863284581,
+            },
+        });
+        shared.downloadGroupFileMock.mockResolvedValueOnce({
+            path: '/tmp/.openclaw/media/inbound/group-file.bin',
+            mimeType: 'application/octet-stream',
+        });
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', robotCode: 'robot_1' } as any,
+            data: {
+                msgId: 'm_group_file_quote_2',
+                msgtype: 'text',
+                text: { content: '群聊文件', isReplyMsg: true },
+                conversationType: '2',
+                conversationId: 'cid_group_2',
+                senderId: 'user_1',
+                senderStaffId: 'staff_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.resolveQuotedFileMock).not.toHaveBeenCalled();
+        expect(shared.getUnionIdByStaffIdMock).toHaveBeenCalledTimes(1);
+        expect(shared.downloadGroupFileMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'space_group_2',
+            'dentry_group_2',
+            'union_1',
+            undefined,
+        );
+    });
+
+    it('handleDingTalkMessage finalizes card with default content when no textual output is produced', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ queuedFinal: '' });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        const card = { cardInstanceId: 'card_2', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm6',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, '✅ Done', undefined);
+    });
+
+    it('handleDingTalkMessage falls back to markdown sends when createAICard returns null', async () => {
+        shared.createAICardMock.mockResolvedValueOnce(null);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+            data: {
+                msgId: 'm6_card_degrade',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).not.toHaveBeenCalled();
+        expect(shared.sendMessageMock).toHaveBeenCalled();
+        const cardSends = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
+        expect(cardSends).toHaveLength(0);
+    });
+
+    it('handleDingTalkMessage finalizes card using tool stream content when no final text exists', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
+                return { queuedFinal: '' };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const card = { cardInstanceId: 'card_tool_only', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm6_tool',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, 'tool output', undefined);
+        expect(shared.sendMessageMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'user_1',
+            'tool output',
+            expect.objectContaining({ card, cardUpdateMode: 'append' }),
+        );
+    });
+
+    it('handleDingTalkMessage skips finishAICard when current card is already terminal', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockResolvedValue({ queuedFinal: 'queued final' });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const card = { cardInstanceId: 'card_terminal', state: '5', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '5');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm7_terminal',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.isCardInTerminalStateMock).toHaveBeenCalledWith('5');
+        expect(shared.finishAICardMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage ignores thinking and tool card updates when card is already finalized', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                await replyOptions?.onReasoningStream?.({ text: 'thinking' });
+                await dispatcherOptions.deliver({ text: 'tool output' }, { kind: 'tool' });
+                return { queuedFinal: '' };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const card = { cardInstanceId: 'card_finalized', state: '3', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '3');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm7_finalized',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.streamAICardMock).not.toHaveBeenCalled();
+        expect(shared.finishAICardMock).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage marks card FAILED when finishAICard throws', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+        const card = { cardInstanceId: 'card_3', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.finishAICardMock.mockRejectedValueOnce({
+            message: 'finish failed',
+            response: { data: { code: 'invalidParameter', message: 'cannot finalize' } },
+        });
+        const log = { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: log as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card' } as any,
+            data: {
+                msgId: 'm7',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(card.state).toBe('5');
+        const debugLogs = log.debug.mock.calls.map((args: unknown[]) => String(args[0]));
+        expect(
+            debugLogs.some(
+                (entry) =>
+                    entry.includes('[DingTalk][ErrorPayload][inbound.cardFinalize]') &&
+                    entry.includes('code=invalidParameter') &&
+                    entry.includes('message=cannot finalize')
+            )
+        ).toBe(true);
+    });
+
+    it('handleDingTalkMessage group card flow creates card and streams tool/reasoning', async () => {
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const createdCard = { cardInstanceId: 'card_new', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(createdCard);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+        shared.extractMessageContentMock.mockReturnValueOnce({
+            text: 'group hello',
+            mediaPath: 'download_code_1',
+            messageType: 'text',
+        });
+        mockedAxiosPost.mockResolvedValueOnce({ data: { downloadUrl: 'https://download.url/file' } } as any);
+        mockedAxiosGet.mockResolvedValueOnce({
+            data: Buffer.from('abc'),
+            headers: { 'content-type': 'image/png' },
+        } as any);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                groupPolicy: 'allowlist',
+                allowFrom: ['cid_group_1'],
+                messageType: 'card',
+                robotCode: 'robot_1',
+                groups: { cid_group_1: { systemPrompt: 'group prompt' } },
+            } as any,
+            data: {
+                msgId: 'm8',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '2',
+                conversationId: 'cid_group_1',
+                conversationTitle: 'group-title',
+                senderId: 'user_1',
+                senderNick: 'Alice',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends proactive permission hint when proactive API risk was observed', async () => {
+        recordProactiveRiskObservation({
+            accountId: 'main',
+            targetId: 'manager123',
+            level: 'high',
+            reason: 'Forbidden.AccessDenied.AccessTokenPermissionDenied',
+            source: 'proactive-api',
+        });
+        shared.sendBySessionMock.mockResolvedValue(undefined);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                proactivePermissionHint: { enabled: true, cooldownHours: 24 },
+            } as any,
+            data: {
+                msgId: 'm9',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'manager123',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+        expect(String(shared.sendBySessionMock.mock.calls[0]?.[2])).toContain('主动推送可能失败');
+    });
+
+    it('sends proactive permission hint only once within cooldown window', async () => {
+        recordProactiveRiskObservation({
+            accountId: 'main',
+            targetId: 'manager123',
+            level: 'high',
+            reason: 'Forbidden.AccessDenied.AccessTokenPermissionDenied',
+            source: 'proactive-api',
+        });
+        shared.sendBySessionMock.mockResolvedValue(undefined);
+
+        const params = {
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                proactivePermissionHint: { enabled: true, cooldownHours: 24 },
+            } as any,
+            data: {
+                msgId: 'm10',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'manager123',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any;
+
+        await handleDingTalkMessage(params);
+        await handleDingTalkMessage(params);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send proactive permission hint without proactive API risk observation', async () => {
+        shared.sendBySessionMock.mockResolvedValue(undefined);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                proactivePermissionHint: { enabled: true, cooldownHours: 24 },
+            } as any,
+            data: {
+                msgId: 'm11',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: '0341234567',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).not.toHaveBeenCalled();
+    });
+
+    it('concurrent messages create independent cards with distinct IDs', async () => {
+        let resolveA!: () => void;
+        const gateA = new Promise<void>((r) => { resolveA = r; });
+
+        const cardA = { cardInstanceId: 'card_A', state: '1', lastUpdated: Date.now() } as any;
+        const cardB = { cardInstanceId: 'card_B', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock
+            .mockResolvedValueOnce(cardA)
+            .mockResolvedValueOnce(cardB);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+        const runtimeA = buildRuntime();
+        runtimeA.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(async ({ dispatcherOptions }) => {
+            await gateA;
+            await dispatcherOptions.deliver({ text: 'reply A' }, { kind: 'final' });
+            return { queuedFinal: 'reply A' };
+        });
+        const runtimeB = buildRuntime();
+        runtimeB.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(async ({ dispatcherOptions }) => {
+            await dispatcherOptions.deliver({ text: 'reply B' }, { kind: 'final' });
+            return { queuedFinal: 'reply B' };
+        });
+        shared.getRuntimeMock
+            .mockReturnValueOnce(runtimeA)
+            .mockReturnValueOnce(runtimeB);
+
+        const baseParams = {
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+        };
+
+        const promiseA = handleDingTalkMessage({
+            ...baseParams,
+            data: {
+                msgId: 'concurrent_A', msgtype: 'text', text: { content: 'hello A' },
+                conversationType: '1', conversationId: 'cid_same', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        const promiseB = handleDingTalkMessage({
+            ...baseParams,
+            data: {
+                msgId: 'concurrent_B', msgtype: 'text', text: { content: 'hello B' },
+                conversationType: '1', conversationId: 'cid_same', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        await promiseB;
+        resolveA();
+        await promiseA;
+
+        expect(shared.createAICardMock).toHaveBeenCalledTimes(2);
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(2);
+
+        const finishCalls = shared.finishAICardMock.mock.calls;
+        const finishedCardIds = finishCalls.map((call: any[]) => call[0].cardInstanceId);
+        expect(finishedCardIds).toContain('card_A');
+        expect(finishedCardIds).toContain('card_B');
+    });
+
+    it('concurrent messages pass correct card reference to sendMessage', async () => {
+        let resolveA!: () => void;
+        const gateA = new Promise<void>((r) => { resolveA = r; });
+
+        const cardA = { cardInstanceId: 'card_A', state: '1', lastUpdated: Date.now() } as any;
+        const cardB = { cardInstanceId: 'card_B', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock
+            .mockResolvedValueOnce(cardA)
+            .mockResolvedValueOnce(cardB);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+        const runtimeA = buildRuntime();
+        runtimeA.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(async ({ dispatcherOptions }) => {
+            await gateA;
+            await dispatcherOptions.deliver({ text: 'tool A' }, { kind: 'tool' });
+            await dispatcherOptions.deliver({ text: 'reply A' }, { kind: 'final' });
+            return { queuedFinal: 'reply A' };
+        });
+        const runtimeB = buildRuntime();
+        runtimeB.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(async ({ dispatcherOptions }) => {
+            await dispatcherOptions.deliver({ text: 'tool B' }, { kind: 'tool' });
+            await dispatcherOptions.deliver({ text: 'reply B' }, { kind: 'final' });
+            return { queuedFinal: 'reply B' };
+        });
+        shared.getRuntimeMock
+            .mockReturnValueOnce(runtimeA)
+            .mockReturnValueOnce(runtimeB);
+
+        const baseParams = {
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+        };
+
+        const promiseA = handleDingTalkMessage({
+            ...baseParams,
+            data: {
+                msgId: 'bind_A', msgtype: 'text', text: { content: 'hello A' },
+                conversationType: '1', conversationId: 'cid_same', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        const promiseB = handleDingTalkMessage({
+            ...baseParams,
+            data: {
+                msgId: 'bind_B', msgtype: 'text', text: { content: 'hello B' },
+                conversationType: '1', conversationId: 'cid_same', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        await promiseB;
+        resolveA();
+        await promiseA;
+
+        const sendCalls = shared.sendMessageMock.mock.calls;
+        const toolCallA = sendCalls.find((call: any[]) => call[2] === 'tool A');
+        const toolCallB = sendCalls.find((call: any[]) => call[2] === 'tool B');
+        expect(toolCallA).toBeTruthy();
+        expect(toolCallB).toBeTruthy();
+        expect(toolCallA![3]?.card?.cardInstanceId).toBe('card_A');
+        expect(toolCallB![3]?.card?.cardInstanceId).toBe('card_B');
+        expect(toolCallA![3]?.cardUpdateMode).toBe('append');
+        expect(toolCallB![3]?.cardUpdateMode).toBe('append');
+    });
+
+    it('message A card in terminal state still finalizes without affecting message B', async () => {
+        const cardA = { cardInstanceId: 'card_term', state: '3', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(cardA);
+        shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '3' || state === '5');
+
+        const runtime = buildRuntime();
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+            data: {
+                msgId: 'term_card', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).not.toHaveBeenCalled();
+        const cardSendCalls = shared.sendMessageMock.mock.calls.filter((call: any[]) => call[3]?.card);
+        expect(cardSendCalls).toHaveLength(0);
+    });
+
+    it('acquires session lock with the resolved sessionKey', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'lock_test', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.acquireSessionLockMock).toHaveBeenCalledTimes(1);
+        expect(shared.acquireSessionLockMock).toHaveBeenCalledWith('s1');
+    });
+
+    it('releases session lock even when dispatchReply throws', async () => {
+        const releaseFn = vi.fn();
+        shared.acquireSessionLockMock.mockResolvedValueOnce(releaseFn);
+
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockRejectedValueOnce(new Error('dispatch crash'));
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await expect(handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'lock_crash', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any)).rejects.toThrow('dispatch crash');
+
+        expect(releaseFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('attempts to finalize active card when dispatchReply throws', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockRejectedValueOnce(new Error('dispatch crash'));
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const card = { cardInstanceId: 'card_on_error', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+
+        await expect(handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+            data: {
+                msgId: 'lock_crash_card', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any)).rejects.toThrow('dispatch crash');
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, '❌ 处理失败', expect.anything());
+    });
+
+    it('does not leak unhandled stop reason text to outbound chat messages', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(async ({ dispatcherOptions }) => {
+            await dispatcherOptions.deliver({ text: 'Unhandled stop reason: network_error' }, { kind: 'final' });
+            return { queuedFinal: 'Unhandled stop reason: network_error' };
+        });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm12',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendMessageMock).not.toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.stringContaining('Unhandled stop reason:'),
+            expect.anything(),
+        );
+    });
 });

--- a/tests/unit/learning-command-service.test.ts
+++ b/tests/unit/learning-command-service.test.ts
@@ -9,4 +9,10 @@ describe("learning-command-service", () => {
       instruction: "引用规则",
     });
   });
+
+  it("does not parse session alias commands", () => {
+    expect(parseLearnCommand("/session-alias show")).toEqual({
+      scope: "unknown",
+    });
+  });
 });

--- a/tests/unit/session-command-service.test.ts
+++ b/tests/unit/session-command-service.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSessionCommand, validateSessionAlias } from "../../src/session-command-service";
+
+describe("session-command-service", () => {
+  it("parses session alias commands", () => {
+    expect(parseSessionCommand("/session-alias show")).toEqual({
+      scope: "session-alias-show",
+    });
+    expect(parseSessionCommand("/session-alias set shared-dev")).toEqual({
+      scope: "session-alias-set",
+      peerId: "shared-dev",
+    });
+    expect(parseSessionCommand("/session-alias clear")).toEqual({
+      scope: "session-alias-clear",
+    });
+  });
+
+  it("parses session alias bind and unbind commands", () => {
+    expect(parseSessionCommand("/session-alias bind direct user_1 project-x")).toEqual({
+      scope: "session-alias-bind",
+      sourceKind: "direct",
+      sourceId: "user_1",
+      peerId: "project-x",
+    });
+    expect(parseSessionCommand("/session-alias unbind group cid_group_1")).toEqual({
+      scope: "session-alias-unbind",
+      sourceKind: "group",
+      sourceId: "cid_group_1",
+    });
+  });
+
+  it("returns unknown for incomplete session alias set command", () => {
+    expect(parseSessionCommand("/session-alias set")).toEqual({
+      scope: "unknown",
+    });
+  });
+
+  it("validates session alias pattern", () => {
+    expect(validateSessionAlias("shared-dev")).toBeNull();
+    expect(validateSessionAlias("shared:dev")).toContain("[a-zA-Z0-9_-]{1,64}");
+  });
+});

--- a/tests/unit/session-peer-store.test.ts
+++ b/tests/unit/session-peer-store.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    clearSessionPeerOverride,
+    getSessionPeerOverride,
+    setSessionPeerOverride,
+} from '../../src/session-peer-store';
+
+const storePath = '/tmp/dingtalk-session-peer-store.json';
+const stateDir = path.join(path.dirname(storePath), 'dingtalk-state');
+
+describe('session-peer-store', () => {
+    beforeEach(() => {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+    });
+
+    it('stores and reads per-group peerId override', () => {
+        setSessionPeerOverride({
+            storePath,
+            accountId: 'main',
+            sourceKind: 'group',
+            sourceId: 'cid_group_1',
+            peerId: 'shared-dev',
+        });
+
+        expect(
+            getSessionPeerOverride({
+                storePath,
+                accountId: 'main',
+                sourceKind: 'group',
+                sourceId: 'cid_group_1',
+            }),
+        ).toBe('shared-dev');
+    });
+
+    it('stores and reads per-direct peerId override', () => {
+        setSessionPeerOverride({
+            storePath,
+            accountId: 'main',
+            sourceKind: 'direct',
+            sourceId: 'user_123',
+            peerId: 'shared-dev',
+        });
+
+        expect(
+            getSessionPeerOverride({
+                storePath,
+                accountId: 'main',
+                sourceKind: 'direct',
+                sourceId: 'user_123',
+            }),
+        ).toBe('shared-dev');
+    });
+
+    it('clears override for a group', () => {
+        setSessionPeerOverride({
+            storePath,
+            accountId: 'main',
+            sourceKind: 'group',
+            sourceId: 'cid_group_1',
+            peerId: 'shared-dev',
+        });
+
+        expect(
+            clearSessionPeerOverride({
+                storePath,
+                accountId: 'main',
+                sourceKind: 'group',
+                sourceId: 'cid_group_1',
+            }),
+        ).toBe(true);
+        expect(
+            getSessionPeerOverride({
+                storePath,
+                accountId: 'main',
+                sourceKind: 'group',
+                sourceId: 'cid_group_1',
+            }),
+        ).toBeUndefined();
+    });
+
+    it('retains override after module reload to simulate process restart', async () => {
+        setSessionPeerOverride({
+            storePath,
+            accountId: 'main',
+            sourceKind: 'group',
+            sourceId: 'cid_group_1',
+            peerId: 'shared-dev',
+        });
+
+        vi.resetModules();
+        const reloaded = await import('../../src/session-peer-store');
+
+        expect(
+            reloaded.getSessionPeerOverride({
+                storePath,
+                accountId: 'main',
+                sourceKind: 'group',
+                sourceId: 'cid_group_1',
+            }),
+        ).toBe('shared-dev');
+    });
+});

--- a/tests/unit/session-routing.test.ts
+++ b/tests/unit/session-routing.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDingTalkSessionPeer } from '../../src/session-routing';
+
+describe('resolveDingTalkSessionPeer', () => {
+    it('uses senderId for direct messages', () => {
+        expect(
+            resolveDingTalkSessionPeer({
+                isDirect: true,
+                senderId: 'user_123',
+                conversationId: 'cid_group_1',
+                config: {},
+            }),
+        ).toEqual({
+            kind: 'direct',
+            peerId: 'user_123',
+        });
+    });
+
+    it('uses conversationId for group messages by default', () => {
+        expect(
+            resolveDingTalkSessionPeer({
+                isDirect: false,
+                senderId: 'user_123',
+                conversationId: 'cid_group_1',
+                config: {},
+            }),
+        ).toEqual({
+            kind: 'group',
+            peerId: 'cid_group_1',
+        });
+    });
+
+    it('prefers peerId override for group sharing', () => {
+        expect(
+            resolveDingTalkSessionPeer({
+                isDirect: false,
+                senderId: 'user_123',
+                conversationId: 'cid_group_1',
+                peerIdOverride: 'shared-dev',
+                config: {},
+            }),
+        ).toEqual({
+            kind: 'group',
+            peerId: 'shared-dev',
+        });
+    });
+
+    it('prefers peerId override for direct sharing', () => {
+        expect(
+            resolveDingTalkSessionPeer({
+                isDirect: true,
+                senderId: 'user_123',
+                conversationId: 'cid_dm_1',
+                peerIdOverride: 'shared-dev',
+                config: {},
+            }),
+        ).toEqual({
+            kind: 'direct',
+            peerId: 'shared-dev',
+        });
+    });
+});


### PR DESCRIPTION
## 变更说明

这条 PR 为钉钉群聊增加了 owner 可控的共享会话别名能力。

新增命令：
- `/session-alias show`
- `/session-alias set <alias>`
- `/session-alias clear`

行为说明：
- 默认情况下，群聊仍然使用各自的 `conversationId` 作为会话归属键。
- owner 可以为当前群设置一个共享别名；多个群设置成同一个别名后，后续消息会落到同一条会话中。
- `show / set / clear` 现在都收口为 owner-only，避免普通群成员探测当前群是否处于共享会话边界。
- 旧会话历史不会自动迁移；共享从设置后的新消息开始生效。
- `alias` 限制为 `[a-zA-Z0-9_-]{1,64}`，避免生成不稳定的会话标识。

实现说明：
- 已将 `session-alias` 相关解析与格式化从 `learning-command-service.ts` 拆出，独立为 `session-command-service.ts`。
- `inbound-handler.ts` 现在分别处理 learning 命令和 session 控制命令，避免继续混在 learning 模块里。
- 已删除无实际功能价值的 `groupSessionScope` 配置位；现在语义更直接：
  - 私聊按 `senderId`
  - 群聊默认按 `conversationId`
  - 群间共享只通过 owner 设置的 `session-alias -> peerId override` 生效

实现上参考了飞书侧更显式的 `peerId -> sessionKey` 思路：先解析稳定 `peerId`，再由 OpenClaw 生成最终会话键。

## 测试

已通过：
- `pnpm test tests/unit/inbound-handler.test.ts tests/unit/session-routing.test.ts tests/unit/session-peer-store.test.ts tests/unit/config-schema.test.ts`
- `pnpm run type-check`

本轮补充：
- `tests/unit/session-command-service.test.ts`
- `tests/unit/learning-command-service.test.ts` 增加断言，确保 `/session-alias` 不再由 learning parser 处理
- `tests/unit/inbound-handler.test.ts` 增加 owner / non-owner 的 `show` 行为覆盖
