### PR TITLE
chore: cleanup typing (rebased #220)

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -298,7 +298,7 @@ export function isCardInTerminalState(state: string): boolean {
   return state === AICardStatus.FINISHED || state === AICardStatus.FAILED;
 }
 
-export function formatContentForCard(content: string, type: "thinking" | "tool"): string {
+export function formatContentForCard(content: string | undefined, type: "thinking" | "tool"): string {
   if (!content) {
     return "";
   }

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1037,9 +1037,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         cfg,
         dispatcherOptions: {
           responsePrefix: "",
-          deliver: async (payload: any, info?: { kind: string }) => {
+          deliver: async (payload, info) => {
             try {
-              const textToSend = payload.markdown || payload.text;
+              const textToSend = payload.text;
               if (!textToSend) {
                 return;
               }
@@ -1049,12 +1049,12 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 return;
               }
 
-              if (useCardMode && currentAICard && info?.kind === "final") {
+              if (useCardMode && currentAICard && info.kind === "final") {
                 lastCardContent = textToSend;
                 return;
               }
 
-              if (useCardMode && currentAICard && info?.kind === "tool") {
+              if (useCardMode && currentAICard && info.kind === "tool") {
                 if (isCardInTerminalState(currentAICard.state)) {
                   log?.debug?.(
                     `[DingTalk] Skipping tool stream update because card is terminal: state=${currentAICard.state}`,
@@ -1102,7 +1102,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           },
         },
         replyOptions: {
-          onReasoningStream: async (payload: any) => {
+          onReasoningStream: async (payload) => {
             if (!useCardMode || !currentAICard) {
               return;
             }


### PR DESCRIPTION
## Summary

Rebased version of #220 (by @huww98) onto current `main`. The original PR had fallen behind after several merges (#281 etc.) and could no longer cleanly merge.

**Changes (identical intent to #220):**

- **`src/inbound-handler.ts`**: Remove explicit `any` from `deliver` and `onReasoningStream` callback parameters, letting TypeScript infer correct types from the upstream SDK. Remove dead `payload.markdown` fallback (`OutboundReplyPayload` has no `markdown` field). Remove unnecessary optional chaining on `info` (upstream guarantees non-null).
- **`src/card-service.ts`**: Widen `formatContentForCard` first parameter from `string` to `string | undefined` to align with its runtime guard (`if (!content) return ""`).

## Verification

- `tsc` type-check: pass (0 errors)
- `oxlint` lint: pass (0 errors, only pre-existing warnings)
- `vitest` relevant tests: 75/75 pass (`inbound-handler.test.ts` + `card-service.test.ts`)

Supersedes #220.
