### PR TITLE
fix: deliver MEDIA attachments in inbound reply handler

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1304,6 +1304,46 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         dispatcherOptions: {
           responsePrefix: "",
           deliver: async (payload: ReplyStreamPayload, info?: ReplyChunkInfo) => {
+            async function deliverMediaAttachments(urls: string[]) {
+              for (const rawMediaUrl of urls) {
+                const preparedMedia = await prepareMediaInput(
+                  rawMediaUrl,
+                  log,
+                  dingtalkConfig.mediaUrlAllowlist,
+                );
+                try {
+                  const actualMediaPath = preparedMedia.path;
+                  const mediaType = resolveOutboundMediaType({
+                    mediaPath: actualMediaPath,
+                    asVoice: false,
+                  });
+                  if (sessionWebhook) {
+                    await sendBySession(dingtalkConfig, sessionWebhook, "", {
+                      mediaPath: actualMediaPath,
+                      mediaType,
+                      log,
+                    });
+                  } else {
+                    const sendResult = await sendProactiveMedia(
+                      dingtalkConfig,
+                      to,
+                      actualMediaPath,
+                      mediaType,
+                      {
+                        accountId,
+                        log,
+                      },
+                    );
+                    if (!sendResult.ok) {
+                      throw new Error(sendResult.error || "Media reply send failed");
+                    }
+                  }
+                } finally {
+                  await preparedMedia.cleanup?.();
+                }
+              }
+            }
+
             try {
               const richPayload = payload as typeof payload & {
                 mediaUrl?: string;
@@ -1325,45 +1365,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 await controller!.flush();
                 await controller!.waitForInFlight();
                 controller!.stop();
-                // Send media attachments before finalizing the card
                 if (mediaUrls.length > 0) {
-                  for (const rawMediaUrl of mediaUrls) {
-                    const preparedMedia = await prepareMediaInput(
-                      rawMediaUrl,
-                      log,
-                      dingtalkConfig.mediaUrlAllowlist,
-                    );
-                    try {
-                      const actualMediaPath = preparedMedia.path;
-                      const mediaType = resolveOutboundMediaType({
-                        mediaPath: actualMediaPath,
-                        asVoice: false,
-                      });
-                      if (sessionWebhook) {
-                        await sendBySession(dingtalkConfig, sessionWebhook, "", {
-                          mediaPath: actualMediaPath,
-                          mediaType,
-                          log,
-                        });
-                      } else {
-                        const sendResult = await sendProactiveMedia(
-                          dingtalkConfig,
-                          to,
-                          actualMediaPath,
-                          mediaType,
-                          {
-                            accountId,
-                            log,
-                          },
-                        );
-                        if (!sendResult.ok) {
-                          throw new Error(sendResult.error || "Media reply send failed");
-                        }
-                      }
-                    } finally {
-                      await preparedMedia.cleanup?.();
-                    }
-                  }
+                  await deliverMediaAttachments(mediaUrls);
                 }
                 if (!isCardInTerminalState(currentAICard.state) && !controller!.isFailed()) {
                   try {
@@ -1422,43 +1425,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
               // ---- media delivery (all modes) ----
               if (mediaUrls.length > 0) {
-                for (const rawMediaUrl of mediaUrls) {
-                  const preparedMedia = await prepareMediaInput(
-                    rawMediaUrl,
-                    log,
-                    dingtalkConfig.mediaUrlAllowlist,
-                  );
-                  try {
-                    const actualMediaPath = preparedMedia.path;
-                    const mediaType = resolveOutboundMediaType({
-                      mediaPath: actualMediaPath,
-                      asVoice: false,
-                    });
-                    if (sessionWebhook) {
-                      await sendBySession(dingtalkConfig, sessionWebhook, "", {
-                        mediaPath: actualMediaPath,
-                        mediaType,
-                        log,
-                      });
-                    } else {
-                      const sendResult = await sendProactiveMedia(
-                        dingtalkConfig,
-                        to,
-                        actualMediaPath,
-                        mediaType,
-                        {
-                          accountId,
-                          log,
-                        },
-                      );
-                      if (!sendResult.ok) {
-                        throw new Error(sendResult.error || "Media reply send failed");
-                      }
-                    }
-                  } finally {
-                    await preparedMedia.cleanup?.();
-                  }
-                }
+                await deliverMediaAttachments(mediaUrls);
               }
 
               // ---- non-card mode (markdown/text) ----

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const shared = vi.hoisted(() => ({
     sendBySessionMock: vi.fn(),
     sendMessageMock: vi.fn(),
+    sendProactiveMediaMock: vi.fn(),
     extractMessageContentMock: vi.fn(),
     findCardContentMock: vi.fn(),
     getCardContentByProcessQueryKeyMock: vi.fn(),
@@ -22,6 +23,8 @@ const shared = vi.hoisted(() => ({
     appendQuoteJournalEntryMock: vi.fn(),
     resolveQuotedMessageByIdMock: vi.fn(),
     extractAttachmentTextMock: vi.fn(),
+    prepareMediaInputMock: vi.fn(),
+    resolveOutboundMediaTypeMock: vi.fn(),
 }));
 
 vi.mock('axios', () => ({
@@ -51,7 +54,17 @@ vi.mock('../../src/attachment-text-extractor', () => ({
 vi.mock('../../src/send-service', () => ({
     sendBySession: shared.sendBySessionMock,
     sendMessage: shared.sendMessageMock,
+    sendProactiveMedia: shared.sendProactiveMediaMock,
 }));
+
+vi.mock('../../src/media-utils', async () => {
+    const actual = await vi.importActual<typeof import('../../src/media-utils')>('../../src/media-utils');
+    return {
+        ...actual,
+        prepareMediaInput: shared.prepareMediaInputMock,
+        resolveOutboundMediaType: shared.resolveOutboundMediaTypeMock,
+    };
+});
 
 vi.mock('../../src/card-service', () => ({
     createAICard: shared.createAICardMock,
@@ -127,10 +140,22 @@ describe('inbound-handler', () => {
         mockedAxiosGet.mockReset();
         shared.sendBySessionMock.mockReset();
         shared.sendMessageMock.mockReset();
+        shared.sendProactiveMediaMock.mockReset();
+        shared.sendProactiveMediaMock.mockResolvedValue({ ok: true });
+        shared.prepareMediaInputMock.mockReset();
+        shared.prepareMediaInputMock.mockImplementation(async (rawMediaUrl: string) => ({
+            path: `/tmp/prepared/${path.basename(rawMediaUrl) || 'media.bin'}`,
+            cleanup: vi.fn().mockResolvedValue(undefined),
+        }));
+        shared.resolveOutboundMediaTypeMock.mockReset();
+        shared.resolveOutboundMediaTypeMock.mockReturnValue('file');
         shared.sendMessageMock.mockImplementation(async (_config: any, _to: any, text: any, options: any) => {
-            // Simulate real sendMessage behavior: update lastStreamedContent when appending to card
-            if (options?.card && options?.cardUpdateMode === 'append') {
-                options.card.lastStreamedContent = text;
+            // Simulate real sendMessage behavior for AI card updates.
+            if (options?.card) {
+                options.card.lastStreamedContent =
+                    options.cardUpdateMode === 'append' && options.card.lastStreamedContent
+                        ? `${options.card.lastStreamedContent}${text}`
+                        : text;
             }
             return { ok: true };
         });
@@ -2066,6 +2091,280 @@ describe('inbound-handler', () => {
             'union_1',
             undefined,
         );
+    });
+
+    it('deliver callback sends single media payload through session webhook', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver({ mediaUrl: 'https://cdn.example.com/report.pdf' }, { kind: 'final' });
+                return { queuedFinal: false };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const cleanup = vi.fn().mockResolvedValue(undefined);
+        shared.prepareMediaInputMock.mockResolvedValueOnce({
+            path: '/tmp/prepared/report.pdf',
+            cleanup,
+        });
+        shared.resolveOutboundMediaTypeMock.mockReturnValueOnce('file');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_media_single',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.prepareMediaInputMock).toHaveBeenCalledWith(
+            'https://cdn.example.com/report.pdf',
+            undefined,
+            undefined,
+        );
+        expect(shared.sendBySessionMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://session.webhook',
+            '',
+            expect.objectContaining({ mediaPath: '/tmp/prepared/report.pdf', mediaType: 'file' }),
+        );
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('deliver callback sends multiple media payloads sequentially', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver(
+                    { mediaUrls: ['https://cdn.example.com/a.png', 'https://cdn.example.com/b.png'] },
+                    { kind: 'final' },
+                );
+                return { queuedFinal: false };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const cleanupA = vi.fn().mockResolvedValue(undefined);
+        const cleanupB = vi.fn().mockResolvedValue(undefined);
+        shared.prepareMediaInputMock
+            .mockResolvedValueOnce({ path: '/tmp/prepared/a.png', cleanup: cleanupA })
+            .mockResolvedValueOnce({ path: '/tmp/prepared/b.png', cleanup: cleanupB });
+        shared.resolveOutboundMediaTypeMock.mockReturnValue('image');
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_media_multi',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenNthCalledWith(
+            1,
+            expect.anything(),
+            'https://session.webhook',
+            '',
+            expect.objectContaining({ mediaPath: '/tmp/prepared/a.png', mediaType: 'image' }),
+        );
+        expect(shared.sendBySessionMock).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            'https://session.webhook',
+            '',
+            expect.objectContaining({ mediaPath: '/tmp/prepared/b.png', mediaType: 'image' }),
+        );
+        expect(cleanupA).toHaveBeenCalledTimes(1);
+        expect(cleanupB).toHaveBeenCalledTimes(1);
+    });
+
+    it('deliver callback sends mixed text and media payloads', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver(
+                    { text: 'final output', mediaUrl: 'https://cdn.example.com/report.pdf' },
+                    { kind: 'final' },
+                );
+                return { queuedFinal: false };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_media_text',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://session.webhook',
+            '',
+            expect.objectContaining({ mediaPath: '/tmp/prepared/report.pdf', mediaType: 'file' }),
+        );
+        expect(shared.sendMessageMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'user_1',
+            'final output',
+            expect.objectContaining({ sessionWebhook: 'https://session.webhook' }),
+        );
+    });
+
+    it('card mode + media bypasses finalContent accumulation and still finalizes with text', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver(
+                    { text: 'final output', mediaUrl: 'https://cdn.example.com/report.pdf' },
+                    { kind: 'final' },
+                );
+                return { queuedFinal: true };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const card = { cardInstanceId: 'card_media_final', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+            data: {
+                msgId: 'm_card_media_text',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'https://session.webhook',
+            '',
+            expect.objectContaining({ mediaPath: '/tmp/prepared/report.pdf', mediaType: 'file' }),
+        );
+        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, 'final output', undefined);
+    });
+
+    it('deliver callback falls back to proactive media send when sessionWebhook is absent', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver({ mediaUrl: 'https://cdn.example.com/report.pdf' }, { kind: 'final' });
+                return { queuedFinal: false };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: undefined,
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_media_proactive',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.sendBySessionMock).not.toHaveBeenCalled();
+        expect(shared.sendProactiveMediaMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'user_1',
+            '/tmp/prepared/report.pdf',
+            'file',
+            expect.objectContaining({ accountId: 'main' }),
+        );
+    });
+
+    it('deliver callback cleans up prepared media when send fails', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver({ mediaUrl: 'https://cdn.example.com/report.pdf' }, { kind: 'final' });
+                return { queuedFinal: false };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        const cleanup = vi.fn().mockResolvedValue(undefined);
+        shared.prepareMediaInputMock.mockResolvedValueOnce({
+            path: '/tmp/prepared/report.pdf',
+            cleanup,
+        });
+        shared.sendBySessionMock.mockRejectedValueOnce(new Error('send failed'));
+
+        await expect(handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'markdown', showThinking: false } as any,
+            data: {
+                msgId: 'm_media_cleanup_failure',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any)).rejects.toThrow('send failed');
+
+        expect(cleanup).toHaveBeenCalledTimes(1);
     });
 
     it('handleDingTalkMessage finalizes card with default content when no textual output is produced', async () => {


### PR DESCRIPTION
## Summary

Fix DingTalk inbound reply delivery so assistant replies containing `MEDIA:` are sent as actual media/file messages instead of being silently dropped.

## Problem

The inbound reply handler only forwarded `payload.text` / `payload.markdown` via `sendMessage(...)`, but ignored `payload.mediaUrl` and `payload.mediaUrls`.

As a result, OpenClaw could parse `MEDIA:...` in assistant replies, but the DingTalk plugin never delivered those attachments.

## Fix

- detect `payload.mediaUrl` / `payload.mediaUrls` in `inbound-handler.ts`
- prepare the media with `prepareMediaInput(...)`
- resolve the outbound media type with `resolveOutboundMediaType(...)`
- send via `sendProactiveMedia(...)`
- preserve existing text-only behavior

## Verified

Tested in DingTalk direct chat with:

`MEDIA:./OpenClaw_大众介绍_5页.pptx`

Before fix: no file received  
After fix: file delivered successfully
