### PR TITLE
fix: wire onToolResult to enable verbose tool streaming in card mode

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1154,36 +1154,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 return;
               }
 
-              if (useCardMode && currentAICard && info.kind === "tool") {
-                if (isCardInTerminalState(currentAICard.state)) {
-                  log?.debug?.(
-                    `[DingTalk] Skipping tool stream update because card is terminal: state=${currentAICard.state}`,
-                  );
-                  return;
-                }
-
-                log?.info?.(
-                  `[DingTalk] Tool result received, streaming to AI Card: ${textToSend.slice(0, 100)}`,
-                );
-                const toolText = formatContentForCard(textToSend, "tool");
-                if (toolText) {
-                  const sendResult = await sendMessage(dingtalkConfig, to, toolText, {
-                    sessionWebhook,
-                    atUserId: !isDirect ? senderId : null,
-                    log,
-                    card: currentAICard,
-                    accountId,
-                    storePath,
-                    conversationId: groupId,
-                    cardUpdateMode: "append",
-                  });
-                  if (!sendResult.ok) {
-                    throw new Error(sendResult.error || "Tool stream send failed");
-                  }
-                  lastCardContent = currentAICard.lastStreamedContent || toolText;
-                  return;
-                }
-              }
+              // Note: tool results (kind === "tool") are handled via replyOptions.onToolResult,
+              // which streams them to the AI Card before the final reply is composed.
 
               lastCardContent = textToSend;
               const sendResult = await sendMessage(dingtalkConfig, to, textToSend, {
@@ -1210,6 +1182,49 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           },
         },
         replyOptions: {
+          onToolResult: async (payload) => {
+            if (!useCardMode || !currentAICard) {
+              return;
+            }
+            if (isCardInTerminalState(currentAICard.state)) {
+              log?.debug?.(
+                `[DingTalk] Skipping tool stream update because card is terminal: state=${currentAICard.state}`,
+              );
+              return;
+            }
+            const text = payload.markdown || payload.text;
+            if (!text) {
+              return;
+            }
+            const toolText = formatContentForCard(text, "tool");
+            if (!toolText) {
+              return;
+            }
+            log?.info?.(`[DingTalk] Tool result received, streaming to AI Card: ${text.slice(0, 100)}`);
+            try {
+              const sendResult = await sendMessage(dingtalkConfig, to, toolText, {
+                sessionWebhook,
+                atUserId: !isDirect ? senderId : null,
+                log,
+                card: currentAICard,
+                accountId,
+                storePath,
+                conversationId: groupId,
+                cardUpdateMode: "append",
+              });
+              if (!sendResult.ok) {
+                throw new Error(sendResult.error || "Tool stream send failed");
+              }
+              lastCardContent = currentAICard.lastStreamedContent || toolText;
+            } catch (err: any) {
+              log?.debug?.(`[DingTalk] Tool stream update failed: ${err.message}`);
+              if (err?.response?.data !== undefined) {
+                log?.debug?.(
+                  formatDingTalkErrorPayloadLog("inbound.toolStream", err.response.data),
+                );
+              }
+            }
+          },
           onReasoningStream: async (payload) => {
             if (!useCardMode || !currentAICard) {
               return;


### PR DESCRIPTION
## Problem

When `/verbose on` is enabled in card mode, tool call results are never shown in the AI Card — even though the card is created successfully and the `deliver()` handler has a `info.kind === "tool"` branch.

## Root Cause

The `deliver()` branch for `kind === "tool"` is dead code. The core runtime only calls `dispatcher.sendToolResult()` (which routes payloads through `deliver()`) when `onToolResult` is provided in `replyOptions`. Since `replyOptions` only implemented `onReasoningStream` and left `onToolResult` undefined, the core short-circuits:

```js
if (ctx.params.onToolResult && shouldEmitToolEvents && ...) {
  // never reached
}
```

As a result, no tool payload ever enters `deliver()`, and the `kind === "tool"` branch is unreachable.

## Fix

- Implement `replyOptions.onToolResult` with the same card-streaming logic (append mode, terminal-state guard, `formatContentForCard`).
- Remove the now-unreachable `info.kind === "tool"` block from `deliver()` and replace with an explanatory comment.

## Effect

`/verbose on` now correctly shows 🛠️ **工具执行** progress updates in the AI Card during tool calls, in both DM and group chat.