### PR TITLE
fix: increase health check interval/grace to prevent reconnect storm

### DIFF
--- a/src/connection-manager.ts
+++ b/src/connection-manager.ts
@@ -46,8 +46,8 @@ export class ConnectionManager {
   private connectedAt?: number;
   private consecutiveUnhealthyChecks: number = 0;
 
-  private static readonly HEALTH_CHECK_INTERVAL_MS = 5000;
-  private static readonly HEALTH_CHECK_GRACE_MS = 3000;
+  private static readonly HEALTH_CHECK_INTERVAL_MS = 60000;
+  private static readonly HEALTH_CHECK_GRACE_MS = 30000;
   private static readonly HEALTH_CHECK_UNHEALTHY_THRESHOLD = 2;
   private static readonly DEFAULT_MAX_RECONNECT_CYCLES = 10;
   private static readonly MAX_CYCLE_BACKOFF_MS = 5000;


### PR DESCRIPTION
## Problem

The DingTalk channel suffers from an infinite reconnect storm after connection establishment, causing messages to be lost during reconnect windows.

### Root Cause

In `src/connection-manager.ts`:
```
HEALTH_CHECK_INTERVAL_MS = 5000  // health check every 5s
HEALTH_CHECK_GRACE_MS    = 3000  // only 3s grace after connect
```

The DingTalk SDK `client.connect()` resolves before the WebSocket `open` event fires, so in the early connection phase:
- `client.connected` remains `false`
- `client.socket.readyState` may not yet be `1` (OPEN)

After the 3s grace period, the health check at 5-10s already evaluates the connection. With `UNHEALTHY_THRESHOLD=2`, two consecutive false negatives trigger `handleRuntimeDisconnection()` → reconnect → same false negative → **infinite reconnect storm**.

This was observed in logs:
```
connected → health check failed → reconnect → connected → health check failed → ...
```
Cycling every ~10 seconds, causing messages sent during reconnect windows to be dropped.

### Note

The health check is intended as a **last-resort fallback**. Fast detection is already handled by socket `close` events and server `disconnect` messages. The current 5s/3s values are far too aggressive for a fallback mechanism.

## Fix

```diff
-  private static readonly HEALTH_CHECK_INTERVAL_MS = 5000;
-  private static readonly HEALTH_CHECK_GRACE_MS = 3000;
+  private static readonly HEALTH_CHECK_INTERVAL_MS = 60000;
+  private static readonly HEALTH_CHECK_GRACE_MS = 30000;
```

Increasing the interval to 60s and grace to 30s gives the connection time to fully stabilize before health checks begin, and reduces the frequency of fallback checks to an appropriate level for a last-resort mechanism.