### PR TITLE
fix(config): resolve dashboard Unsupported schema node for #304

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -130,27 +130,15 @@ const DingTalkAccountConfigShape = {
   feedbackLearningNoteTtlMs: z.number().int().min(60_000).optional(),
 } as const;
 
-const DingTalkAccountConfigSchemaBase = z.object(DingTalkAccountConfigShape);
-
-const DingTalkAccountConfigSchema = DingTalkAccountConfigSchemaBase.transform((value) => ({
-  ...value,
-  learningEnabled: value.learningEnabled ?? value.feedbackLearningEnabled ?? false,
-  learningAutoApply: value.learningAutoApply ?? value.feedbackLearningAutoApply ?? false,
-  learningNoteTtlMs: value.learningNoteTtlMs ?? value.feedbackLearningNoteTtlMs ?? 6 * 60 * 60 * 1000,
-}));
+const DingTalkAccountConfigSchema = z.object(DingTalkAccountConfigShape);
 
 /**
  * DingTalk configuration schema using Zod
  * Mirrors the structure needed for proper control-ui rendering
  */
-export const DingTalkConfigSchema: z.ZodTypeAny = DingTalkAccountConfigSchemaBase.extend({
+export const DingTalkConfigSchema: z.ZodTypeAny = DingTalkAccountConfigSchema.extend({
   /** Multi-account configuration */
   accounts: z.record(z.string(), DingTalkAccountConfigSchema.optional()).optional(),
-}).transform((value) => ({
-  ...value,
-  learningEnabled: value.learningEnabled ?? value.feedbackLearningEnabled ?? false,
-  learningAutoApply: value.learningAutoApply ?? value.feedbackLearningAutoApply ?? false,
-  learningNoteTtlMs: value.learningNoteTtlMs ?? value.feedbackLearningNoteTtlMs ?? 6 * 60 * 60 * 1000,
-}));
+});
 
 export type DingTalkConfig = z.infer<typeof DingTalkConfigSchema>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,24 @@ const WINDOWS_ROOT_DIRECTORIES = new Set([
   "Windows",
   "Documents and Settings",
 ]);
+const DEFAULT_LEARNING_NOTE_TTL_MS = 6 * 60 * 60 * 1000;
+
+function normalizeLearningConfig(
+  config: DingTalkConfig,
+  options: { applyDefaults: boolean },
+): DingTalkConfig {
+  const learningEnabled = config.learningEnabled ?? config.feedbackLearningEnabled;
+  const learningAutoApply = config.learningAutoApply ?? config.feedbackLearningAutoApply;
+  const learningNoteTtlMs = config.learningNoteTtlMs ?? config.feedbackLearningNoteTtlMs;
+  return {
+    ...config,
+    learningEnabled: options.applyDefaults ? learningEnabled ?? false : learningEnabled,
+    learningAutoApply: options.applyDefaults ? learningAutoApply ?? false : learningAutoApply,
+    learningNoteTtlMs: options.applyDefaults
+      ? learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS
+      : learningNoteTtlMs,
+  };
+}
 
 /**
  * Merge channel-level defaults into an account-specific config.
@@ -21,16 +39,20 @@ export function mergeAccountWithDefaults(
   accountCfg: DingTalkConfig,
 ): DingTalkConfig {
   const { accounts: _accounts, ...defaults } = channelCfg;
+  const normalizedAccountCfg = normalizeLearningConfig(accountCfg, { applyDefaults: false });
   const overrides: Partial<DingTalkConfig> = {};
-  for (const [key, value] of Object.entries(accountCfg)) {
+  for (const [key, value] of Object.entries(normalizedAccountCfg)) {
     if (value !== undefined) {
       Object.assign(overrides, { [key]: value });
     }
   }
-  return {
-    ...defaults,
-    ...overrides,
-  };
+  return normalizeLearningConfig(
+    {
+      ...defaults,
+      ...overrides,
+    },
+    { applyDefaults: true },
+  );
 }
 
 /**
@@ -48,7 +70,15 @@ export function getConfig(cfg: OpenClawConfig, accountId?: string): DingTalkConf
     return mergeAccountWithDefaults(dingtalkCfg, dingtalkCfg.accounts[accountId]);
   }
 
-  return dingtalkCfg;
+  if (accountId) {
+    return normalizeLearningConfig(dingtalkCfg, { applyDefaults: true });
+  }
+
+  if (dingtalkCfg.accounts && Object.keys(dingtalkCfg.accounts).length > 0) {
+    return dingtalkCfg;
+  }
+
+  return normalizeLearningConfig(dingtalkCfg, { applyDefaults: true });
 }
 
 export function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {

--- a/tests/unit/config-advanced.test.ts
+++ b/tests/unit/config-advanced.test.ts
@@ -152,6 +152,53 @@ describe('config advanced', () => {
         expect((merged as any).accounts).toBeUndefined();
     });
 
+    it('normalizes legacy learning keys in single-account config', () => {
+        const cfg = {
+            channels: {
+                dingtalk: {
+                    clientId: 'top_id',
+                    clientSecret: 'top_sec',
+                    feedbackLearningEnabled: true,
+                    feedbackLearningAutoApply: true,
+                    feedbackLearningNoteTtlMs: 120000,
+                },
+            },
+        } as any;
+
+        const resolved = getConfig(cfg);
+        expect(resolved.learningEnabled).toBe(true);
+        expect(resolved.learningAutoApply).toBe(true);
+        expect(resolved.learningNoteTtlMs).toBe(120000);
+    });
+
+    it('normalizes account-level legacy learning keys with account override precedence', () => {
+        const cfg = {
+            channels: {
+                dingtalk: {
+                    clientId: 'top_id',
+                    clientSecret: 'top_sec',
+                    learningEnabled: true,
+                    learningAutoApply: true,
+                    learningNoteTtlMs: 3600000,
+                    accounts: {
+                        bot1: {
+                            clientId: 'bot1_id',
+                            clientSecret: 'bot1_sec',
+                            feedbackLearningEnabled: true,
+                            feedbackLearningAutoApply: false,
+                            feedbackLearningNoteTtlMs: 180000,
+                        },
+                    },
+                },
+            },
+        } as any;
+
+        const resolved = getConfig(cfg, 'bot1');
+        expect(resolved.learningEnabled).toBe(true);
+        expect(resolved.learningAutoApply).toBe(false);
+        expect(resolved.learningNoteTtlMs).toBe(180000);
+    });
+
     it('recovers Windows root-relative workspace paths only on win32', () => {
         Object.defineProperty(process, 'platform', {
             configurable: true,

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -115,8 +115,8 @@ describe('DingTalkConfigSchema', () => {
 
         expect(parsed.learningEnabled).toBe(true);
         expect(parsed.allowFrom).toEqual(['owner-test-id']);
-        expect(parsed.learningAutoApply).toBe(false);
-        expect(parsed.learningNoteTtlMs).toBe(6 * 60 * 60 * 1000);
+        expect(parsed.learningAutoApply).toBeUndefined();
+        expect(parsed.learningNoteTtlMs).toBeUndefined();
     });
 
     it('keeps backward compatibility for legacy feedback learning keys', () => {
@@ -126,10 +126,34 @@ describe('DingTalkConfigSchema', () => {
             feedbackLearningEnabled: true,
             feedbackLearningAutoApply: true,
             feedbackLearningNoteTtlMs: 120000,
-        }) as { learningEnabled?: boolean; learningAutoApply?: boolean; learningNoteTtlMs?: number };
+        }) as {
+            learningEnabled?: boolean;
+            learningAutoApply?: boolean;
+            learningNoteTtlMs?: number;
+            feedbackLearningEnabled?: boolean;
+            feedbackLearningAutoApply?: boolean;
+            feedbackLearningNoteTtlMs?: number;
+        };
 
-        expect(parsed.learningEnabled).toBe(true);
-        expect(parsed.learningAutoApply).toBe(true);
-        expect(parsed.learningNoteTtlMs).toBe(120000);
+        expect(parsed.learningEnabled).toBeUndefined();
+        expect(parsed.learningAutoApply).toBeUndefined();
+        expect(parsed.learningNoteTtlMs).toBeUndefined();
+        expect(parsed.feedbackLearningEnabled).toBe(true);
+        expect(parsed.feedbackLearningAutoApply).toBe(true);
+        expect(parsed.feedbackLearningNoteTtlMs).toBe(120000);
+    });
+
+    it('exports control-ui-compatible JSON schema nodes', () => {
+        const jsonSchema = DingTalkConfigSchema.toJSONSchema({
+            target: 'draft-07',
+            unrepresentable: 'any',
+        }) as {
+            type?: string;
+            properties?: Record<string, any>;
+        };
+
+        expect(jsonSchema.type).toBe('object');
+        expect(jsonSchema.properties?.accounts?.type).toBe('object');
+        expect(jsonSchema.properties?.accounts?.additionalProperties?.type).toBe('object');
     });
 });


### PR DESCRIPTION
## Summary
- remove Zod `.transform(...)` usage from `src/config-schema.ts` to keep generated JSON Schema ControlUI-compatible
- move legacy learning key normalization (`feedbackLearning*` -> `learning*`) into runtime config resolution in `src/config.ts`
- preserve account override precedence by applying a two-phase normalization (map-only before merge, defaults after merge)
- add regression tests for JSON Schema shape and legacy-key normalization behavior

## Root cause
The schema introduced `.transform(...)`, which produced non-renderable nodes for OpenClaw dashboard form renderer, leading to:

> Unsupported schema node. Use Raw mode.

## Verification
- npm run type-check
- pnpm test

Closes #304