### PR TITLE
feat(dingtalk): 增加钉钉原生思考中表情反馈

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ openclaw configure --section channels
       "journalTTLDays": 7,
       "showThinking": true, // 仅 markdown 模式生效
       "thinkingMessage": "🤔 思考中，请稍候...", // 仅 markdown 模式生效；设为 "emoji" 可启用随机颜文字彩蛋
+      "showThinkingReaction": false, // 可选：给原消息贴“🤔思考中”表情，处理结束后撤回（仅 markdown 模式）
       "debug": false,
       "messageType": "markdown", // 或 "card"
       // "mediaMaxMb": 20,  // 可选：接收文件大小上限（MB），默认 5 MB
@@ -387,6 +388,7 @@ openclaw gateway restart
 | `journalTTLDays`        | number   | `7`          | `originalMsgId` 文本回溯日志的保留天数      |
 | `showThinking`          | boolean  | `true`       | 是否发送“思考中”提示消息（仅 markdown 模式生效） |
 | `thinkingMessage`       | string   | `"🤔 思考中，请稍候..."` | 自定义“思考中”提示文案（showThinking 开启时生效，仅 markdown 模式）；设为 `"emoji"` 可按用户语气返回随机颜文字 |
+| `showThinkingReaction`  | boolean  | `false`      | 是否给用户原消息添加钉钉原生“🤔思考中”表情，并在处理结束后撤回（仅 markdown 模式） |
 | `messageType`           | string   | `"markdown"` | 消息类型：markdown/card                     |
 | `cardTemplateId`        | string   |              | AI 互动卡片模板 ID（仅当 messageType=card） |
 | `cardTemplateKey`       | string   | `"content"`  | 卡片模板内容字段键（仅当 messageType=card） |
@@ -416,11 +418,23 @@ openclaw gateway restart
 }
 ```
 
-> 说明：这是一个轻量彩蛋功能，仅影响 markdown 模式下的“思考中”提示；`messageType="card"` 时不会发送该独立提示消息。
 | `bypassProxyForSend`    | boolean  | `false`      | 仅对 send/card/upload 出站请求绕过系统 HTTP(S) 代理 |
 | `learningEnabled` | boolean | `false`    | 启用本地学习闭环（事件、反思、会话笔记、全局规则） |
 | `learningAutoApply` | boolean | `false` | 是否将反思自动注入会话/全局规则；默认只采集不生效 |
 | `learningNoteTtlMs` | number | `21600000` | 会话级学习笔记有效期（毫秒，默认 6 小时） |
+
+### 钉钉原生“思考中”表情反馈
+
+当 `messageType=markdown` 且 `showThinkingReaction=true` 时，插件会在处理开始时给用户原消息添加一条钉钉原生“🤔思考中”表情反馈，并在处理结束后自动撤回。该增强不会阻断主流程：贴表情或撤表情失败时只记录日志，仍继续正常回复。
+
+> 设计/实现参考自 `DingTalk-Real-AI/dingtalk-openclaw-connector`（MIT）：
+> <https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector>
+
+说明：
+
+- 仅 `markdown` 模式启用；`card` 模式继续使用现有卡片流式 thinking 展示
+- 该反馈作用于用户原消息，不会额外发送一条“思考中”消息
+- 可与 `showThinking` 同时开启；两者分别对应“原消息表情反馈”和“独立提示消息”
 
 ### 连接鲁棒性配置
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -42,6 +42,9 @@ const DingTalkAccountConfigShape = {
   /** Custom thinking message content when showThinking is enabled (markdown mode only) */
   thinkingMessage: z.string().optional().default("🤔 思考中，请稍候..."),
 
+  /** Show native DingTalk thinking reaction on the inbound message (markdown mode only) */
+  showThinkingReaction: z.boolean().optional().default(false),
+
   /** Enable debug logging */
   debug: z.boolean().optional().default(false),
 

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -72,10 +72,13 @@ import {
   listScopedLearningRules,
   resolveManualForcedReply,
 } from "./feedback-learning-service";
-import { formatDingTalkErrorPayloadLog, maskSensitiveData } from "./utils";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption, maskSensitiveData } from "./utils";
 
 const DEFAULT_PROACTIVE_HINT_COOLDOWN_HOURS = 24;
 const DEFAULT_THINKING_MESSAGE = "🤔 思考中，请稍候...";
+const THINKING_EMOTION_NAME = "🤔思考中";
+const THINKING_EMOTION_ID = "2659900";
+const THINKING_EMOTION_BACKGROUND_ID = "im_bg_1";
 const proactiveHintLastSentAt = new Map<string, number>();
 
 export function resetProactivePermissionHintStateForTest(): void {
@@ -139,6 +142,95 @@ function isUnhandledStopReasonText(value: string): boolean {
     return false;
   }
   return /^Unhandled stop reason:\s*[A-Za-z0-9_-]+/i.test(normalized);
+}
+
+async function addThinkingEmotionReply(
+  config: DingTalkConfig,
+  data: {
+    msgId: string;
+    conversationId: string;
+    robotCode?: string;
+  },
+  log?: { debug?: (msg: string) => void; warn?: (msg: string) => void },
+): Promise<boolean> {
+  const robotCode = (data.robotCode || config.robotCode || config.clientId || "").trim();
+  if (!robotCode || !data.msgId || !data.conversationId) {
+    return false;
+  }
+
+  try {
+    const token = await getAccessToken(config, log as any);
+    await axios.post(
+      "https://api.dingtalk.com/v1.0/robot/emotion/reply",
+      {
+        robotCode,
+        openMsgId: data.msgId,
+        openConversationId: data.conversationId,
+        emotionType: 2,
+        emotionName: THINKING_EMOTION_NAME,
+        textEmotion: {
+          emotionId: THINKING_EMOTION_ID,
+          emotionName: THINKING_EMOTION_NAME,
+          text: THINKING_EMOTION_NAME,
+          backgroundId: THINKING_EMOTION_BACKGROUND_ID,
+        },
+      },
+      {
+        headers: {
+          "x-acs-dingtalk-access-token": token,
+          "Content-Type": "application/json",
+        },
+        ...getProxyBypassOption(config),
+      },
+    );
+    return true;
+  } catch (err: any) {
+    log?.warn?.(`[DingTalk] Thinking reaction attach failed: ${err.message}`);
+    if (err?.response?.data !== undefined) {
+      log?.warn?.(formatDingTalkErrorPayloadLog("inbound.thinkingReactionAttach", err.response.data));
+    }
+    return false;
+  }
+}
+
+async function recallThinkingEmotionReply(
+  config: DingTalkConfig,
+  data: {
+    msgId: string;
+    conversationId: string;
+    robotCode?: string;
+  },
+  log?: { debug?: (msg: string) => void; warn?: (msg: string) => void },
+): Promise<void> {
+  const robotCode = (data.robotCode || config.robotCode || config.clientId || "").trim();
+  if (!robotCode || !data.msgId || !data.conversationId) {
+    return;
+  }
+
+  try {
+    const token = await getAccessToken(config, log as any);
+    await axios.post(
+      "https://api.dingtalk.com/v1.0/robot/emotion/recall",
+      {
+        robotCode,
+        openMsgId: data.msgId,
+        openConversationId: data.conversationId,
+        emotionType: 2,
+      },
+      {
+        headers: {
+          "x-acs-dingtalk-access-token": token,
+          "Content-Type": "application/json",
+        },
+        ...getProxyBypassOption(config),
+      },
+    );
+  } catch (err: any) {
+    log?.debug?.(`[DingTalk] Thinking reaction recall failed: ${err.message}`);
+    if (err?.response?.data !== undefined) {
+      log?.debug?.(formatDingTalkErrorPayloadLog("inbound.thinkingReactionRecall", err.response.data));
+    }
+  }
 }
 
 function stripQuotedPrefixForJournal(value: string): string {
@@ -1245,7 +1337,20 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // from receiving concurrent dispatch calls on the same session key, which
   // causes empty replies for all but the first caller.
   const releaseSessionLock = await acquireSessionLock(route.sessionKey);
+  let thinkingReactionAttached = false;
   try {
+    if (!useCardMode && dingtalkConfig.showThinkingReaction === true) {
+      thinkingReactionAttached = await addThinkingEmotionReply(
+        dingtalkConfig,
+        {
+          msgId: data.msgId,
+          conversationId: groupId,
+          robotCode: data.robotCode,
+        },
+        log,
+      );
+    }
+
     // 4) Optional "thinking..." feedback (markdown mode only).
     if (dingtalkConfig.showThinking !== false) {
       let thinkingText = (dingtalkConfig.thinkingMessage || "").trim() || DEFAULT_THINKING_MESSAGE;
@@ -1444,6 +1549,17 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       }
     }
   } finally {
+    if (thinkingReactionAttached) {
+      await recallThinkingEmotionReply(
+        dingtalkConfig,
+        {
+          msgId: data.msgId,
+          conversationId: groupId,
+          robotCode: data.robotCode,
+        },
+        log,
+      );
+    }
     releaseSessionLock();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,8 @@ export interface DingTalkConfig extends OpenClawConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
+  /** Show native DingTalk thinking reaction on the inbound message (markdown mode only) */
+  showThinkingReaction?: boolean;
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;
@@ -106,6 +108,8 @@ export interface DingTalkChannelConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
+  /** Show native DingTalk thinking reaction on the inbound message (markdown mode only) */
+  showThinkingReaction?: boolean;
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;
@@ -262,6 +266,7 @@ export interface DingTalkInboundMessage {
   senderStaffId?: string;
   senderNick?: string;
   chatbotUserId: string;
+  robotCode?: string;
   sessionWebhook: string;
 }
 

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -73,9 +73,10 @@ describe('DingTalkConfigSchema', () => {
         const parsed = DingTalkConfigSchema.parse({
             clientId: 'id',
             clientSecret: 'secret',
-        }) as { keepAlive?: boolean };
+        }) as { keepAlive?: boolean; showThinkingReaction?: boolean };
 
         expect(parsed.keepAlive).toBeUndefined();
+        expect(parsed.showThinkingReaction).toBe(false);
     });
 
     it('keeps account-level keepAlive undefined when omitted', () => {

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import fs from 'node:fs';
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAccessToken } from '../../src/auth';
 
 const shared = vi.hoisted(() => ({
     sendBySessionMock: vi.fn(),
@@ -84,6 +85,7 @@ import { recordProactiveRiskObservation } from '../../src/proactive-risk-registr
 
 const mockedAxiosPost = vi.mocked(axios.post);
 const mockedAxiosGet = vi.mocked(axios.get);
+const mockedGetAccessToken = vi.mocked(getAccessToken);
 
 function buildRuntime() {
     return {
@@ -120,6 +122,8 @@ describe('inbound-handler', () => {
         fs.rmSync(path.join(path.dirname('/tmp/store.json'), 'dingtalk-state'), { recursive: true, force: true });
         mockedAxiosPost.mockReset();
         mockedAxiosGet.mockReset();
+        mockedGetAccessToken.mockReset();
+        mockedGetAccessToken.mockResolvedValue('token_abc');
         shared.sendBySessionMock.mockReset();
         shared.sendMessageMock.mockReset();
         shared.sendMessageMock.mockImplementation(async (_config: any, _to: any, text: any, options: any) => {
@@ -1527,6 +1531,125 @@ describe('inbound-handler', () => {
         expect(shared.sendMessageMock).toHaveBeenCalled();
     });
 
+    it('handleDingTalkMessage adds and recalls native thinking reaction in markdown mode', async () => {
+        mockedAxiosPost.mockResolvedValue({ data: { success: true } } as any);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                clientId: 'ding_client',
+                clientSecret: 'secret',
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                showThinkingReaction: true,
+            } as any,
+            data: {
+                msgId: 'm5_reaction',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(mockedAxiosPost).toHaveBeenNthCalledWith(
+            1,
+            'https://api.dingtalk.com/v1.0/robot/emotion/reply',
+            expect.objectContaining({
+                robotCode: 'ding_client',
+                openMsgId: 'm5_reaction',
+                openConversationId: 'cid_ok',
+                emotionName: '🤔思考中',
+            }),
+            expect.objectContaining({
+                headers: expect.objectContaining({
+                    'x-acs-dingtalk-access-token': 'token_abc',
+                }),
+            }),
+        );
+        expect(mockedAxiosPost).toHaveBeenNthCalledWith(
+            2,
+            'https://api.dingtalk.com/v1.0/robot/emotion/recall',
+            expect.objectContaining({
+                robotCode: 'ding_client',
+                openMsgId: 'm5_reaction',
+                openConversationId: 'cid_ok',
+            }),
+            expect.any(Object),
+        );
+    });
+
+    it('handleDingTalkMessage does not add thinking reaction in card mode', async () => {
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                clientId: 'ding_client',
+                clientSecret: 'secret',
+                dmPolicy: 'open',
+                messageType: 'card',
+                showThinking: false,
+                showThinkingReaction: true,
+            } as any,
+            data: {
+                msgId: 'm5_card_reaction',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any);
+
+        expect(mockedAxiosPost).not.toHaveBeenCalled();
+    });
+
+    it('handleDingTalkMessage continues when thinking reaction attach fails', async () => {
+        mockedAxiosPost.mockRejectedValueOnce(new Error('reaction failed'));
+
+        await expect(handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: {
+                clientId: 'ding_client',
+                clientSecret: 'secret',
+                dmPolicy: 'open',
+                messageType: 'markdown',
+                showThinking: false,
+                showThinkingReaction: true,
+            } as any,
+            data: {
+                msgId: 'm5_reaction_fail',
+                msgtype: 'text',
+                text: { content: 'hello' },
+                conversationType: '1',
+                conversationId: 'cid_ok',
+                senderId: 'user_1',
+                chatbotUserId: 'bot_1',
+                sessionWebhook: 'https://session.webhook',
+                createAt: Date.now(),
+            },
+        } as any)).resolves.toBeUndefined();
+
+        expect(shared.sendMessageMock).toHaveBeenCalled();
+        expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    });
+
     it('handleDingTalkMessage restores quoted card by originalProcessQueryKey', async () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
@@ -2756,4 +2879,5 @@ describe('inbound-handler', () => {
             expect.anything(),
         );
     });
+
 });


### PR DESCRIPTION
## 变更说明

这次给钉钉 channel 增加了一条独立的原生思考反馈能力：在 `markdown` 模式下，可选地给用户原消息贴上钉钉原生的 `🤔思考中` 表情，并在处理结束后自动撤回。

本 PR 做了这些事：
- 新增配置项 `showThinkingReaction`，默认 `false`
- 在 `markdown` 模式下，处理开始前调用 `robot/emotion/reply`
- 在处理结束的 `finally` 中调用 `robot/emotion/recall`
- 贴表情或撤表情失败时只记日志，不阻断原有回复链路
- 保持 `card` 模式不变，继续使用现有卡片流式 thinking 展示
- 补充了 inbound/config 对应单测和 README 中文说明

## 设计取舍

- 第一版只对 `markdown` 模式启用，避免和现有 AI Card 流式展示重复
- 不改变现有 `showThinking` / `thinkingMessage` 语义；两者可以并存
- 失败降级为日志，不影响主流程

## 参考来源

设计/实现参考自官方仓库（MIT）：
- https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector

具体借鉴的是其通过钉钉 `emotion/reply` 与 `emotion/recall` API 在处理开始/结束时对原消息添加与撤回“思考中”表情的思路；本 PR 按 `openclaw-channel-dingtalk` 现有结构做了适配实现。

## 验证

已本地通过：
- `pnpm test tests/unit/inbound-handler.test.ts tests/unit/config-schema.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`