### PR TITLE
Revert "feat(dingtalk): 增加异步回执模式"

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,6 @@ openclaw configure --section channels
       "journalTTLDays": 7,
       "showThinking": true, // 仅 markdown 模式生效
       "thinkingMessage": "🤔 思考中，请稍候...", // 仅 markdown 模式生效；设为 "emoji" 可启用随机颜文字彩蛋
-      "asyncMode": false, // 开启后先回执“已收到”，再后台处理
-      "asyncAckText": "已收到，正在处理中，稍后回复。", // asyncMode 生效时的即时回执文案
       "debug": false,
       "messageType": "markdown", // 或 "card"
       // "mediaMaxMb": 20,  // 可选：接收文件大小上限（MB），默认 5 MB
@@ -416,8 +414,6 @@ openclaw gateway restart
 | `journalTTLDays`        | number   | `7`          | `originalMsgId` 文本回溯日志的保留天数      |
 | `showThinking`          | boolean  | `true`       | 是否发送“思考中”提示消息（仅 markdown 模式生效） |
 | `thinkingMessage`       | string   | `"🤔 思考中，请稍候..."` | 自定义“思考中”提示文案（showThinking 开启时生效，仅 markdown 模式）；设为 `"emoji"` 可按用户语气返回随机颜文字 |
-| `asyncMode`             | boolean  | `false`      | 是否在收到消息后立即回执，并在后台继续处理 |
-| `asyncAckText`          | string   | `"已收到，正在处理中，稍后回复。"` | `asyncMode` 开启时的即时回执文案 |
 | `messageType`           | string   | `"markdown"` | 消息类型：markdown/card                     |
 | `cardTemplateId`        | string   |              | AI 互动卡片模板 ID（仅当 messageType=card） |
 | `cardTemplateKey`       | string   | `"content"`  | 卡片模板内容字段键（仅当 messageType=card） |
@@ -448,15 +444,10 @@ openclaw gateway restart
 ```
 
 > 说明：这是一个轻量彩蛋功能，仅影响 markdown 模式下的“思考中”提示；`messageType="card"` 时不会发送该独立提示消息。
-
-### `asyncMode` 异步回执
-
-当 `asyncMode=true` 时，插件会先通过 `sessionWebhook` 发送一条即时回执，然后在后台继续完成整条消息处理链路，适合处理耗时较长的推理请求。
-
-- 即时回执文案由 `asyncAckText` 控制
-- 当前仅对带 `sessionWebhook` 的普通文本消息生效
-- 异步后台回复会强制使用 `markdown` 模式；即使配置了 `messageType: "card"`，也不会创建或流式更新 AI 卡片
-- 后台处理失败时，会额外回一条失败提示，避免静默丢回复
+| `bypassProxyForSend`    | boolean  | `false`      | 仅对 send/card/upload 出站请求绕过系统 HTTP(S) 代理 |
+| `learningEnabled` | boolean | `false`    | 启用本地学习闭环（事件、反思、会话笔记、全局规则） |
+| `learningAutoApply` | boolean | `false` | 是否将反思自动注入会话/全局规则；默认只采集不生效 |
+| `learningNoteTtlMs` | number | `21600000` | 会话级学习笔记有效期（毫秒，默认 6 小时） |
 
 ### 连接鲁棒性配置
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -25,7 +25,6 @@ import { DingTalkConfigSchema } from "./config-schema.js";
 import { ConnectionManager } from "./connection-manager";
 import { isMessageProcessed, markMessageProcessed } from "./dedup";
 import { handleDingTalkMessage } from "./inbound-handler";
-import { parseLearnCommand } from "./learning-command-service";
 import { getLogger } from "./logger-context";
 import { prepareMediaInput, resolveOutboundMediaType } from "./media-utils";
 import { dingtalkOnboardingAdapter } from "./onboarding.js";
@@ -44,7 +43,6 @@ import {
   uploadMedia,
 } from "./send-service";
 import type {
-  DingTalkConfig,
   DingTalkInboundMessage,
   GatewayStartContext,
   GatewayStopResult,
@@ -144,8 +142,6 @@ const inboundCountersByAccount = new Map<
   }
 >();
 const INBOUND_COUNTER_LOG_EVERY = 10;
-const DEFAULT_ASYNC_ACK_TEXT = "已收到，正在处理中，稍后回复。";
-const DEFAULT_ASYNC_FAILURE_TEXT = "⚠️ 处理失败，请稍后重试。";
 
 function getInboundCounters(accountId: string) {
   const existing = inboundCountersByAccount.get(accountId);
@@ -170,48 +166,6 @@ function logInboundCounters(log: any, accountId: string, reason: string): void {
   log?.info?.(
     `[${accountId}] Inbound counters (${reason}): received=${stats.received}, acked=${stats.acked}, processed=${stats.processed}, dedupSkipped=${stats.dedupSkipped}, inflightSkipped=${stats.inflightSkipped}, failed=${stats.failed}, noMessageId=${stats.noMessageId}`,
   );
-}
-
-function shouldHandleAsync(data: DingTalkInboundMessage, config: DingTalkConfig): boolean {
-  if (!config.asyncMode || !data.sessionWebhook) {
-    return false;
-  }
-  if (data.msgtype !== "text") {
-    return false;
-  }
-  const text = data.text?.content?.trim();
-  if (!text) {
-    return false;
-  }
-  if (text.startsWith("/")) {
-    return false;
-  }
-  // Reuse control-command parsing so non-slash owner helpers like "我是谁" or
-  // "这里是谁" keep their existing synchronous semantics instead of being
-  // acknowledged as async free-form chat.
-  if (parseLearnCommand(text).scope !== "unknown") {
-    return false;
-  }
-  return true;
-}
-
-async function sendAsyncFailureNotice(
-  config: DingTalkConfig,
-  data: DingTalkInboundMessage,
-  log: any,
-  accountId: string,
-  dedupKey: string,
-): Promise<void> {
-  if (!data.sessionWebhook) {
-    return;
-  }
-  try {
-    await sendBySession(config, data.sessionWebhook, DEFAULT_ASYNC_FAILURE_TEXT, { log });
-  } catch (notifyError: any) {
-    log?.warn?.(
-      `[${accountId}] Failed to send async failure notice for ${dedupKey}: ${notifyError.message}`,
-    );
-  }
 }
 
 function readBooleanLikeParam(params: Record<string, unknown>, key: string): boolean | undefined {
@@ -677,7 +631,6 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
           try {
             const data = JSON.parse(res.data) as DingTalkInboundMessage;
 
-            // Message deduplication key is bot-scoped to avoid cross-account conflicts.
             const robotKey = config.robotCode || config.clientId || account.accountId;
             const msgId = data.msgId || messageId;
             const dedupKey = msgId ? `${robotKey}:${msgId}` : undefined;
@@ -711,7 +664,6 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
 
             const inflightSince = processingDedupKeys.get(dedupKey);
             if (inflightSince !== undefined) {
-              const asyncMode = shouldHandleAsync(data, config);
               if (Date.now() - inflightSince > INFLIGHT_TTL_MS) {
                 ctx.log?.warn?.(
                   `[${account.accountId}] Releasing stale in-flight lock for ${dedupKey} (held ${Date.now() - inflightSince}ms > TTL ${INFLIGHT_TTL_MS}ms)`,
@@ -722,74 +674,13 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
                   `[${account.accountId}] Skipping in-flight duplicate message: ${dedupKey}`,
                 );
                 stats.inflightSkipped += 1;
-                if (asyncMode) {
-                  // Async mode already acknowledged the original callback, so duplicates should
-                  // also be acknowledged to avoid pointless server retries during background work.
-                  acknowledge();
-                }
                 logInboundCounters(ctx.log, account.accountId, "inflight-skipped");
                 return;
               }
             }
 
             processingDedupKeys.set(dedupKey, Date.now());
-            let releaseInOuterFinally = true;
             try {
-              const asyncMode = shouldHandleAsync(data, config);
-              if (asyncMode) {
-                releaseInOuterFinally = false;
-                const ackText = (config.asyncAckText || "").trim() || DEFAULT_ASYNC_ACK_TEXT;
-                try {
-                  await sendBySession(config, data.sessionWebhook, ackText, { log: ctx.log });
-                } catch (ackTextError: any) {
-                  ctx.log?.warn?.(
-                    `[${account.accountId}] Failed to send async ack text for ${dedupKey}: ${ackTextError.message}`,
-                  );
-                }
-
-                acknowledge();
-                void handleDingTalkMessage({
-                  cfg,
-                  accountId: account.accountId,
-                  data,
-                  sessionWebhook: data.sessionWebhook,
-                  log: ctx.log,
-                  dingtalkConfig: {
-                    ...config,
-                    // Async ack should stay on a single reply channel: immediate session ack
-                    // plus background markdown reply. Card streaming in the background would
-                    // conflict with the already-sent async acknowledgement.
-                    messageType: "markdown",
-                    showThinking: false,
-                  },
-                })
-                  .then(() => {
-                    stats.processed += 1;
-                    markMessageProcessed(dedupKey);
-                    if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
-                      logInboundCounters(ctx.log, account.accountId, "periodic");
-                    }
-                  })
-                  .catch((error: any) => {
-                    stats.failed += 1;
-                    logInboundCounters(ctx.log, account.accountId, "failed");
-                    ctx.log?.error?.(
-                      `[${account.accountId}] Error processing async message: ${error.message}`,
-                    );
-                    return sendAsyncFailureNotice(
-                      config,
-                      data,
-                      ctx.log,
-                      account.accountId,
-                      dedupKey,
-                    );
-                  })
-                  .finally(() => {
-                    processingDedupKeys.delete(dedupKey);
-                  });
-                return;
-              }
-
               await handleDingTalkMessage({
                 cfg,
                 accountId: account.accountId,
@@ -805,9 +696,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
                 logInboundCounters(ctx.log, account.accountId, "periodic");
               }
             } finally {
-              if (releaseInOuterFinally) {
-                processingDedupKeys.delete(dedupKey);
-              }
+              processingDedupKeys.delete(dedupKey);
             }
           } catch (error: any) {
             stats.failed += 1;

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -42,12 +42,6 @@ const DingTalkAccountConfigShape = {
   /** Custom thinking message content when showThinking is enabled (markdown mode only) */
   thinkingMessage: z.string().optional().default("🤔 思考中，请稍候..."),
 
-  /** Acknowledge user messages immediately and continue processing in the background */
-  asyncMode: z.boolean().optional().default(false),
-
-  /** Immediate session ack text used when asyncMode is enabled */
-  asyncAckText: z.string().optional().default("已收到，正在处理中，稍后回复。"),
-
   /** Enable debug logging */
   debug: z.boolean().optional().default(false),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,8 +45,6 @@ export interface DingTalkConfig extends OpenClawConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
-  asyncMode?: boolean;
-  asyncAckText?: string;
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;
@@ -108,8 +106,6 @@ export interface DingTalkChannelConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
-  asyncMode?: boolean;
-  asyncAckText?: string;
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;

--- a/tests/integration/gateway-inbound-flow.test.ts
+++ b/tests/integration/gateway-inbound-flow.test.ts
@@ -11,7 +11,6 @@ const shared = vi.hoisted(() => ({
     markMessageProcessedMock: vi.fn(),
     handleDingTalkMessageMock: vi.fn(),
     sendProactiveTextMock: vi.fn(),
-    sendBySessionMock: vi.fn(),
     connectionConfig: undefined as any,
 }));
 
@@ -67,7 +66,7 @@ vi.mock('../../src/send-service', () => ({
     sendMessage: vi.fn(),
     sendProactiveMedia: vi.fn(),
     sendProactiveTextOrMarkdown: shared.sendProactiveTextMock,
-    sendBySession: shared.sendBySessionMock,
+    sendBySession: vi.fn(),
     uploadMedia: vi.fn(),
 }));
 
@@ -114,7 +113,6 @@ describe('gateway inbound callback pipeline', () => {
         shared.markMessageProcessedMock.mockReset();
         shared.handleDingTalkMessageMock.mockReset();
         shared.sendProactiveTextMock.mockReset();
-        shared.sendBySessionMock.mockReset();
         shared.connectionConfig = undefined;
 
         shared.listeners = {};
@@ -122,7 +120,6 @@ describe('gateway inbound callback pipeline', () => {
         shared.waitForStopMock.mockResolvedValue(undefined);
         shared.isConnectedMock.mockReturnValue(false);
         shared.sendProactiveTextMock.mockResolvedValue({});
-        shared.sendBySessionMock.mockResolvedValue({});
     });
 
     it('acknowledges callback after successful dispatch for non-duplicate message', async () => {
@@ -156,199 +153,6 @@ describe('gateway inbound callback pipeline', () => {
                 accountId: 'main',
                 sessionWebhook: 'https://webhook',
             })
-        );
-    });
-
-    it('acknowledges early and continues async processing when asyncMode is enabled', async () => {
-        shared.isMessageProcessedMock.mockReturnValue(false);
-        let resolveAsync: (() => void) | undefined;
-        shared.handleDingTalkMessageMock.mockImplementationOnce(
-            () =>
-                new Promise<void>((resolve) => {
-                    resolveAsync = resolve;
-                })
-        );
-        const ctx = createStartContext();
-        ctx.account.config.asyncMode = true;
-        ctx.account.config.asyncAckText = '收到，后台处理中';
-
-        await startGatewayAccount(ctx as any);
-
-        const promise = shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_1' },
-            data: JSON.stringify({
-                msgId: 'msg_async_1',
-                msgtype: 'text',
-                text: { content: '帮我异步处理一下' },
-                conversationType: '1',
-                conversationId: 'cidA1B2C3',
-                senderId: 'user_1',
-                chatbotUserId: 'bot_1',
-                sessionWebhook: 'https://webhook',
-            }),
-        });
-
-        await promise;
-
-        expect(shared.sendBySessionMock).toHaveBeenCalledWith(
-            expect.objectContaining({ asyncMode: true }),
-            'https://webhook',
-            '收到，后台处理中',
-            expect.objectContaining({ log: ctx.log }),
-        );
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_async_1', { success: true });
-        expect(shared.markMessageProcessedMock).not.toHaveBeenCalled();
-        expect(shared.handleDingTalkMessageMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                sessionWebhook: 'https://webhook',
-                dingtalkConfig: expect.objectContaining({
-                    asyncMode: true,
-                    messageType: 'markdown',
-                    showThinking: false,
-                }),
-            })
-        );
-
-        resolveAsync?.();
-        await Promise.resolve();
-
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_async_1');
-    });
-
-    it('forces markdown background replies when asyncMode is enabled even if card mode is configured', async () => {
-        shared.isMessageProcessedMock.mockReturnValue(false);
-        shared.handleDingTalkMessageMock.mockResolvedValueOnce(undefined);
-        const ctx = createStartContext();
-        ctx.account.config.asyncMode = true;
-        ctx.account.config.messageType = 'card';
-
-        await startGatewayAccount(ctx as any);
-
-        await shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_card' },
-            data: JSON.stringify({
-                msgId: 'msg_async_card',
-                msgtype: 'text',
-                text: { content: '帮我异步处理卡片模式' },
-                conversationType: '1',
-                conversationId: 'cidA1B2C3',
-                senderId: 'user_1',
-                chatbotUserId: 'bot_1',
-                sessionWebhook: 'https://webhook',
-            }),
-        });
-
-        await Promise.resolve();
-
-        expect(shared.sendBySessionMock).toHaveBeenNthCalledWith(
-            1,
-            expect.objectContaining({ asyncMode: true, messageType: 'card' }),
-            'https://webhook',
-            '已收到，正在处理中，稍后回复。',
-            expect.objectContaining({ log: ctx.log }),
-        );
-        expect(shared.handleDingTalkMessageMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                dingtalkConfig: expect.objectContaining({
-                    asyncMode: true,
-                    messageType: 'markdown',
-                    showThinking: false,
-                }),
-            })
-        );
-    });
-
-    it('keeps non-slash control aliases on the synchronous path even when asyncMode is enabled', async () => {
-        shared.isMessageProcessedMock.mockReturnValue(false);
-        shared.handleDingTalkMessageMock.mockResolvedValueOnce(undefined);
-        const ctx = createStartContext();
-        ctx.account.config.asyncMode = true;
-        ctx.account.config.asyncAckText = '收到，后台处理中';
-
-        await startGatewayAccount(ctx as any);
-
-        await shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_control_alias' },
-            data: JSON.stringify({
-                msgId: 'msg_async_control_alias',
-                msgtype: 'text',
-                text: { content: '我是谁' },
-                conversationType: '1',
-                conversationId: 'cidA1B2C3',
-                senderId: 'user_1',
-                chatbotUserId: 'bot_1',
-                sessionWebhook: 'https://webhook',
-            }),
-        });
-
-        expect(shared.sendBySessionMock).not.toHaveBeenCalledWith(
-            expect.anything(),
-            'https://webhook',
-            '收到，后台处理中',
-            expect.anything(),
-        );
-        expect(shared.handleDingTalkMessageMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                dingtalkConfig: expect.objectContaining({
-                    asyncMode: true,
-                }),
-            }),
-        );
-        expect(shared.handleDingTalkMessageMock).not.toHaveBeenCalledWith(
-            expect.objectContaining({
-                dingtalkConfig: expect.objectContaining({
-                    messageType: 'markdown',
-                    showThinking: false,
-                }),
-            }),
-        );
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_async_control_alias');
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_async_control_alias', { success: true });
-    });
-
-    it('sends failure notice when async background processing fails after early ack', async () => {
-        shared.isMessageProcessedMock.mockReturnValue(false);
-        shared.handleDingTalkMessageMock.mockRejectedValueOnce(new Error('async failure'));
-        const ctx = createStartContext();
-        ctx.account.config.asyncMode = true;
-
-        await startGatewayAccount(ctx as any);
-
-        await shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_fail' },
-            data: JSON.stringify({
-                msgId: 'msg_async_fail',
-                msgtype: 'text',
-                text: { content: '请异步处理失败案例' },
-                conversationType: '1',
-                conversationId: 'cidA1B2C3',
-                senderId: 'user_1',
-                chatbotUserId: 'bot_1',
-                sessionWebhook: 'https://webhook',
-            }),
-        });
-
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_async_fail', { success: true });
-        expect(shared.markMessageProcessedMock).not.toHaveBeenCalled();
-        expect(shared.sendBySessionMock).toHaveBeenNthCalledWith(
-            1,
-            expect.objectContaining({ asyncMode: true }),
-            'https://webhook',
-            '已收到，正在处理中，稍后回复。',
-            expect.objectContaining({ log: ctx.log }),
-        );
-        expect(shared.sendBySessionMock).toHaveBeenNthCalledWith(
-            2,
-            expect.objectContaining({ asyncMode: true }),
-            'https://webhook',
-            '⚠️ 处理失败，请稍后重试。',
-            expect.objectContaining({ log: ctx.log }),
-        );
-        expect(ctx.log.error).toHaveBeenCalledWith(
-            expect.stringContaining('Error processing async message: async failure')
         );
     });
 
@@ -477,58 +281,6 @@ describe('gateway inbound callback pipeline', () => {
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(1);
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_inflight_1', { success: true });
         expect(shared.socketCallBackResponseMock).not.toHaveBeenCalledWith('stream_msg_inflight_2', { success: true });
-    });
-
-    it('keeps async in-flight lock after listener returns so duplicates are still blocked', async () => {
-        shared.isMessageProcessedMock.mockReturnValue(false);
-        let resolveFirst: (() => void) | undefined;
-        shared.handleDingTalkMessageMock.mockImplementationOnce(
-            () =>
-                new Promise<void>((resolve) => {
-                    resolveFirst = resolve;
-                })
-        );
-        const ctx = createStartContext();
-        ctx.account.config.asyncMode = true;
-
-        await startGatewayAccount(ctx as any);
-
-        const payloadData = JSON.stringify({
-            msgId: 'msg_async_inflight',
-            msgtype: 'text',
-            text: { content: 'async in flight' },
-            conversationType: '1',
-            conversationId: 'cidA1B2C3',
-            senderId: 'user_1',
-            chatbotUserId: 'bot_1',
-            sessionWebhook: 'https://webhook',
-        });
-
-        const first = shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_inflight_1' },
-            data: payloadData,
-        });
-        await first;
-
-        expect(shared.handleDingTalkMessageMock).toHaveBeenCalledTimes(1);
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_async_inflight_1', { success: true });
-
-        const second = shared.listeners.TOPIC_ROBOT?.({
-            headers: { messageId: 'stream_msg_async_inflight_2' },
-            data: payloadData,
-        });
-
-        await second;
-
-        expect(shared.handleDingTalkMessageMock).toHaveBeenCalledTimes(1);
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_async_inflight_2', { success: true });
-        expect(shared.markMessageProcessedMock).not.toHaveBeenCalled();
-
-        resolveFirst?.();
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_async_inflight');
     });
 
     it('releases stale in-flight lock after ttl and allows reprocessing', async () => {

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -142,16 +142,6 @@ describe('DingTalkConfigSchema', () => {
         expect(parsed.feedbackLearningAutoApply).toBe(true);
         expect(parsed.feedbackLearningNoteTtlMs).toBe(120000);
     });
-    it('accepts asyncMode config and default asyncAckText', () => {
-        const parsed = DingTalkConfigSchema.parse({
-            clientId: 'id',
-            clientSecret: 'secret',
-            asyncMode: true,
-        }) as { asyncMode?: boolean; asyncAckText?: string };
-
-        expect(parsed.asyncMode).toBe(true);
-        expect(parsed.asyncAckText).toBe('已收到，正在处理中，稍后回复。');
-    });
 
     it('exports control-ui-compatible JSON schema nodes', () => {
         const jsonSchema = DingTalkConfigSchema.toJSONSchema({
@@ -166,4 +156,5 @@ describe('DingTalkConfigSchema', () => {
         expect(jsonSchema.properties?.accounts?.type).toBe('object');
         expect(jsonSchema.properties?.accounts?.additionalProperties?.type).toBe('object');
     });
+
 });


### PR DESCRIPTION
Reverts soimy/openclaw-channel-dingtalk#295

**回撤总结**
本次回撤的对象是 [PR #295](https://github.com/soimy/openclaw-channel-dingtalk/pull/295) 引入的 `asyncMode/asyncAckText` 异步回执路径。

回撤原因主要有三点：

1. `PR #295` 解决的问题和现有 `showThinking` 机制不相同，且当前没有充分证据表明必须引入新的异步回调分支。
现有 `showThinking` 已能在处理开始时给用户即时反馈，逻辑位于 [src/inbound-handler.ts#L1241](/Users/sym/Repo/openclaw-channel-dingtalk/src/inbound-handler.ts#L1241)。它虽然不改变 callback ack 时机，但已经覆盖“用户感知无响应”的主要诉求。

2. `asyncMode` 会引入一条新的 gateway 处理分叉，显著增加状态复杂度。
PR 在 gateway 层提前发送 ack，再后台执行 `handleDingTalkMessage()`，并额外维护 in-flight 锁、重复回调 ack、失败补发提示等语义，逻辑集中在 [src/channel.ts#L712](/Users/sym/Repo/openclaw-channel-dingtalk/src/channel.ts#L712) 到 [src/channel.ts#L790](/Users/sym/Repo/openclaw-channel-dingtalk/src/channel.ts#L790)。这属于处理时序层面的改造，不只是提示文案增强。

3. 异步模式会主动降级现有回复体验。
在异步路径下，PR 强制后台回复改为 `markdown` 且关闭 `showThinking`，避免“已收到”后再次出现“思考中”，对应代码见 [src/channel.ts#L757](/Users/sym/Repo/openclaw-channel-dingtalk/src/channel.ts#L757)。这意味着：
- 无法继续使用 card 流式更新
- reasoning/tool/card 的现有体验被绕开
- 行为在同步/异步两条路径之间变得不一致

**结论**
当前实现中，`showThinking` 仍然是更轻量、行为更一致的默认方案；而 `PR #295` 的异步回执模式只有在“已确认存在 callback 长耗时、重试或重复投递问题”时才有明确必要性。在缺少这类线上证据前，引入额外分支和体验降级的收益不足，因此选择回撤。
