### PR TITLE
refactor: deprecate legacy dingtalk debug config

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -43,6 +43,7 @@ import {
   uploadMedia,
 } from "./send-service";
 import type {
+  DingTalkConfig,
   DingTalkInboundMessage,
   GatewayStartContext,
   GatewayStopResult,
@@ -126,6 +127,54 @@ function instrumentConnectionStages(client: DWClient): void {
   };
 }
 
+type ExplicitBooleanConfig = {
+  value: boolean;
+  path: string;
+};
+
+type ExplicitDebugConfig = {
+  dwClientDebug?: ExplicitBooleanConfig;
+  debug?: ExplicitBooleanConfig;
+};
+
+function readExplicitBooleanConfig(
+  source: Record<string, unknown> | undefined,
+  key: "dwClientDebug" | "debug",
+  path: string,
+): ExplicitBooleanConfig | undefined {
+  if (!source || !Object.prototype.hasOwnProperty.call(source, key)) {
+    return undefined;
+  }
+  const value = source[key];
+  if (typeof value !== "boolean") {
+    return undefined;
+  }
+  return { value, path };
+}
+
+function resolveExplicitDebugConfig(
+  cfg: OpenClawConfig,
+  accountId: string,
+): ExplicitDebugConfig {
+  const dingtalk = cfg?.channels?.dingtalk as DingTalkConfig | undefined;
+  const topLevel = dingtalk as Record<string, unknown> | undefined;
+  const accountLevel = accountId !== "default"
+    ? (dingtalk?.accounts?.[accountId] as Record<string, unknown> | undefined)
+    : undefined;
+
+  return {
+    dwClientDebug:
+      readExplicitBooleanConfig(
+        accountLevel,
+        "dwClientDebug",
+        `channels.dingtalk.accounts.${accountId}.dwClientDebug`,
+      ) ??
+      readExplicitBooleanConfig(topLevel, "dwClientDebug", "channels.dingtalk.dwClientDebug"),
+    debug:
+      readExplicitBooleanConfig(accountLevel, "debug", `channels.dingtalk.accounts.${accountId}.debug`) ??
+      readExplicitBooleanConfig(topLevel, "debug", "channels.dingtalk.debug"),
+  };
+}
 const INFLIGHT_TTL_MS = 5 * 60 * 1000; // 5 min safety net for hung handlers
 const processingDedupKeys = new Map<string, number>(); // key → timestamp when acquired
 export const CHANNEL_INFLIGHT_NAMESPACE_POLICY = "memory-only" as const;
@@ -592,6 +641,20 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       }
 
       const useConnectionManager = config.useConnectionManager ?? true;
+      const explicitDebugConfig = resolveExplicitDebugConfig(cfg, account.accountId);
+      const dwClientDebug = config.dwClientDebug ?? config.debug ?? false;
+
+      if (explicitDebugConfig.debug) {
+        if (explicitDebugConfig.dwClientDebug) {
+          ctx.log?.warn?.(
+            `[${account.accountId}] Config key "${explicitDebugConfig.debug.path}" is deprecated and ignored because "${explicitDebugConfig.dwClientDebug.path}" is also set. Use "dwClientDebug" instead.`,
+          );
+        } else {
+          ctx.log?.warn?.(
+            `[${account.accountId}] Config key "${explicitDebugConfig.debug.path}" is deprecated; use "dwClientDebug" instead. This flag controls DWClient debug logging only, not plugin-wide log verbosity.`,
+          );
+        }
+      }
 
       // Factory that creates a fresh DWClient with the TOPIC_ROBOT callback
       // already registered. Each client captures its own reference for
@@ -603,7 +666,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
         const c = new DWClient({
           clientId: config.clientId,
           clientSecret: config.clientSecret,
-          debug: config.debug || false,
+          debug: dwClientDebug,
           keepAlive: config.keepAlive ?? !useConnectionManager,
         });
 

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -42,7 +42,10 @@ const DingTalkAccountConfigShape = {
   /** Custom thinking message content when showThinking is enabled (markdown mode only) */
   thinkingMessage: z.string().optional().default("🤔 思考中，请稍候..."),
 
-  /** Enable debug logging */
+  /** Whether to enable DWClient debug logging */
+  dwClientDebug: z.boolean().optional(),
+
+  /** @deprecated Use dwClientDebug. Controls DWClient debug logging only. */
   debug: z.boolean().optional().default(false),
 
   /** Message type for replies: markdown or card */

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,9 @@ export interface DingTalkConfig extends OpenClawConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
+  /** Whether to enable DWClient debug logging */
+  dwClientDebug?: boolean;
+  /** @deprecated Use dwClientDebug. Controls DWClient debug logging only. */
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;
@@ -106,6 +109,9 @@ export interface DingTalkChannelConfig {
   journalTTLDays?: number;
   showThinking?: boolean;
   thinkingMessage?: string;
+  /** Whether to enable DWClient debug logging */
+  dwClientDebug?: boolean;
+  /** @deprecated Use dwClientDebug. Controls DWClient debug logging only. */
   debug?: boolean;
   messageType?: "markdown" | "card";
   cardTemplateId?: string;
@@ -682,6 +688,7 @@ export function resolveDingTalkAccount(
       journalTTLDays: dingtalk?.journalTTLDays,
       showThinking: dingtalk?.showThinking,
       thinkingMessage: dingtalk?.thinkingMessage,
+      dwClientDebug: dingtalk?.dwClientDebug,
       debug: dingtalk?.debug,
       messageType: dingtalk?.messageType,
       cardTemplateId: dingtalk?.cardTemplateId,

--- a/tests/integration/gateway-start-flow.test.ts
+++ b/tests/integration/gateway-start-flow.test.ts
@@ -220,6 +220,65 @@ describe('gateway.startAccount lifecycle', () => {
         expect(shared.stopMock).not.toHaveBeenCalled();
     });
 
+    it('uses dwClientDebug to configure DWClient debug flag', async () => {
+        const controller = new AbortController();
+        const { ctx } = createStartContext(controller.signal);
+        (ctx.cfg as any).channels = {
+            dingtalk: {
+                clientId: 'ding_id',
+                clientSecret: 'ding_secret',
+                dwClientDebug: true,
+            },
+        };
+        ctx.account.config = {
+            clientId: 'ding_id',
+            clientSecret: 'ding_secret',
+            useConnectionManager: false,
+            dwClientDebug: true,
+        } as any;
+        (ctx.cfg as any).channels.dingtalk.dwClientDebug = true;
+        shared.clientConnectMock.mockImplementation(async () => {
+            controller.abort();
+        });
+
+        const stopResult = await startGatewayAccount(ctx as any);
+
+        expect(shared.dwClientConfig).toMatchObject({
+            debug: true,
+            autoReconnect: true,
+        });
+
+        stopResult.stop();
+    });
+
+    it('warns when legacy debug is explicitly configured', async () => {
+        const controller = new AbortController();
+        const { ctx } = createStartContext(controller.signal);
+        (ctx.cfg as any).channels = {
+            dingtalk: {
+                clientId: 'ding_id',
+                clientSecret: 'ding_secret',
+                debug: true,
+            },
+        };
+        ctx.account.config = {
+            clientId: 'ding_id',
+            clientSecret: 'ding_secret',
+            useConnectionManager: false,
+            debug: true,
+        } as any;
+        (ctx.cfg as any).channels.dingtalk.debug = true;
+        shared.clientConnectMock.mockImplementation(async () => {
+            controller.abort();
+        });
+
+        const stopResult = await startGatewayAccount(ctx as any);
+
+        expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining('deprecated'));
+        expect(ctx.log.warn).toHaveBeenCalledWith(expect.stringContaining('dwClientDebug'));
+
+        stopResult.stop();
+    });
     it('labels websocket-stage failures when native connect fails after open succeeds', async () => {
         const { ctx } = createStartContext();
         ctx.account.config = {

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -91,6 +91,15 @@ describe('DingTalkConfigSchema', () => {
         expect(parsed.accounts.main?.keepAlive).toBeUndefined();
     });
 
+    it('accepts dwClientDebug on top-level config', () => {
+        const parsed = DingTalkConfigSchema.parse({
+            clientId: 'id',
+            clientSecret: 'secret',
+            dwClientDebug: true,
+        }) as { dwClientDebug?: boolean };
+
+        expect(parsed.dwClientDebug).toBe(true);
+    });
     it('accepts custom aicardDegradeMs for account config', () => {
         const parsed = DingTalkConfigSchema.parse({
             accounts: {


### PR DESCRIPTION
## Summary
- add `dwClientDebug` as the explicit config key for DWClient debug logging
- keep legacy `debug` as a deprecated alias with startup warnings
- add schema and gateway-start tests for the new/legacy keys

## Why
`debug` currently only controls DWClient debug output, but the name reads like a plugin-wide debug switch. This PR narrows the meaning and keeps backward compatibility.

## Verification
- `npm test -- --run tests/unit/config-schema.test.ts tests/integration/gateway-start-flow.test.ts tests/unit/connection-manager.test.ts`