### PR TITLE
fix: add connection manager heartbeat

### DIFF
--- a/src/connection-manager.ts
+++ b/src/connection-manager.ts
@@ -52,12 +52,19 @@ export class ConnectionManager {
   private static readonly DEFAULT_MAX_RECONNECT_CYCLES = 10;
   private static readonly MAX_CYCLE_BACKOFF_MS = 5000;
   private static readonly MAX_CONSECUTIVE_DEADLINE_TIMEOUTS = 5;
+  private static readonly HEARTBEAT_INTERVAL_MS = 20_000;
+  private static readonly HEARTBEAT_MISS_THRESHOLD = 2;
   private runtimeReconnectCycles: number = 0;
   private reconnectDeadline?: number;
   private consecutiveDeadlineTimeouts: number = 0;
+  private lastSocketActivityAt?: number;
+  private lastHeartbeatPingAt?: number;
+  private consecutiveHeartbeatMisses: number = 0;
   private runtimeCounters = {
     healthUnhealthyChecks: 0,
     healthTriggeredReconnects: 0,
+    heartbeatMisses: 0,
+    heartbeatTriggeredReconnects: 0,
     serverDisconnectMessages: 0,
     socketCloseEvents: 0,
     runtimeDisconnects: 0,
@@ -68,9 +75,11 @@ export class ConnectionManager {
 
   // Runtime monitoring resources
   private healthCheckInterval?: NodeJS.Timeout;
+  private heartbeatInterval?: NodeJS.Timeout;
   private socketCloseHandler?: (code: number, reason: string) => void;
   private socketErrorHandler?: (error: Error) => void;
   private socketMessageHandler?: (data: any) => void;
+  private socketPongHandler?: () => void;
   private monitoredSocket?: any;
 
   // Sleep abort control
@@ -106,8 +115,69 @@ export class ConnectionManager {
   private logRuntimeCounters(reason: string): void {
     const c = this.runtimeCounters;
     this.log?.info?.(
-      `[${this.accountId}] Runtime counters (${reason}): healthUnhealthyChecks=${c.healthUnhealthyChecks}, healthTriggeredReconnects=${c.healthTriggeredReconnects}, serverDisconnectMessages=${c.serverDisconnectMessages}, socketCloseEvents=${c.socketCloseEvents}, runtimeDisconnects=${c.runtimeDisconnects}, reconnectAttempts=${c.reconnectAttempts}, reconnectSuccess=${c.reconnectSuccess}, reconnectFailures=${c.reconnectFailures}`,
+      `[${this.accountId}] Runtime counters (${reason}): healthUnhealthyChecks=${c.healthUnhealthyChecks}, healthTriggeredReconnects=${c.healthTriggeredReconnects}, heartbeatMisses=${c.heartbeatMisses}, heartbeatTriggeredReconnects=${c.heartbeatTriggeredReconnects}, serverDisconnectMessages=${c.serverDisconnectMessages}, socketCloseEvents=${c.socketCloseEvents}, runtimeDisconnects=${c.runtimeDisconnects}, reconnectAttempts=${c.reconnectAttempts}, reconnectSuccess=${c.reconnectSuccess}, reconnectFailures=${c.reconnectFailures}`,
     );
+  }
+
+  private recordSocketActivity(now: number = Date.now()): void {
+    this.lastSocketActivityAt = now;
+    this.consecutiveHeartbeatMisses = 0;
+  }
+
+  private setupHeartbeat(socket: any): void {
+    this.cleanupHeartbeatInterval();
+    this.heartbeatInterval = setInterval(() => {
+      if (this.stopped || this.state !== ConnectionStateEnum.CONNECTED) {
+        return;
+      }
+
+      if (socket.readyState !== 1) {
+        return;
+      }
+
+      const now = Date.now();
+      const idleMs = this.lastSocketActivityAt !== undefined
+        ? now - this.lastSocketActivityAt
+        : ConnectionManager.HEARTBEAT_INTERVAL_MS;
+      if (idleMs >= ConnectionManager.HEARTBEAT_INTERVAL_MS) {
+        this.consecutiveHeartbeatMisses += 1;
+        this.runtimeCounters.heartbeatMisses += 1;
+
+        if (this.consecutiveHeartbeatMisses >= ConnectionManager.HEARTBEAT_MISS_THRESHOLD) {
+          const lastPingAgoMs = this.lastHeartbeatPingAt !== undefined
+            ? now - this.lastHeartbeatPingAt
+            : undefined;
+          this.log?.warn?.(
+            `[${this.accountId}] Connection heartbeat missed ${this.consecutiveHeartbeatMisses}/${ConnectionManager.HEARTBEAT_MISS_THRESHOLD} checks, triggering reconnection (lastPingAgoMs=${lastPingAgoMs ?? "n/a"})`,
+          );
+          this.runtimeCounters.heartbeatTriggeredReconnects += 1;
+          this.logRuntimeCounters("heartbeat-triggered-reconnect");
+          this.cleanupHeartbeatInterval();
+          this.handleRuntimeDisconnection();
+          return;
+        }
+
+        this.log?.debug?.(
+          `[${this.accountId}] Connection heartbeat missed (${this.consecutiveHeartbeatMisses}/${ConnectionManager.HEARTBEAT_MISS_THRESHOLD})`,
+        );
+      }
+
+      this.lastHeartbeatPingAt = now;
+      try {
+        socket.ping();
+      } catch (err: any) {
+        this.log?.warn?.(
+          `[${this.accountId}] Failed to send heartbeat ping: ${err.message}`,
+        );
+      }
+    }, ConnectionManager.HEARTBEAT_INTERVAL_MS);
+  }
+
+  private cleanupHeartbeatInterval(): void {
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
   }
 
   /**
@@ -257,8 +327,11 @@ export class ConnectionManager {
 
       this.state = ConnectionStateEnum.CONNECTED;
       this.connectedAt = Date.now();
+      this.recordSocketActivity(this.connectedAt);
+      this.lastHeartbeatPingAt = undefined;
       this.reconnectDeadline = undefined;
       this.consecutiveUnhealthyChecks = 0;
+      this.consecutiveHeartbeatMisses = 0;
       this.notifyStateChange();
       const successfulAttempt = this.attemptCount;
       this.attemptCount = 0;
@@ -450,6 +523,7 @@ export class ConnectionManager {
       const socket = client.socket;
       // Store the socket instance we're attaching listeners to
       this.monitoredSocket = socket;
+      this.setupHeartbeat(socket);
 
       // Handler for socket close event
       this.socketCloseHandler = (code: number, reason: string) => {
@@ -487,6 +561,7 @@ export class ConnectionManager {
       // reconnecting immediately instead of waiting for the health check or
       // the eventual TCP close.
       this.socketMessageHandler = (data: any) => {
+        this.recordSocketActivity();
         try {
           const msg = JSON.parse(typeof data === "string" ? data : data.toString());
           if (msg?.type === "SYSTEM" && msg?.headers?.topic === "disconnect") {
@@ -505,6 +580,11 @@ export class ConnectionManager {
         }
       };
       socket.on("message", this.socketMessageHandler);
+
+      this.socketPongHandler = () => {
+        this.recordSocketActivity();
+      };
+      socket.on("pong", this.socketPongHandler);
     }
   }
 
@@ -543,6 +623,7 @@ export class ConnectionManager {
       this.healthCheckInterval = undefined;
       this.log?.debug?.(`[${this.accountId}] Health check interval cleared`);
     }
+    this.cleanupHeartbeatInterval();
 
     // Remove socket event listeners from the stored socket instance
     if (this.monitoredSocket) {
@@ -559,6 +640,10 @@ export class ConnectionManager {
       if (this.socketMessageHandler) {
         socket.removeListener("message", this.socketMessageHandler);
         this.socketMessageHandler = undefined;
+      }
+      if (this.socketPongHandler) {
+        socket.removeListener("pong", this.socketPongHandler);
+        this.socketPongHandler = undefined;
       }
 
       this.log?.debug?.(`[${this.accountId}] Socket event listeners removed from monitored socket`);
@@ -584,7 +669,10 @@ export class ConnectionManager {
     this.notifyStateChange("Runtime disconnection detected");
     this.attemptCount = 0;
     this.connectedAt = undefined;
+    this.lastSocketActivityAt = undefined;
+    this.lastHeartbeatPingAt = undefined;
     this.consecutiveUnhealthyChecks = 0;
+    this.consecutiveHeartbeatMisses = 0;
 
     const deadlineMs = this.config.reconnectDeadlineMs ?? 50000;
     this.reconnectDeadline = Date.now() + deadlineMs;
@@ -712,6 +800,9 @@ export class ConnectionManager {
     this.reconnectDeadline = undefined;
     this.consecutiveDeadlineTimeouts = 0;
     this.consecutiveUnhealthyChecks = 0;
+    this.lastSocketActivityAt = undefined;
+    this.lastHeartbeatPingAt = undefined;
+    this.consecutiveHeartbeatMisses = 0;
 
     // Clear reconnect timer
     this.clearReconnectTimer();

--- a/tests/unit/connection-manager.test.ts
+++ b/tests/unit/connection-manager.test.ts
@@ -12,6 +12,7 @@ function createMockClient(overrides?: Record<string, any>) {
     const socket = new EventEmitter();
     (socket as any).readyState = 1;
     (socket as any).removeListener = socket.removeListener.bind(socket);
+    (socket as any).ping = vi.fn();
 
     const client = {
         connected: false,
@@ -910,16 +911,125 @@ describe('ConnectionManager', () => {
         clearInterval(fakeIntervalId);
     });
 
-    // ── Quiet socket should not self-trigger reconnect ──────────────────
+    // ── ConnectionManager heartbeat ─────────────────────────────────────
 
-    it('does not reconnect when the socket stays silent', async () => {
-        const { client } = createMockClient();
+    it('triggers reconnection when heartbeat sees no pong or message activity', async () => {
+        const { client, socket } = createMockClient();
+        const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+        const manager = new ConnectionManager(client, 'main', baseConfig(), log);
+
+        await manager.connect();
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect((socket as any).ping).toHaveBeenCalled();
+        expect(log.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Connection heartbeat missed 2/2 checks'),
+        );
+        expect(client.connect.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not reconnect when pong frames keep heartbeat healthy', async () => {
+        const { client, socket } = createMockClient();
 
         const manager = new ConnectionManager(client, 'main', baseConfig());
 
         await manager.connect();
-        await vi.advanceTimersByTimeAsync(121_000);
+        const connectCountAfterInit = client.connect.mock.calls.length;
 
-        expect(client.connect).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(20_000);
+        socket.emit('pong');
+        await vi.advanceTimersByTimeAsync(20_000);
+        socket.emit('pong');
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect(client.connect.mock.calls.length).toBe(connectCountAfterInit);
+    });
+
+    it('does not reconnect when message activity keeps heartbeat healthy', async () => {
+        const { client, socket } = createMockClient();
+
+        const manager = new ConnectionManager(client, 'main', baseConfig());
+
+        await manager.connect();
+        const connectCountAfterInit = client.connect.mock.calls.length;
+
+        await vi.advanceTimersByTimeAsync(20_000);
+        socket.emit('message', JSON.stringify({
+            type: "SYSTEM",
+            headers: { topic: "KEEPALIVE" },
+            data: "",
+        }));
+        await vi.advanceTimersByTimeAsync(20_000);
+        socket.emit('message', JSON.stringify({
+            type: "SYSTEM",
+            headers: { topic: "ping" },
+            data: "",
+        }));
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect(client.connect.mock.calls.length).toBe(connectCountAfterInit);
+    });
+
+    it('tracks heartbeat-triggered reconnect counters', async () => {
+        const { client } = createMockClient();
+        const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+        const manager = new ConnectionManager(client, 'main', baseConfig(), log);
+
+        await manager.connect();
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(10);
+
+        expect(log.info).toHaveBeenCalledWith(
+            expect.stringContaining('heartbeatTriggeredReconnects=1'),
+        );
+        expect(log.info).toHaveBeenCalledWith(
+            expect.stringContaining('heartbeatMisses=2'),
+        );
+    });
+
+    it('stop clears ConnectionManager heartbeat interval', async () => {
+        const { client, socket } = createMockClient();
+
+        const manager = new ConnectionManager(client, 'main', baseConfig());
+
+        await manager.connect();
+        manager.stop();
+        const connectCountBefore = client.connect.mock.calls.length;
+
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect((socket as any).ping).not.toHaveBeenCalled();
+        expect(client.connect.mock.calls.length).toBe(connectCountBefore);
+    });
+
+    it('warm reconnect clears the previous socket heartbeat interval', async () => {
+        const { client: seedClient } = createMockClient();
+        const { client: firstClient, socket: firstSocket } = createMockClient();
+        const { client: secondClient, socket: secondSocket } = createMockClient();
+
+        const factory = vi.fn()
+            .mockReturnValueOnce(firstClient)
+            .mockReturnValueOnce(secondClient);
+
+        const manager = new ConnectionManager(
+            seedClient, 'main', baseConfig(), undefined, factory,
+        );
+
+        await manager.connect();
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(20_000);
+        await vi.advanceTimersByTimeAsync(10);
+
+        const firstSocketPingCount = (firstSocket as any).ping.mock.calls.length;
+
+        await vi.advanceTimersByTimeAsync(20_000);
+
+        expect((secondSocket as any).ping).toHaveBeenCalled();
+        expect((firstSocket as any).ping.mock.calls.length).toBe(firstSocketPingCount);
     });
 });


### PR DESCRIPTION
## 简介

这是对 `#336` 的重新提交版本，范围只保留 ConnectionManager heartbeat 修复本身，不包含后续关于配置命名、deprecated warning、配置归一化的调整。

这次改动的必要性，核心在于把“静默断链检测”从 `DWClient.keepAlive` 依赖中解耦出来，并且继续保持 SDK 保活模式与 ConnectionManager 接管模式二选一。

## 为何需要这次修改

1. 现状里 `useConnectionManager=true` 与 `DWClient.keepAlive=true` 是互斥的。
   为了让 ConnectionManager 完整接管连接生命周期，在该模式下会显式关闭 SDK 的 `keepAlive/autoReconnect`。这本身没有问题，但旧实现里静默断链检测又隐式依赖 `keepAlive=true` 才能成立，于是 ConnectionManager 模式实际上丢失了“静默僵尸连接”检测能力。

2. DingTalk Stream 的故障不只有显式 `close` 或 `SYSTEM/disconnect`。
   真实环境里会存在 TCP 不立即关闭、但服务端已经不再向该连接投递消息的情况。如果没有一层主动 heartbeat，这类连接只能等低频 health check 兜底，恢复速度慢，期间会直接丢消息。

3. 旧的 idle reconnect 路径语义不清，容易把“正常静默”与“真实断链”混在一起。
   这版实现把语义收敛为 ConnectionManager 自己的 heartbeat：每 `20s` 主动 `ping`，一旦连续 `2` 个窗口没有 `pong` 或任何 websocket `message`，才判定为失活并重连。

4. 方案保持最小化，不扩散公开配置面。
   没有新增 schema/type/config 字段，也没有把两套心跳混在一起；只是把 ConnectionManager 模式缺失的探活能力补回到 ConnectionManager 内部。现有的三条快路径仍然保留：
   - `SYSTEM/disconnect`
   - websocket `close`
   - health check 兜底

## 具体改动

- 为 `ConnectionManager` 增加独立 heartbeat，仅在 ConnectionManager 接管模式下运行
- 使用底层 websocket `ping()` / `pong` 与普通 `message` 作为活动信号
- heartbeat miss 触发专用重连计数与日志，不再复用旧的 `socket idle` 语义
- 在 `stop()` 和 warm reconnect 清理路径里同步清理 heartbeat 定时器与状态
- 补充对应单测覆盖 heartbeat miss / pong / message activity / cleanup 场景

## 验证

- `npm test -- --run tests/unit/connection-manager.test.ts`
