### PR TITLE
fix(inbound-handler): guard textToSend undefined in card final/tool deliver

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1362,6 +1362,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
               // ---- card mode: final ----
               if (useCardMode && currentAICard && info?.kind === "final") {
+                const finalText = typeof textToSend === "string" ? textToSend : "";
                 await controller!.flush();
                 await controller!.waitForInFlight();
                 controller!.stop();
@@ -1370,7 +1371,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 }
                 if (!isCardInTerminalState(currentAICard.state) && !controller!.isFailed()) {
                   try {
-                    await finishAICard(currentAICard, textToSend, log);
+                    await finishAICard(currentAICard, finalText, log);
                     cardFinalized = true;
                   } catch (finalizeErr: any) {
                     log?.debug?.(`[DingTalk] AI Card finalization failed in deliver: ${finalizeErr.message}`);
@@ -1381,14 +1382,14 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                       currentAICard.state = AICardStatus.FAILED;
                       currentAICard.lastUpdated = Date.now();
                     }
-                    finalTextForFallback = textToSend;
+                    finalTextForFallback = finalText;
                   }
                 } else if (currentAICard.state === AICardStatus.FINISHED) {
                   log?.info?.("[DingTalk] Card already FINISHED before deliver(final), skipping duplicate finalize");
                   cardFinalized = true;
                 } else {
                   log?.info?.("[DingTalk] Card failed before deliver(final), deferring markdown fallback to post-dispatch");
-                  finalTextForFallback = textToSend;
+                  finalTextForFallback = finalText;
                 }
                 return;
               }
@@ -1402,9 +1403,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 await controller!.flush();
                 await controller!.waitForInFlight();
                 log?.info?.(
-                  `[DingTalk] Tool result received, streaming to AI Card: ${textToSend.slice(0, 100)}`,
+                  `[DingTalk] Tool result received, streaming to AI Card: ${(textToSend ?? "").slice(0, 100)}`,
                 );
-                const toolText = formatContentForCard(textToSend, "tool");
+                const toolText = typeof textToSend === "string" ? formatContentForCard(textToSend, "tool") : "";
                 if (toolText) {
                   const sendResult = await sendMessage(dingtalkConfig, to, toolText, {
                     sessionWebhook,


### PR DESCRIPTION
## 问题

拉取最新 main 后 `pnpm type-check` 报两处错误：

```
src/inbound-handler.ts(1373,55): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
src/inbound-handler.ts(1405,77): error TS18048: 'textToSend' is possibly 'undefined'.
```

## 根因

`payload.text` 的类型是 `string | undefined`。第 1359 行的 guard 只在「text 为空 **且** mediaUrls 也为空」时才 early return。当消息只有媒体文件、没有文字时（如用户发了一张图），`textToSend === undefined` 但 `mediaUrls.length > 0`，代码会继续往下走，触发：

1. `finishAICard(currentAICard, textToSend, log)` → 函数内部 `content.length` → 运行时 TypeError
2. `textToSend.slice(0, 100)` → 运行时 TypeError

根因由 #341（CardDraftController 重构）引入。

## 修法

**card final 分支**：在 final 分支顶部新增 `const finalText = typeof textToSend === "string" ? textToSend : ""`，后续统一用 `finalText`。

**card tool 分支**：
- 日志行改为 `(textToSend ?? "").slice(0, 100)`
- `formatContentForCard` 调用前加 `typeof textToSend === "string"` 判断

## 验证

- `pnpm type-check` ✅ 通过
- `pnpm test` ✅ 50 files / 477 tests 全绿