### PR TITLE
fix(card): fix AI Card streaming finalization bugs

### DIFF
--- a/src/card-draft-controller.ts
+++ b/src/card-draft-controller.ts
@@ -21,11 +21,16 @@ export type CardDraftPhase = "idle" | "reasoning" | "answer";
 export interface CardDraftController {
     updateAnswer: (text: string) => void;
     updateReasoning: (text: string) => void;
+    /** Signal that a new assistant turn has started (e.g. after a tool call). */
+    notifyNewAssistantTurn: () => void;
     flush: () => Promise<void>;
     waitForInFlight: () => Promise<void>;
     stop: () => void;
     isFailed: () => boolean;
+    /** Last content sent to card (reasoning or answer). */
     getLastContent: () => string;
+    /** Last content sent to card during answer phase only. */
+    getLastAnswerContent: () => string;
 }
 
 export function createCardDraftController(params: {
@@ -37,8 +42,9 @@ export function createCardDraftController(params: {
     let failed = false;
     let stopped = false;
     let lastSentContent = "";
+    let lastAnswerContent = "";
     let answerPrefix = "";
-    let lastPartialLen = 0;
+    let turnBoundaryPending = false;
 
     const loop = createDraftStreamLoop({
         throttleMs: params.throttleMs ?? 300,
@@ -47,6 +53,9 @@ export function createCardDraftController(params: {
             try {
                 await streamAICard(params.card, content, false, params.log);
                 lastSentContent = content;
+                if (phase === "answer") {
+                    lastAnswerContent = content;
+                }
             } catch (err: unknown) {
                 failed = true;
                 const message = err instanceof Error ? err.message : String(err);
@@ -68,22 +77,25 @@ export function createCardDraftController(params: {
         updateAnswer: (text: string) => {
             if (stopped || failed) { return; }
             if (phase !== "answer") {
-                if (phase === "reasoning") {
-                    loop.resetPending();
-                }
                 params.log?.debug?.(`[DingTalk][Draft] phase ${phase} → answer`);
                 phase = "answer";
             }
             if (text) {
-                // Heuristic: runtime resets payload.text per assistant turn
-                // (e.g. after a tool call). A dramatic length drop (>50%)
-                // signals a new turn; minor trimming is ignored.
-                if (text.length < lastPartialLen * 0.5 && lastSentContent) {
-                    answerPrefix = lastSentContent + "\n\n";
+                if (turnBoundaryPending && lastAnswerContent) {
+                    answerPrefix = lastAnswerContent + "\n\n";
+                    turnBoundaryPending = false;
                 }
-                lastPartialLen = text.length;
                 loop.update(answerPrefix + text);
             }
+        },
+
+        notifyNewAssistantTurn: () => {
+            if (stopped || failed) { return; }
+            turnBoundaryPending = true;
+            if (phase === "reasoning") {
+                loop.resetPending();
+            }
+            phase = "idle";
         },
 
         flush: () => loop.flush(),
@@ -96,5 +108,6 @@ export function createCardDraftController(params: {
 
         isFailed: () => failed,
         getLastContent: () => lastSentContent,
+        getLastAnswerContent: () => lastAnswerContent,
     };
 }

--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -22,7 +22,6 @@ import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 
 const DINGTALK_API = "https://api.dingtalk.com";
 // Thinking/tool stream snippets are truncated to keep card updates compact.
-const THINKING_TRUNCATE_LENGTH = 500;
 const CARD_STATE_FILE_VERSION = 1;
 const CARD_PENDING_NAMESPACE = "cards.active.pending";
 const CARD_PROCESS_QUERY_NAMESPACE = "cards.content.quote-process-query";
@@ -323,15 +322,10 @@ export function formatContentForCard(content: string | undefined, type: "thinkin
     return "";
   }
 
-  // Truncate to configured length and keep a visual ellipsis when truncated.
-  const truncated =
-    content.slice(0, THINKING_TRUNCATE_LENGTH) +
-    (content.length > THINKING_TRUNCATE_LENGTH ? "…" : "");
-
   const emoji = type === "thinking" ? "🤔" : "🛠️";
   const label = type === "thinking" ? "思考中" : "工具执行";
 
-  const escaped = truncated
+  const escaped = content
     .split("\n")
     .map((line) => line.replace(/^_(?=[^ ])/, "*").replace(/(?<=[^ ])_(?=$)/, "*"))
     .join("\n");

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1358,41 +1358,36 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                   ? [richPayload.mediaUrl]
                   : [];
 
+              // In card mode, deliver(final) must always reach finalize even with empty text
+              // (e.g. bot sent a file via tool with no accompanying text).
               if ((typeof textToSend !== "string" || textToSend.length === 0) && mediaUrls.length === 0) {
-                return;
+                if (useCardMode && currentAICard && info?.kind === "final") {
+                  // fall through to card finalize below
+                } else {
+                  return;
+                }
               }
 
               // ---- card mode: final ----
+              // Do NOT finalize or stop the controller here — runtime calls
+              // deliver(final) once per assistant turn, so there may be more
+              // turns coming after tool calls. Finalization is deferred to
+              // step 5 (post-dispatch) where the full accumulated content
+              // is available.
               if (useCardMode && currentAICard && info?.kind === "final") {
-                const rawFinalText = typeof textToSend === "string" ? textToSend : "";
-                await controller!.flush();
-                await controller!.waitForInFlight();
-                controller!.stop();
+                log?.info?.(
+                  `[DingTalk][Finalize] deliver(final) received — cardState=${currentAICard.state} ` +
+                  `textLen=${typeof textToSend === "string" ? textToSend.length : "null"} ` +
+                  `mediaUrls=${mediaUrls.length} ` +
+                  `lastAnswer="${(controller?.getLastAnswerContent() ?? "").slice(0, 80)}" ` +
+                  `lastContent="${(controller?.getLastContent() ?? "").slice(0, 80)}"`,
+                );
                 if (mediaUrls.length > 0) {
                   await deliverMediaAttachments(mediaUrls);
                 }
-                const finalText = controller!.getLastContent() || rawFinalText;
-                if (!isCardInTerminalState(currentAICard.state) && !controller!.isFailed()) {
-                  try {
-                    await finishAICard(currentAICard, finalText, log);
-                    cardFinalized = true;
-                  } catch (finalizeErr: any) {
-                    log?.debug?.(`[DingTalk] AI Card finalization failed in deliver: ${finalizeErr.message}`);
-                    if (finalizeErr?.response?.data !== undefined) {
-                      log?.debug?.(formatDingTalkErrorPayloadLog("inbound.cardFinalize", finalizeErr.response.data));
-                    }
-                    if (currentAICard.state !== AICardStatus.FINISHED) {
-                      currentAICard.state = AICardStatus.FAILED;
-                      currentAICard.lastUpdated = Date.now();
-                    }
-                    finalTextForFallback = finalText;
-                  }
-                } else if (currentAICard.state === AICardStatus.FINISHED) {
-                  log?.info?.("[DingTalk] Card already FINISHED before deliver(final), skipping duplicate finalize");
-                  cardFinalized = true;
-                } else {
-                  log?.info?.("[DingTalk] Card failed before deliver(final), deferring markdown fallback to post-dispatch");
-                  finalTextForFallback = finalText;
+                const rawFinalText = typeof textToSend === "string" ? textToSend : "";
+                if (rawFinalText) {
+                  finalTextForFallback = rawFinalText;
                 }
                 return;
               }
@@ -1461,6 +1456,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         replyOptions: {
           disableBlockStreaming: dingtalkConfig.cardRealTimeStream && controller ? true : undefined,
 
+          onAssistantMessageStart: controller
+            ? () => { controller.notifyNewAssistantTurn(); }
+            : undefined,
+
           onPartialReply: dingtalkConfig.cardRealTimeStream && controller
             ? (payload: ReplyStreamPayload) => {
                 if (payload.text) {
@@ -1495,18 +1494,30 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       throw dispatchErr;
     }
 
-    // 5) Fallback finalize: covers queuedFinal=false (tool-only, no final text).
+    // 5) Post-dispatch card finalization.
+    // This is the sole finalize path — deliver(final) defers here because
+    // runtime may call deliver(final) multiple times (once per assistant turn).
+    log?.info?.(
+      `[DingTalk][Finalize] Step 5 entry — useCardMode=${useCardMode} ` +
+      `hasCard=${!!currentAICard} cardFinalized=${cardFinalized} ` +
+      `cardState=${currentAICard?.state ?? "N/A"} ` +
+      `controllerFailed=${controller?.isFailed() ?? "N/A"} ` +
+      `finalTextForFallback="${(finalTextForFallback ?? "").slice(0, 80)}" ` +
+      `lastAnswer="${(controller?.getLastAnswerContent() ?? "").slice(0, 80)}" ` +
+      `lastContent="${(controller?.getLastContent() ?? "").slice(0, 80)}"`,
+    );
     if (useCardMode && currentAICard && !cardFinalized) {
       try {
         if (currentAICard.state === AICardStatus.FINISHED) {
-          log?.debug?.(
-            `[DingTalk] Skipping AI Card finalization because card is already FINISHED`,
+          log?.info?.(
+            `[DingTalk][Finalize] Skipping — card already FINISHED`,
           );
           return;
         }
 
         if (currentAICard.state === AICardStatus.FAILED || controller!.isFailed()) {
           const fallbackText = finalTextForFallback
+            || controller!.getLastAnswerContent()
             || controller!.getLastContent()
             || currentAICard.lastStreamedContent;
           if (fallbackText) {
@@ -1531,10 +1542,15 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         await controller!.flush();
         await controller!.waitForInFlight();
         controller!.stop();
-        const fallbackText = controller!.getLastContent()
-          || currentAICard.lastStreamedContent
+        const finalText = controller!.getLastAnswerContent()
+          || finalTextForFallback
           || "✅ Done";
-        await finishAICard(currentAICard, fallbackText, log);
+        log?.info?.(
+          `[DingTalk][Finalize] Calling finishAICard — finalTextLen=${finalText.length} ` +
+          `source=${controller!.getLastAnswerContent() ? "lastAnswerContent" : finalTextForFallback ? "finalTextForFallback" : "fallbackDone"} ` +
+          `preview="${finalText.slice(0, 120)}"`,
+        );
+        await finishAICard(currentAICard, finalText, log);
       } catch (err: any) {
         log?.debug?.(`[DingTalk] AI Card finalization failed: ${err.message}`);
         if (err?.response?.data !== undefined) {

--- a/tests/unit/card-draft-controller.test.ts
+++ b/tests/unit/card-draft-controller.test.ts
@@ -244,60 +244,74 @@ describe("card-draft-controller", () => {
         expect(inFlightDone).toBe(true);
     });
 
-    it("answerPrefix: dramatic length drop (>50%) prepends previous content", async () => {
+    it("notifyNewAssistantTurn: next updateAnswer prepends previous answer content", async () => {
         const card = makeCard();
         const ctrl = createCardDraftController({ card, throttleMs: 0 });
 
-        ctrl.updateAnswer("long answer text here");
+        ctrl.updateAnswer("Turn 1 content");
         await vi.advanceTimersByTimeAsync(0);
         streamAICardMock.mockClear();
 
-        ctrl.updateAnswer("Hi");
+        ctrl.notifyNewAssistantTurn();
+        ctrl.updateAnswer("Turn 2");
         await vi.advanceTimersByTimeAsync(0);
 
         expect(streamAICardMock).toHaveBeenCalledWith(
             card,
-            "long answer text here\n\nHi",
+            "Turn 1 content\n\nTurn 2",
             false,
             undefined,
         );
     });
 
-    it("answerPrefix: minor length drop (<50%) does NOT trigger prefix", async () => {
+    it("notifyNewAssistantTurn: without prior answer content does not prepend", async () => {
         const card = makeCard();
         const ctrl = createCardDraftController({ card, throttleMs: 0 });
 
-        ctrl.updateAnswer("abcdefghij");
+        ctrl.updateReasoning("thinking...");
         await vi.advanceTimersByTimeAsync(0);
         streamAICardMock.mockClear();
 
-        ctrl.updateAnswer("abcdefg");
+        ctrl.notifyNewAssistantTurn();
+        ctrl.updateAnswer("first answer");
         await vi.advanceTimersByTimeAsync(0);
 
         expect(streamAICardMock).toHaveBeenCalledWith(
             card,
-            "abcdefg",
+            "first answer",
             false,
             undefined,
         );
     });
 
-    it("answerPrefix: exactly 50% length does NOT trigger prefix", async () => {
+    it("notifyNewAssistantTurn: resets phase to idle, allowing reasoning again", async () => {
         const card = makeCard();
         const ctrl = createCardDraftController({ card, throttleMs: 0 });
 
-        ctrl.updateAnswer("abcdefghij");
+        ctrl.updateAnswer("answer");
         await vi.advanceTimersByTimeAsync(0);
         streamAICardMock.mockClear();
 
-        ctrl.updateAnswer("abcde");
+        ctrl.notifyNewAssistantTurn();
+        ctrl.updateReasoning("new thinking");
         await vi.advanceTimersByTimeAsync(0);
 
-        expect(streamAICardMock).toHaveBeenCalledWith(
-            card,
-            "abcde",
-            false,
-            undefined,
-        );
+        const sentContent = streamAICardMock.mock.calls[0]?.[1] as string;
+        expect(sentContent).toContain("思考中");
+        expect(sentContent).toContain("new thinking");
+    });
+
+    it("getLastAnswerContent only tracks answer phase sends", async () => {
+        const card = makeCard();
+        const ctrl = createCardDraftController({ card, throttleMs: 0 });
+
+        ctrl.updateReasoning("thinking");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(ctrl.getLastAnswerContent()).toBe("");
+        expect(ctrl.getLastContent()).toContain("思考中");
+
+        ctrl.updateAnswer("answer text");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(ctrl.getLastAnswerContent()).toBe("answer text");
     });
 });

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -371,13 +371,13 @@ describe('card-service', () => {
         expect(card.state).toBe(AICardStatus.FINISHED);
     });
 
-    it('formatContentForCard truncates and annotates content', () => {
+    it('formatContentForCard preserves full content without truncation', () => {
         const content = `${'x'.repeat(510)}`;
         const result = formatContentForCard(content, 'thinking');
 
         expect(result).toContain('🤔 **思考中**');
-        expect(result).toContain('…');
-        expect(result).not.toContain('> ');
+        expect(result).toContain('x'.repeat(510));
+        expect(result).not.toContain('…');
         expect(result.startsWith('🤔 **思考中**\n\n')).toBe(true);
     });
 

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -2186,7 +2186,7 @@ describe('inbound-handler', () => {
         } as any);
 
         expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
-        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, 'tool output', undefined);
+        expect(shared.finishAICardMock).toHaveBeenCalledWith(card, '✅ Done', undefined);
         expect(shared.sendMessageMock).toHaveBeenCalledWith(
             expect.anything(),
             'user_1',
@@ -3249,8 +3249,9 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
             .fn()
-            .mockImplementation(async ({ replyOptions }) => {
+            .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
                 await replyOptions?.onReasoningStream?.({ text: 'thinking pass 1' });
+                await dispatcherOptions.deliver({ text: 'done' }, { kind: 'final' });
                 return { queuedFinal: false };
             });
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
@@ -3636,6 +3637,52 @@ describe('inbound-handler', () => {
         expect(cardSendCalls).toHaveLength(0);
     });
 
+    it('sends markdown fallback in post-dispatch when card fails mid-stream', async () => {
+        const card = { cardInstanceId: 'card_mid_fail', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === '3' || state === '5');
+
+        shared.streamAICardMock.mockImplementation(async () => {
+            card.state = '5';
+            throw new Error('stream api error');
+        });
+
+        const log = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                replyOptions?.onPartialReply?.({ text: 'partial content' });
+                await new Promise((r) => setTimeout(r, 350));
+                await dispatcherOptions.deliver({ text: 'complete final answer' }, { kind: 'final' });
+                return { queuedFinal: 'complete final answer' };
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: log as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardRealTimeStream: true } as any,
+            data: {
+                msgId: 'mid_fail_test', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        const debugLogs = log.debug.mock.calls.map((args: unknown[]) => String(args[0]));
+        expect(debugLogs.some((msg) => msg.includes('Card failed during streaming, sending markdown fallback'))).toBe(true);
+
+        const fallbackCalls = shared.sendMessageMock.mock.calls.filter(
+            (call: any[]) => !call[3]?.card && !call[3]?.cardUpdateMode
+        );
+        expect(fallbackCalls.length).toBeGreaterThanOrEqual(1);
+        expect(fallbackCalls[0][2]).toBe('complete final answer');
+    });
+
     it('acquires session lock with the resolved sessionKey', async () => {
         await handleDingTalkMessage({
             cfg: {},
@@ -3712,14 +3759,18 @@ describe('inbound-handler', () => {
         runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
             .fn()
             .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                // Turn 1
                 replyOptions?.onPartialReply?.({ text: 'Turn 1: Full inspection report with tables and analysis' });
                 await new Promise((r) => setTimeout(r, 350));
 
-                replyOptions?.onPartialReply?.({ text: 'Tu' });
-                await new Promise((r) => setTimeout(r, 50));
+                // Runtime signals new assistant turn (after tool call)
+                replyOptions?.onAssistantMessageStart?.();
+
+                // Turn 2: text starts fresh
                 replyOptions?.onPartialReply?.({ text: 'Turn 2 short summary' });
                 await new Promise((r) => setTimeout(r, 350));
 
+                // deliver(final) only provides last turn's text
                 await dispatcherOptions.deliver({ text: 'Turn 2 short summary' }, { kind: 'final' });
                 return {};
             });
@@ -3730,7 +3781,7 @@ describe('inbound-handler', () => {
             accountId: 'main',
             sessionWebhook: 'https://session.webhook',
             log: undefined,
-            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardRealTimeStream: true, ackReaction: '' } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardRealTimeStream: true, ackReaction: '', showThinking: false } as any,
             data: {
                 msgId: 'mid_accum_test', msgtype: 'text', text: { content: 'hello' },
                 conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
@@ -3743,5 +3794,106 @@ describe('inbound-handler', () => {
         expect(finalizeContent).toContain('Turn 1');
         expect(finalizeContent).toContain('Turn 2');
         expect(finalizeContent).not.toBe('Turn 2 short summary');
+    });
+
+    it('card finalize with empty deliver(final) text still finalizes card instead of early-returning', async () => {
+        const card = { cardInstanceId: 'card_empty_final', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions }) => {
+                await dispatcherOptions.deliver({ text: '' }, { kind: 'final' });
+                return {};
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false } as any,
+            data: {
+                msgId: 'mid_empty_final', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('cardRealTimeStream=false: finalize uses rawFinalText not reasoning content from controller', async () => {
+        const card = { cardInstanceId: 'card_no_realtime', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                replyOptions?.onReasoningStream?.({ text: 'deep thinking about the problem' });
+                await new Promise((r) => setTimeout(r, 350));
+                await dispatcherOptions.deliver({ text: 'Here is the final answer.' }, { kind: 'final' });
+                return {};
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', showThinking: false, cardRealTimeStream: false } as any,
+            data: {
+                msgId: 'mid_norealtime', msgtype: 'text', text: { content: 'hello' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        const finalizeContent = shared.finishAICardMock.mock.calls[0][1];
+        expect(finalizeContent).toBe('Here is the final answer.');
+        expect(finalizeContent).not.toContain('思考中');
+    });
+
+    it('file-only response finalizes card with Done instead of reasoning content', async () => {
+        const card = { cardInstanceId: 'card_file_only', state: '1', lastUpdated: Date.now() } as any;
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+            .fn()
+            .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
+                replyOptions?.onReasoningStream?.({ text: 'Let me send the file' });
+                await new Promise((r) => setTimeout(r, 350));
+                // Bot sent file via tool, deliver(final) has no text and no media
+                await dispatcherOptions.deliver({ text: '' }, { kind: 'final' });
+                return {};
+            });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+        await handleDingTalkMessage({
+            cfg: {},
+            accountId: 'main',
+            sessionWebhook: 'https://session.webhook',
+            log: undefined,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardRealTimeStream: true, showThinking: false } as any,
+            data: {
+                msgId: 'mid_file_only', msgtype: 'text', text: { content: 'send me the file' },
+                conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
+                chatbotUserId: 'bot_1', sessionWebhook: 'https://session.webhook', createAt: Date.now(),
+            },
+        } as any);
+
+        expect(shared.finishAICardMock).toHaveBeenCalledTimes(1);
+        const finalizeContent = shared.finishAICardMock.mock.calls[0][1];
+        expect(finalizeContent).not.toContain('思考中');
+        expect(finalizeContent).not.toContain('send');
     });
 });


### PR DESCRIPTION
## Summary

修复 AI Card 流式打字效果下多个 finalization 相关 bug，解决卡片最终内容丢失、reasoning 内容泄漏、思考内容截断等问题。

### 修复的问题

| Bug | 原因 | 修复 |
|-----|------|------|
| 多轮对话（含 tool call）时卡片 final 内容只显示最后一轮 | `deliver(final)` 使用 `payload.text`（仅当前轮）而非 controller 累积内容 | 将 finalize 统一移至 post-dispatch Step 5，使用 `getLastAnswerContent()` |
| 空 `deliver(final)` 文本时卡片不 finalize | 空文本 + 无 media 时提前 return，跳过 finalize 路径 | card mode 下 `deliver(final)` 始终 fall through |
| 文件回复时卡片显示 "🤔 思考中..." 而非正常结束 | `lastStreamedContent`（含 reasoning）作为 fallback 泄漏到 final | 从 finalize fallback 链中移除 `lastStreamedContent` |
| `cardRealTimeStream=false` 时 final 卡片显示 reasoning | `getLastContent()` 不区分 reasoning/answer 阶段 | 新增 `getLastAnswerContent()` 仅追踪 answer 阶段内容 |
| 多轮转场靠 50% 长度下降启发式检测，不可靠 | 文本长度波动导致误判 | 替换为 `onAssistantMessageStart` 显式回调 |
| 思考内容截断，只显示约 100 字符 | reasoning→answer 转换时 `resetPending()` 丢弃最后一批未发送的思考内容 | 移除 `updateAnswer` 中的 `resetPending()` |
| 思考内容硬截断 500 字符 | `THINKING_TRUNCATE_LENGTH = 500` | 移除截断限制，完整展示 |

### 主要改动

- **`src/inbound-handler.ts`** — deliver(final) 不再直接 finalize，统一延迟到 post-dispatch；集成 `onAssistantMessageStart`；诊断日志
- **`src/card-draft-controller.ts`** — 新增 `notifyNewAssistantTurn()`、`getLastAnswerContent()`；移除 `resetPending()` 和长度启发式
- **`src/card-service.ts`** — 移除 `THINKING_TRUNCATE_LENGTH` 截断

### 测试

所有 fix 均有对应测试用例覆盖，`card-draft-controller.ts` 语句覆盖率 100%。

## Test plan

- [x] 单元测试全部通过（474 tests）
- [ ] 纯文本对话：卡片流式 → final 显示完整内容
- [ ] 多轮 tool call 对话：卡片 final 包含所有轮次内容
- [ ] 文件回复：卡片显示 "✅ Done"，文件正常发送
- [ ] 思考模式开启：思考内容完整展示，final 不泄漏 reasoning
- [ ] `cardRealTimeStream=false`：卡片使用 deliver(final) 原始文本
