### PR TITLE
fix(card): fix AI Card streaming finalization bugs

### DIFF
--- a/src/card-draft-controller.ts
+++ b/src/card-draft-controller.ts
@@ -79,13 +79,14 @@ export function createCardDraftController(params: {
             if (phase !== "answer") {
                 params.log?.debug?.(`[DingTalk][Draft] phase ${phase} → answer`);
                 phase = "answer";
-            }
-            if (text) {
                 if (turnBoundaryPending && lastAnswerContent) {
                     answerPrefix = lastAnswerContent + "\n\n";
-                    turnBoundaryPending = false;
                 }
-                loop.update(answerPrefix + text);
+                turnBoundaryPending = false;
+            }
+            const trimmed = text?.trimStart();
+            if (trimmed) {
+                loop.update(answerPrefix + trimmed);
             }
         },
 


### PR DESCRIPTION
## Summary

修复 AI Card 流式打字效果中两个残留 bug：

1. **首行重复 bug**：`onAssistantMessageStart` 在首轮也会触发 `turnBoundaryPending`，当第一批 partial reply 被节流发出后 `lastAnswerContent` 变为非空，后续 partial 误触发 turn boundary prepend，导致首字内容被重复拼接到前面（如"这\n\n这是 OpenClaw..."）。
   - 修复：将 `turnBoundaryPending` 判断和重置移入 phase 切换块，进入 answer 阶段时一次性决策并始终重置 flag。

2. **首行多空行 bug**：模型在 thinking 结束后输出的 answer 文本常带前导 `\n`，导致卡片首行出现空行。
   - 修复：在 `updateAnswer` 中对文本做 `trimStart()` 去除前导空白。

### 改动文件

- **`src/card-draft-controller.ts`** — `updateAnswer` 中 boundary 判断逻辑重构 + `trimStart()`

## Test plan

- [x] 单元测试全部通过（474 tests）
- [ ] 首轮回复：首字不再重复或多空行
- [ ] 多轮 tool call：第二轮正确拼接前一轮内容
- [ ] reasoning 流式展示不受影响
