### PR TITLE
fix: import buildChannelConfigSchema from plugin-sdk/discord

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,6 +5,7 @@ import type {
   OpenClawConfig,
 } from "openclaw/plugin-sdk";
 import * as pluginSdk from "openclaw/plugin-sdk";
+import { buildChannelConfigSchema } from "openclaw/plugin-sdk/discord";
 import { getAccessToken } from "./auth";
 import { analyzeCardCallback } from "./card-callback-service";
 import {
@@ -315,7 +316,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
     blurb: "钉钉企业内部机器人，使用 Stream 模式，无需公网 IP。",
     aliases: ["dd", "ding"],
   },
-  configSchema: pluginSdk.buildChannelConfigSchema(DingTalkConfigSchema),
+  configSchema: buildChannelConfigSchema(DingTalkConfigSchema),
   onboarding: dingtalkOnboardingAdapter,
   capabilities: {
     chatTypes: ["direct", "group"] as Array<"direct" | "group">,


### PR DESCRIPTION
## Summary

- Import `buildChannelConfigSchema` from `openclaw/plugin-sdk/discord` instead of relying on `pluginSdk.buildChannelConfigSchema`
- The `buildChannelConfigSchema` function is not exported from the main `openclaw/plugin-sdk` module in OpenClaw 2026.3.13

## Problem

When loading the dingtalk plugin with OpenClaw 2026.3.13, the following error occurs:

```
TypeError: pluginSdk.buildChannelConfigSchema is not a function
```

This is because `buildChannelConfigSchema` is not exported from the main SDK entrypoint. It is available from channel-specific SDK subpaths like `openclaw/plugin-sdk/discord`.

## Solution

Add an explicit import:
```typescript
import { buildChannelConfigSchema } from "openclaw/plugin-sdk/discord";
```

And use the imported function directly instead of `pluginSdk.buildChannelConfigSchema`.

## Testing

Verified with OpenClaw 2026.3.13:
- Plugin loads successfully
- Channel status shows `DingTalk default: configured, enabled`