### PR TITLE
fix(markdown): disable block streaming in markdown mode to prevent split messages

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1454,7 +1454,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           },
         },
         replyOptions: {
-          disableBlockStreaming: dingtalkConfig.cardRealTimeStream && controller ? true : undefined,
+          disableBlockStreaming: useCardMode
+            ? (dingtalkConfig.cardRealTimeStream && controller ? true : undefined)
+            : true,
 
           onAssistantMessageStart: controller
             ? () => { controller.notifyNewAssistantTurn(); }


### PR DESCRIPTION
## Summary

Closes #360

Markdown 模式下 disableBlockStreaming 为 undefined，导致 runtime 逐块投递，每块触发一次 sendBySession，一个回复被拆成多条独立消息。

- 修复：非卡片模式下强制 disableBlockStreaming: true，让 runtime 缓冲所有块后通过 deliver(final) 一次性投递
- Card 模式逻辑不变

## Test plan

- [x] 474 个单元测试全部通过
- [ ] Markdown 模式下回复合并为一条消息
- [ ] Card 模式 + cardRealTimeStream=true 流式正常
- [ ] Card 模式 + cardRealTimeStream=false 行为不变

