### PR TITLE
fix(config): add default ackReaction fallback to prevent silent upgrade regression

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -193,7 +193,7 @@ export function resolveAckReactionSetting(params: {
     return typeof messages.ackReaction === "string" ? messages.ackReaction.trim() : "";
   }
 
-  return resolveAgentIdentityEmoji(params.cfg, params.agentId);
+  return resolveAgentIdentityEmoji(params.cfg, params.agentId) || "👀";
 }
 
 /**

--- a/tests/unit/config-advanced.test.ts
+++ b/tests/unit/config-advanced.test.ts
@@ -212,7 +212,7 @@ describe('config advanced', () => {
             cfg: {} as any,
             accountId: 'main',
             agentId: 'main',
-        })).toBeUndefined();
+        })).toBe('👀');
     });
 
     it('normalizes legacy learning keys in single-account config', () => {

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -2791,7 +2791,7 @@ describe('inbound-handler', () => {
         }
     });
 
-    it('handleDingTalkMessage does not attach ack reaction when config and agent identity ackReaction are absent', async () => {
+    it('handleDingTalkMessage attaches default ack reaction (👀) when config and agent identity ackReaction are absent', async () => {
         vi.useFakeTimers();
         mockedAxiosPost.mockResolvedValue({ data: { success: true } } as any);
         try {
@@ -2820,7 +2820,15 @@ describe('inbound-handler', () => {
             } as any);
             await vi.advanceTimersByTimeAsync(1200);
 
-            expect(mockedAxiosPost).not.toHaveBeenCalled();
+            expect(mockedAxiosPost).toHaveBeenCalledWith(
+                'https://api.dingtalk.com/v1.0/robot/emotion/reply',
+                expect.objectContaining({
+                    openMsgId: 'm5_default_ackreaction',
+                    openConversationId: 'cid_ok',
+                    emotionName: '👀',
+                }),
+                expect.any(Object),
+            );
         } finally {
             vi.useRealTimers();
         }


### PR DESCRIPTION
## Summary

- v3.3.0 移除了旧版 `showThinking` / `thinkingMessage` 文字提示，改为 `ackReaction` 原生表情反馈。但当用户未配置 `ackReaction` 且 `agents.list[].identity.emoji` 也为空时，`resolveAckReactionSetting` 返回 `undefined`，导致发消息后完全没有任何反馈（既没表情也没文字）
- 在 `resolveAckReactionSetting` 的最终 fallback 处增加 `"👀"` 默认值，确保升级用户开箱即用
- 更新相关单元测试以反映新的默认行为

## 改动

- `src/config.ts`: `resolveAckReactionSetting` 末尾 fallback 从 `resolveAgentIdentityEmoji(...)` 改为 `resolveAgentIdentityEmoji(...) || "👀"`
- `tests/unit/config-advanced.test.ts`: 空配置场景期望值从 `undefined` 改为 `"👀"`
- `tests/unit/inbound-handler.test.ts`: 无配置场景测试改为验证默认 `"👀"` 反馈确实被发送

## Test plan

- [x] 全部 474 个单元测试通过
- [ ] 验证全新安装（无 `ackReaction` 配置）时发消息后收到 👀 表情反馈
- [ ] 验证显式设置 `ackReaction: ""` 时可禁用反馈
- [ ] 验证显式配置 `ackReaction: "🤔"` 等自定义值时正常工作

Closes #359
