### PR TITLE
fix(card): prevent duplicate cards and disable unused block streaming

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -41,7 +41,7 @@ import {
   resolveQuotedMessageById,
 } from "./quote-journal";
 import { getDingTalkRuntime } from "./runtime";
-import { sendBySession, sendMessage, sendProactiveMedia } from "./send-service";
+import { sendBySession, sendMessage, sendProactiveMedia, sendProactiveTextOrMarkdown } from "./send-service";
 import { clearSessionPeerOverride, getSessionPeerOverride, setSessionPeerOverride } from "./session-peer-store";
 import { resolveDingTalkSessionPeer } from "./session-routing";
 import type { DingTalkConfig, HandleDingTalkMessageParams, MediaFile } from "./types";
@@ -1454,9 +1454,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           },
         },
         replyOptions: {
-          disableBlockStreaming: useCardMode
-            ? (dingtalkConfig.cardRealTimeStream && controller ? true : undefined)
-            : true,
+          // Card mode: intermediate blocks are unused — card updates go through
+          // onPartialReply (real-time) or deliver(final) → finishAICard (block-buffered).
+          // Markdown mode: runtime must buffer all blocks and deliver once via deliver(final).
+          // Both modes benefit from disabling block streaming.
+          disableBlockStreaming: true,
 
           onAssistantMessageStart: controller
             ? () => { controller.notifyNewAssistantTurn(); }
@@ -1524,16 +1526,21 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             || currentAICard.lastStreamedContent;
           if (fallbackText) {
             log?.debug?.("[DingTalk] Card failed during streaming, sending markdown fallback");
-            const sendResult = await sendMessage(dingtalkConfig, to, fallbackText, {
-              sessionWebhook,
-              atUserId: !isDirect ? senderId : null,
-              log,
-              accountId,
-              storePath,
-              conversationId: groupId,
-            });
-            if (!sendResult.ok) {
-              throw new Error(sendResult.error || "Markdown fallback send failed after card failure — user received no reply");
+            // Bypass sendMessage to avoid sendProactiveCardText creating a second card.
+            // Use sendBySession when session webhook is available, otherwise fall back
+            // to sendProactiveTextOrMarkdown which always sends markdown/text.
+            if (sessionWebhook) {
+              await sendBySession(dingtalkConfig, sessionWebhook, fallbackText, {
+                atUserId: !isDirect ? senderId : null,
+                log,
+              });
+            } else {
+              await sendProactiveTextOrMarkdown(
+                { ...dingtalkConfig, messageType: "markdown" },
+                to,
+                fallbackText,
+                { atUserId: !isDirect ? senderId : null, log, accountId, storePath, conversationId: groupId },
+              );
             }
           } else {
             log?.debug?.("[DingTalk] Card failed but no content to fallback with");

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -3684,11 +3684,12 @@ describe('inbound-handler', () => {
         const debugLogs = log.debug.mock.calls.map((args: unknown[]) => String(args[0]));
         expect(debugLogs.some((msg) => msg.includes('Card failed during streaming, sending markdown fallback'))).toBe(true);
 
-        const fallbackCalls = shared.sendMessageMock.mock.calls.filter(
-            (call: any[]) => !call[3]?.card && !call[3]?.cardUpdateMode
-        );
-        expect(fallbackCalls.length).toBeGreaterThanOrEqual(1);
-        expect(fallbackCalls[0][2]).toBe('complete final answer');
+        // Fallback now uses sendBySession directly (bypassing sendMessage to avoid
+        // sendProactiveCardText creating a second card).
+        expect(shared.sendBySessionMock).toHaveBeenCalled();
+        const sessionCalls = shared.sendBySessionMock.mock.calls;
+        const fallbackCall = sessionCalls.find((call: any[]) => call[2] === 'complete final answer');
+        expect(fallbackCall).toBeTruthy();
     });
 
     it('acquires session lock with the resolved sessionKey', async () => {


### PR DESCRIPTION
## Summary

- **Always set `disableBlockStreaming: true`** — in card mode, intermediate blocks from the runtime are silently discarded (card updates go through `onPartialReply` or `deliver(final)` → `finishAICard`). Leaving it as `undefined` when `cardRealTimeStream: false` (default) caused unnecessary deliver callbacks with no effect.
- **Prevent duplicate cards on fallback** — when a card fails mid-stream, the Step 5 fallback previously called `sendMessage` without a `card` reference, which internally routed to `sendProactiveCardText` and created a second card. Now bypasses `sendMessage` entirely: uses `sendBySession` when session webhook is available, otherwise `sendProactiveTextOrMarkdown` with `messageType` forced to `"markdown"`.

Closes the regression where a single inbound message could produce multiple cards.

## Test plan

- [x] 475 unit/integration tests all pass
- [ ] Card mode + `cardRealTimeStream: true` — streaming works normally, single card
- [ ] Card mode + `cardRealTimeStream: false` (default) — single card, finalized correctly
- [ ] Card stream failure mid-reply — fallback sends markdown text, no duplicate card
- [ ] Markdown mode — behavior unchanged, single message