### PR TITLE
feat: add cardAtSender option to @mention sender after card finalization

### DIFF
--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -132,9 +132,10 @@ const DingTalkAccountConfigShape = {
   /** Whether to convert markdown tables to plain text for better rendering on some clients (default: true) */
   convertMarkdownTables: z.boolean().optional().default(true),
 
-  /** Whether to @mention the sender after card finalization in group chats (default: false).
-   *  Useful when AI response takes a while — the @mention triggers a notification so the sender doesn't miss the reply. */
-  cardAtSender: z.boolean().optional().default(false),
+  /** @mention the sender after card finalization in group chats.
+   *  Set to a non-empty string (e.g. "✅ 回复完成") to enable — the value is used as the message text.
+   *  Leave empty or omit to disable. */
+  cardAtSender: z.string().optional(),
 } as const;
 
 const DingTalkAccountConfigSchema = z.object(DingTalkAccountConfigShape);

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1556,14 +1556,16 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
         // In group chats, send a lightweight @mention via session webhook
         // so the sender gets a notification — card API doesn't support @mention.
-        if (!isDirect && senderId && sessionWebhook && dingtalkConfig.cardAtSender) {
+        const cardAtSenderText = (dingtalkConfig.cardAtSender || "").trim();
+        if (!isDirect && senderId && sessionWebhook && cardAtSenderText) {
           try {
-            await sendBySession(dingtalkConfig, sessionWebhook, `@${senderId}`, {
+            await sendBySession(dingtalkConfig, sessionWebhook, cardAtSenderText, {
               atUserId: senderId,
               log,
             });
-          } catch (atErr: any) {
-            log?.debug?.(`[DingTalk] Post-card @mention send failed: ${atErr.message}`);
+          } catch (atErr: unknown) {
+            const msg = atErr instanceof Error ? atErr.message : String(atErr);
+            log?.debug?.(`[DingTalk] Post-card @mention send failed: ${msg}`);
           }
         }
       } catch (err: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,8 +89,8 @@ export interface DingTalkConfig extends OpenClawConfig {
   feedbackLearningNoteTtlMs?: number;
   /** Whether to convert markdown tables to plain text for better rendering on some clients (default: true) */
   convertMarkdownTables?: boolean;
-  /** Whether to @mention the sender after card finalization in group chats (default: false) */
-  cardAtSender?: boolean;
+  /** @mention the sender after card finalization in group chats; value is the message text */
+  cardAtSender?: string;
 }
 
 /**
@@ -154,8 +154,8 @@ export interface DingTalkChannelConfig {
   feedbackLearningNoteTtlMs?: number;
   /** Whether to convert markdown tables to plain text for better rendering on some clients (default: true) */
   convertMarkdownTables?: boolean;
-  /** Whether to @mention the sender after card finalization in group chats (default: false) */
-  cardAtSender?: boolean;
+  /** @mention the sender after card finalization in group chats; value is the message text */
+  cardAtSender?: string;
 }
 
 /**

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -3919,7 +3919,7 @@ describe('inbound-handler', () => {
             accountId: 'main',
             sessionWebhook: 'https://session.webhook',
             log: undefined,
-            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: true } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: '✅ 回复完成' } as any,
             data: {
                 msgId: 'mid_at_group', msgtype: 'text', text: { content: 'hello' },
                 conversationType: '2', conversationId: 'cid_group_1', senderId: 'user_1',
@@ -3976,7 +3976,7 @@ describe('inbound-handler', () => {
             accountId: 'main',
             sessionWebhook: 'https://session.webhook',
             log: undefined,
-            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: true } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: '✅ 回复完成' } as any,
             data: {
                 msgId: 'mid_at_dm', msgtype: 'text', text: { content: 'hello' },
                 conversationType: '1', conversationId: 'cid_ok', senderId: 'user_1',
@@ -4005,7 +4005,7 @@ describe('inbound-handler', () => {
             accountId: 'main',
             sessionWebhook: 'https://session.webhook',
             log: undefined,
-            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: true } as any,
+            dingtalkConfig: { dmPolicy: 'open', messageType: 'card', cardAtSender: '✅ 回复完成' } as any,
             data: {
                 msgId: 'mid_at_err', msgtype: 'text', text: { content: 'hello' },
                 conversationType: '2', conversationId: 'cid_group_1', senderId: 'user_1',


### PR DESCRIPTION
## Background

Card 模式提供了流式输出体验，但 AI 响应时间有时较长（几十秒甚至更久），用户在群聊中往往会切走去做别的事。Markdown 模式下每条回复自带 @sender 通知，用户能及时看到；而 card 模式因为钉钉 card API 本身不支持 `atOpenIds`/@mention，回复完成后用户收不到任何通知，很容易错过 AI 的回复。

## Summary

- 新增 `cardAtSender` 配置项（默认 `false`），开启后在 card finalize 成功后通过 session webhook 补发一条 @sender 消息触发通知
- 仅群聊生效，单聊不触发；@mention 失败不影响主流程

## Test plan

- [x] `cardAtSender: true` + 群聊 → 发送 @mention
- [x] `cardAtSender: false`（默认）→ 不发送
- [x] `cardAtSender: true` + 单聊 → 不发送
- [x] @mention 发送失败 → card finalize 不受影响
- [x] 线上验证效果（截图确认 @mention 通知正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)