### PR TITLE
fix: unify message context journaling scope

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -877,7 +877,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   if (data.text?.isReplyMsg && data.originalMsgId && !hasConcreteQuotedPayload) {
     try {
       const quoted = resolveByMsgId({
-        storePath,
+        storePath: accountStorePath,
         accountId,
         conversationId: groupId,
         msgId: data.originalMsgId,
@@ -900,7 +900,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
   try {
     upsertInboundMessageContext({
-      storePath,
+      storePath: accountStorePath,
       accountId,
       conversationId: groupId,
       msgId: data.msgId,
@@ -929,7 +929,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // Cache downloadCode (+ spaceId/fileId) for quoted file lookups (DM + group).
   if (content.mediaPath && data.msgId) {
     upsertInboundMessageContext({
-      storePath,
+      storePath: accountStorePath,
       accountId,
       conversationId: data.conversationId,
       msgId: data.msgId,
@@ -954,7 +954,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     content.docFileId
   ) {
     upsertInboundMessageContext({
-      storePath,
+      storePath: accountStorePath,
       accountId,
       conversationId: data.conversationId,
       msgId: data.msgId,
@@ -996,7 +996,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       return null;
     }
     const cached = resolveByMsgId({
-      storePath,
+      storePath: accountStorePath,
       accountId,
       conversationId: data.conversationId,
       msgId: quotedMsgId,
@@ -1068,7 +1068,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         fileResolved = true;
         if (content.quoted.msgId) {
           upsertInboundMessageContext({
-            storePath,
+            storePath: accountStorePath,
             accountId,
             conversationId: data.conversationId,
             msgId: content.quoted.msgId,
@@ -1129,7 +1129,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         content.text = content.text.replace(content.quoted.prefix, "[引用了钉钉文档]\n\n");
         if (content.quoted.msgId) {
           upsertInboundMessageContext({
-            storePath,
+            storePath: accountStorePath,
             accountId,
             conversationId: data.conversationId,
             msgId: content.quoted.msgId,
@@ -1354,6 +1354,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             {
               accountId,
               log,
+              storePath: accountStorePath,
+              conversationId: to,
             },
           );
           if (!sendResult.ok) {
@@ -1398,7 +1400,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       senderId,
       isDirect,
       accountId,
-      storePath,
+      storePath: accountStorePath,
       groupId,
       log,
       deliverMedia: deliverMediaAttachments,

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -1206,10 +1206,10 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/agent-store.json')
             .mockReturnValueOnce('/tmp/account-store.json')
             .mockReturnValueOnce('/tmp/agent-store.json')
-            .mockReturnValueOnce('/tmp/account-store.json');
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json');
         shared.getRuntimeMock.mockReturnValue(runtime);
         shared.extractMessageContentMock
             .mockReturnValueOnce({
@@ -1329,8 +1329,8 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/agent-store.json')
-            .mockReturnValueOnce('/tmp/account-store.json');
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json');
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
 
         await handleDingTalkMessage({
@@ -1370,8 +1370,8 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/dm-agent-store.json')
-            .mockReturnValueOnce('/tmp/dm-account-store.json');
+            .mockReturnValueOnce('/tmp/dm-account-store.json')
+            .mockReturnValueOnce('/tmp/dm-agent-store.json');
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
         shared.extractMessageContentMock.mockReturnValueOnce({
             text: '[这是一条引用消息，原消息ID: orig_msg_001]\n\nhello',
@@ -1410,6 +1410,7 @@ describe('inbound-handler', () => {
 
         expect(mockedResolveByMsgId).toHaveBeenCalledWith(
             expect.objectContaining({
+                storePath: '/tmp/dm-account-store.json',
                 accountId: 'main',
                 conversationId: 'cid_ok',
                 msgId: 'orig_msg_001',
@@ -1424,8 +1425,8 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/dm-agent-store.json')
-            .mockReturnValueOnce('/tmp/dm-account-store.json');
+            .mockReturnValueOnce('/tmp/dm-account-store.json')
+            .mockReturnValueOnce('/tmp/dm-agent-store.json');
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
         shared.extractMessageContentMock.mockReturnValueOnce({
             text: '[引用消息: "历史原文"]\n\n真正正文',
@@ -1453,6 +1454,7 @@ describe('inbound-handler', () => {
 
         expect(mockedUpsertInboundMessageContext).toHaveBeenCalledWith(
             expect.objectContaining({
+                storePath: '/tmp/dm-account-store.json',
                 text: '真正正文',
             }),
         );
@@ -1462,8 +1464,8 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/dm-agent-store.json')
-            .mockReturnValueOnce('/tmp/dm-account-store.json');
+            .mockReturnValueOnce('/tmp/dm-account-store.json')
+            .mockReturnValueOnce('/tmp/dm-agent-store.json');
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
 
         await handleDingTalkMessage({
@@ -1487,6 +1489,7 @@ describe('inbound-handler', () => {
 
         expect(mockedUpsertInboundMessageContext).toHaveBeenCalledWith(
             expect.objectContaining({
+                storePath: '/tmp/dm-account-store.json',
                 conversationId: 'cid_dm_stable',
             }),
         );
@@ -1501,8 +1504,8 @@ describe('inbound-handler', () => {
         const runtime = buildRuntime();
         runtime.channel.session.resolveStorePath = vi
             .fn()
-            .mockReturnValueOnce('/tmp/dm-agent-store.json')
-            .mockReturnValueOnce('/tmp/dm-account-store.json');
+            .mockReturnValueOnce('/tmp/dm-account-store.json')
+            .mockReturnValueOnce('/tmp/dm-agent-store.json');
         shared.getRuntimeMock.mockReturnValueOnce(runtime);
         shared.extractMessageContentMock.mockReturnValueOnce({
             text: '我在讨论字符串 [引用消息:] 本身',
@@ -1542,11 +1545,21 @@ describe('inbound-handler', () => {
         const envelopeArg = (runtime.channel.reply.formatInboundEnvelope as any).mock.calls[0]?.[0];
         expect(envelopeArg.body).toContain('[引用消息: "被引用原文"]');
         expect(mockedResolveByMsgId).toHaveBeenCalledWith(
-            expect.objectContaining({ msgId: 'orig_msg_literal' }),
+            expect.objectContaining({
+                storePath: '/tmp/dm-account-store.json',
+                msgId: 'orig_msg_literal',
+            }),
         );
     });
 
     it('handleDingTalkMessage runs non-card flow and sends thinking + final outputs', async () => {
+        const runtime = buildRuntime();
+        runtime.channel.session.resolveStorePath = vi
+            .fn()
+            .mockReturnValueOnce('/tmp/account-store.json')
+            .mockReturnValueOnce('/tmp/agent-store.json');
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
         await handleDingTalkMessage({
             cfg: {},
             accountId: 'main',
@@ -1567,6 +1580,12 @@ describe('inbound-handler', () => {
         } as any);
 
         expect(shared.sendMessageMock).toHaveBeenCalled();
+        expect(shared.sendMessageMock).toHaveBeenCalledWith(
+            expect.anything(),
+            'user_1',
+            expect.any(String),
+            expect.objectContaining({ storePath: '/tmp/account-store.json' }),
+        );
     });
 
     it('handleDingTalkMessage restores quoted card by originalProcessQueryKey', async () => {
@@ -2526,7 +2545,11 @@ describe('inbound-handler', () => {
             'user_1',
             '/tmp/prepared/report.pdf',
             'file',
-            expect.objectContaining({ accountId: 'main' }),
+            expect.objectContaining({
+                accountId: 'main',
+                storePath: '/tmp/store.json',
+                conversationId: 'user_1',
+            }),
         );
     });
 


### PR DESCRIPTION
## 背景
这是对原 PR #364 的 follow-up 修复。

PR #364 引入了统一的 `message-context-store` 能力，但在实际运行中，`message-context` 的持久化作用域仍然发生了分裂：
- 入站消息上下文写入 routed agent 对应的 `storePath`
- AI Card 出站消息上下文、quoted card 查找等逻辑使用 account 级 `storePath`

结果就是同一个 DingTalk 会话的 `messages.context` 被拆散到了不同文件里，表现为“看到入站消息，但看不到卡片出站消息”。

这里最关键的分析是：`message context` 的语义更接近“渠道消息事实”，天然主键是 `accountId + conversationId + msgId/processQueryKey`，而不是 `route.agentId`。`route.agentId` 是会话路由结果，会因为 peer override、binding 或后续路由策略变化而变化；但同一条 DingTalk 消息的引用关系、卡片 tracking 信息、quoted 恢复能力不应该随着路由漂移。与此同时，AI Card callback、pending card recovery、feedback 关联等链路本身也是按 account 维度运行的，很多时候并没有稳定且必要的 routed agent 语义。因此，`message-context-store` 更合理的归属是 `accountStorePath`：它应该作为账号下共享的渠道消息上下文层存在，而不是某个 routed agent 私有的 session 状态。

## 本次修复
本 PR 只做最小闭环修复，不调整 session / routing 的 agent 级作用域，只统一 `message-context-store` 这一类渠道消息事实数据的作用域。

具体包括：
- 将入站 `message-context` 的读写统一到 account 级 `storePath`
- 将 inbound reply 链路中的出站 journaling 统一到 account 级 `storePath`
- 为 proactive media reply 补齐 account 级 journaling 所需的 `storePath` / `conversationId`

## 为什么这样修
这样可以修复 `messages.context` 被 agent 路由拆分的问题，同时避免扩大改动范围：
- 不改 `route.agentId` 的 session 路由语义
- 不改 session transcript / agent 私有状态的落盘位置
- 只把 `message-context-store` 统一到账户级作用域，与现有的 card recovery、feedback、quoted card lookup 保持一致

## 验证
已执行：
- `pnpm vitest run tests/unit/inbound-handler.test.ts`
- `pnpm vitest run tests/unit/message-context-store.test.ts tests/unit/card-service.test.ts tests/unit/send-service-advanced.test.ts tests/integration/send-lifecycle.test.ts`
- `npm run type-check`