### PR TITLE
fix(dingtalk): 限制 main 会话默认路由只被 owner 接管

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -90,6 +90,20 @@ const MIN_THINKING_REACTION_VISIBLE_MS = 1200;
 const ATTACHMENT_TEXT_PREFIX = "[附件内容摘录]";
 const proactiveHintLastSentAt = new Map<string, number>();
 
+function resolvePinnedMainDmOwner(params: {
+  dmScope?: string;
+  allowFrom?: string[];
+}): string | null {
+  if ((params.dmScope ?? "main") !== "main") {
+    return null;
+  }
+  const allow = normalizeAllowFrom(params.allowFrom);
+  if (allow.hasWildcard) {
+    return null;
+  }
+  return allow.entries.length === 1 ? allow.entries[0] : null;
+}
+
 function ttlDaysToMs(ttlDays: number | undefined): number | undefined {
   if (typeof ttlDays !== "number" || !Number.isFinite(ttlDays) || ttlDays <= 0) {
     return undefined;
@@ -1423,7 +1437,27 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     storePath,
     sessionKey: ctx.SessionKey || route.sessionKey,
     ctx,
-    updateLastRoute: { sessionKey: route.mainSessionKey, channel: "dingtalk", to, accountId },
+    updateLastRoute: (() => {
+      if (!isDirect) {
+        return undefined;
+      }
+      const pinnedMainDmOwner = resolvePinnedMainDmOwner({
+        dmScope: cfg.session?.dmScope,
+        allowFrom: dingtalkConfig.allowFrom,
+      });
+      const senderRecipient = (senderOriginalId || senderId || "").trim().toLowerCase();
+      if (
+        pinnedMainDmOwner
+        && senderRecipient
+        && pinnedMainDmOwner.trim().toLowerCase() !== senderRecipient
+      ) {
+        log?.debug?.(
+          `[DingTalk] Skipping main-session last route update for ${senderRecipient} (pinned owner ${pinnedMainDmOwner})`,
+        );
+        return undefined;
+      }
+      return { sessionKey: route.mainSessionKey, channel: "dingtalk", to, accountId };
+    })(),
     onRecordError: (err: unknown) => {
       log?.error?.(`[DingTalk] Failed to record inbound session: ${String(err)}`);
     },
@@ -1610,4 +1644,3 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
   }
 }
-

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -3855,6 +3855,121 @@ describe("inbound-handler", () => {
     expect(sentTexts.some((text: string) => text.includes("思考中"))).toBe(false);
   });
 
+  it("does not update the main-session last route for group inbound messages", async () => {
+    const runtime = buildRuntime();
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        groupPolicy: "allowlist",
+        allowFrom: ["cid_group_1"],
+        messageType: "markdown",
+        ackReaction: "",
+      } as any,
+      data: {
+        msgId: "m_group_last_route",
+        msgtype: "text",
+        text: { content: "hello group" },
+        conversationType: "2",
+        conversationId: "cid_group_1",
+        conversationTitle: "group-title",
+        senderId: "user_1",
+        senderNick: "Alice",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as any);
+
+    expect(runtime.channel.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "s1",
+        updateLastRoute: undefined,
+      }),
+    );
+  });
+
+  it("does not update the main-session last route for non-owner direct messages when a main owner is pinned", async () => {
+    const runtime = buildRuntime();
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: { session: { dmScope: "main" } },
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        allowFrom: ["owner_user"],
+        messageType: "markdown",
+        ackReaction: "",
+      } as any,
+      data: {
+        msgId: "m_dm_non_owner_last_route",
+        msgtype: "text",
+        text: { content: "hello direct" },
+        conversationType: "1",
+        conversationId: "cid_ok",
+        senderId: "other_user",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as any);
+
+    expect(runtime.channel.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "s1",
+        updateLastRoute: undefined,
+      }),
+    );
+  });
+
+  it("updates the main-session last route for the pinned owner direct message", async () => {
+    const runtime = buildRuntime();
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: { session: { dmScope: "main" } },
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        allowFrom: ["owner_user"],
+        messageType: "markdown",
+        ackReaction: "",
+      } as any,
+      data: {
+        msgId: "m_dm_owner_last_route",
+        msgtype: "text",
+        text: { content: "hello owner" },
+        conversationType: "1",
+        conversationId: "cid_ok",
+        senderId: "owner_user",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as any);
+
+    expect(runtime.channel.session.recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "s1",
+        updateLastRoute: {
+          sessionKey: "s1",
+          channel: "dingtalk",
+          to: "owner_user",
+          accountId: "main",
+        },
+      }),
+    );
+  });
+
   it("handleDingTalkMessage ignores thinking and tool card updates when card is already finalized", async () => {
     const runtime = buildRuntime();
     runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi


### PR DESCRIPTION
## 背景
当前 DingTalk 的 main 会话会把最近一次入站会话写入 `lastRoute`。这会带来明显的隐私风险：

- 任意群聊里的最近一条消息，可能把 main 会话的默认回复目标悄悄改成这个群
- 如果机器人被多人私聊，在已经实际固定 owner 的情况下，其他私聊用户也可能把 main 会话默认路由抢走
- 这样会导致本来属于 main 会话的回复，被错误发到无关群聊或无关私聊里

这类默认路由漂移不应该发生。除非明确指定，否则 main 会话不应把消息导入任意群聊。

## 改动
- 群聊入站消息不再更新 main 会话的 `lastRoute`
- 当 `session.dmScope = main` 且 `allowFrom` 可以明确推导出唯一 owner 时，只有这个 owner 的私聊消息可以更新 main 会话的默认路由
- 如果当前配置里没有唯一 owner，则保持原有行为，不强行引入破坏性限制

## 为什么重要
这是一个隐私边界问题，不只是体验问题。

main 会话通常承载的是默认上下文和默认回复出口。如果任何最近活跃的会话都能接管这条默认路由，机器人就可能把本该发给 owner 的内容发送到无关会话，尤其是群聊。这种行为在共享机器人场景下风险很高。

## 测试
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run tests/unit/inbound-handler.test.ts -t 'does not update the main-session last route for group inbound messages|does not update the main-session last route for non-owner direct messages when a main owner is pinned|updates the main-session last route for the pinned owner direct message'`
