### PR TITLE
refactor(dingtalk): 抽离入站命令分发逻辑

### DIFF
--- a/src/command/inbound-command-dispatch-service.ts
+++ b/src/command/inbound-command-dispatch-service.ts
@@ -1,0 +1,464 @@
+import {
+  applyManualGlobalLearningRule,
+  applyManualSessionLearningNote,
+  applyManualTargetLearningRule,
+  applyManualTargetsLearningRule,
+  applyTargetSetLearningRule,
+  createOrUpdateTargetSet,
+  deleteManualRule,
+  disableManualRule,
+  listLearningTargetSets,
+  listScopedLearningRules,
+  resolveManualForcedReply,
+} from "../feedback-learning-service";
+import {
+  formatLearnAppliedReply,
+  formatLearnCommandHelp,
+  formatLearnDeletedReply,
+  formatLearnDisabledReply,
+  formatLearnListReply,
+  formatOwnerOnlyDeniedReply,
+  formatOwnerStatusReply,
+  formatTargetSetSavedReply,
+  formatWhereAmIReply,
+  formatWhoAmIReply,
+  isLearningOwner,
+  parseLearnCommand,
+} from "../learning-command-service";
+import {
+  formatSessionAliasBoundReply,
+  formatSessionAliasClearedReply,
+  formatSessionAliasReply,
+  formatSessionAliasSetReply,
+  formatSessionAliasUnboundReply,
+  formatSessionAliasValidationErrorReply,
+  parseSessionCommand,
+  validateSessionAlias,
+} from "../session-command-service";
+import type { SessionPeerSourceKind } from "../session-peer-store";
+import type { DingTalkConfig, HandleDingTalkMessageParams, MessageContent } from "../types";
+
+type InboundCommandDispatchParams = {
+  cfg: HandleDingTalkMessageParams["cfg"];
+  accountId: string;
+  dingtalkConfig: DingTalkConfig;
+  senderId: string;
+  isDirect: boolean;
+  extractedText: string;
+  messageType: MessageContent["messageType"];
+  data: {
+    conversationId: string;
+    senderId?: string;
+    senderStaffId?: string;
+  };
+  accountStorePath: string;
+  currentSessionSourceKind: SessionPeerSourceKind;
+  currentSessionSourceId: string;
+  peerIdOverride?: string;
+  sessionPeer: {
+    peerId: string;
+  };
+  sendReply: (text: string) => Promise<void>;
+  clearSessionPeerOverride: (params: {
+    storePath: string;
+    accountId: string;
+    sourceKind: SessionPeerSourceKind;
+    sourceId: string;
+  }) => boolean;
+  setSessionPeerOverride: (params: {
+    storePath: string;
+    accountId: string;
+    sourceKind: SessionPeerSourceKind;
+    sourceId: string;
+    peerId: string;
+  }) => void;
+};
+
+export async function handleInboundCommandDispatch(
+  params: InboundCommandDispatchParams,
+): Promise<boolean> {
+  const parsedLearnCommand = parseLearnCommand(params.extractedText);
+  const parsedSessionCommand = parseSessionCommand(params.extractedText);
+  const isOwner = isLearningOwner({
+    cfg: params.cfg,
+    config: params.dingtalkConfig,
+    senderId: params.senderId,
+    rawSenderId: params.data.senderId,
+  });
+
+  if (params.isDirect && parsedLearnCommand.scope === "whoami") {
+    await params.sendReply(
+      formatWhoAmIReply({
+        senderId: params.senderId,
+        rawSenderId: params.data.senderId,
+        senderStaffId: params.data.senderStaffId,
+        isOwner,
+      }),
+    );
+    return true;
+  }
+
+  if (parsedLearnCommand.scope === "whereami") {
+    await params.sendReply(
+      formatWhereAmIReply({
+        conversationId: params.data.conversationId,
+        conversationType: params.isDirect ? "dm" : "group",
+        peerId: params.sessionPeer.peerId,
+      }),
+    );
+    return true;
+  }
+
+  if (params.isDirect && parsedLearnCommand.scope === "owner-status") {
+    await params.sendReply(
+      formatOwnerStatusReply({
+        senderId: params.senderId,
+        rawSenderId: params.data.senderId,
+        isOwner,
+      }),
+    );
+    return true;
+  }
+
+  if (parsedLearnCommand.scope === "help") {
+    await params.sendReply(formatLearnCommandHelp());
+    return true;
+  }
+
+  if (
+    (parsedLearnCommand.scope === "global" ||
+      parsedLearnCommand.scope === "session" ||
+      parsedLearnCommand.scope === "here" ||
+      parsedLearnCommand.scope === "target" ||
+      parsedLearnCommand.scope === "targets" ||
+      parsedLearnCommand.scope === "list" ||
+      parsedLearnCommand.scope === "disable" ||
+      parsedLearnCommand.scope === "delete" ||
+      parsedLearnCommand.scope === "target-set-create" ||
+      parsedLearnCommand.scope === "target-set-apply" ||
+      parsedSessionCommand.scope === "session-alias-show" ||
+      parsedSessionCommand.scope === "session-alias-set" ||
+      parsedSessionCommand.scope === "session-alias-clear" ||
+      parsedSessionCommand.scope === "session-alias-bind" ||
+      parsedSessionCommand.scope === "session-alias-unbind") &&
+    !isOwner
+  ) {
+    await params.sendReply(formatOwnerOnlyDeniedReply());
+    return true;
+  }
+
+  if (isOwner) {
+    if (parsedSessionCommand.scope === "session-alias-show") {
+      await params.sendReply(
+        formatSessionAliasReply({
+          sourceKind: params.currentSessionSourceKind,
+          sourceId: params.currentSessionSourceId,
+          peerId: params.sessionPeer.peerId,
+          aliasSource: params.peerIdOverride ? "override" : "default",
+        }),
+      );
+      return true;
+    }
+
+    if (parsedSessionCommand.scope === "session-alias-set" && parsedSessionCommand.peerId) {
+      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
+      if (aliasValidationError) {
+        await params.sendReply(formatSessionAliasValidationErrorReply(aliasValidationError));
+        return true;
+      }
+      params.setSessionPeerOverride({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        sourceKind: params.currentSessionSourceKind,
+        sourceId: params.currentSessionSourceId,
+        peerId: parsedSessionCommand.peerId,
+      });
+      await params.sendReply(
+        formatSessionAliasSetReply({
+          sourceKind: params.currentSessionSourceKind,
+          sourceId: params.currentSessionSourceId,
+          peerId: parsedSessionCommand.peerId,
+        }),
+      );
+      return true;
+    }
+
+    if (parsedSessionCommand.scope === "session-alias-clear") {
+      params.clearSessionPeerOverride({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        sourceKind: params.currentSessionSourceKind,
+        sourceId: params.currentSessionSourceId,
+      });
+      await params.sendReply(
+        formatSessionAliasClearedReply({
+          sourceKind: params.currentSessionSourceKind,
+          sourceId: params.currentSessionSourceId,
+        }),
+      );
+      return true;
+    }
+
+    if (
+      parsedSessionCommand.scope === "session-alias-bind" &&
+      parsedSessionCommand.sourceKind &&
+      parsedSessionCommand.sourceId &&
+      parsedSessionCommand.peerId
+    ) {
+      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
+      if (aliasValidationError) {
+        await params.sendReply(formatSessionAliasValidationErrorReply(aliasValidationError));
+        return true;
+      }
+      params.setSessionPeerOverride({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        sourceKind: parsedSessionCommand.sourceKind,
+        sourceId: parsedSessionCommand.sourceId,
+        peerId: parsedSessionCommand.peerId,
+      });
+      await params.sendReply(
+        formatSessionAliasBoundReply({
+          sourceKind: parsedSessionCommand.sourceKind,
+          sourceId: parsedSessionCommand.sourceId,
+          peerId: parsedSessionCommand.peerId,
+        }),
+      );
+      return true;
+    }
+
+    if (
+      parsedSessionCommand.scope === "session-alias-unbind" &&
+      parsedSessionCommand.sourceKind &&
+      parsedSessionCommand.sourceId
+    ) {
+      const existed = params.clearSessionPeerOverride({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        sourceKind: parsedSessionCommand.sourceKind,
+        sourceId: parsedSessionCommand.sourceId,
+      });
+      await params.sendReply(
+        formatSessionAliasUnboundReply({
+          sourceKind: parsedSessionCommand.sourceKind,
+          sourceId: parsedSessionCommand.sourceId,
+          existed,
+        }),
+      );
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "global" && parsedLearnCommand.instruction) {
+      const applied = applyManualGlobalLearningRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        formatLearnAppliedReply({
+          scope: "global",
+          instruction: parsedLearnCommand.instruction,
+          ruleId: applied?.ruleId,
+        }),
+      );
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "session" && parsedLearnCommand.instruction) {
+      applyManualSessionLearningNote({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        targetId: params.data.conversationId,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        formatLearnAppliedReply({
+          scope: "session",
+          instruction: parsedLearnCommand.instruction,
+        }),
+      );
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "here" && parsedLearnCommand.instruction) {
+      const applied = applyManualTargetLearningRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        targetId: params.data.conversationId,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        formatLearnAppliedReply({
+          scope: "target",
+          targetId: params.data.conversationId,
+          instruction: parsedLearnCommand.instruction,
+          ruleId: applied?.ruleId,
+        }),
+      );
+      return true;
+    }
+
+    if (
+      parsedLearnCommand.scope === "target" &&
+      parsedLearnCommand.targetId &&
+      parsedLearnCommand.instruction
+    ) {
+      const applied = applyManualTargetLearningRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        targetId: parsedLearnCommand.targetId,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        formatLearnAppliedReply({
+          scope: "target",
+          targetId: parsedLearnCommand.targetId,
+          instruction: parsedLearnCommand.instruction,
+          ruleId: applied?.ruleId,
+        }),
+      );
+      return true;
+    }
+
+    if (
+      parsedLearnCommand.scope === "targets" &&
+      parsedLearnCommand.targetIds?.length &&
+      parsedLearnCommand.instruction
+    ) {
+      const applied = applyManualTargetsLearningRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        targetIds: parsedLearnCommand.targetIds,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        formatLearnAppliedReply({
+          scope: "targets",
+          targetIds: parsedLearnCommand.targetIds,
+          instruction: parsedLearnCommand.instruction,
+          ruleId: applied[0]?.ruleId,
+        }),
+      );
+      return true;
+    }
+
+    if (
+      parsedLearnCommand.scope === "target-set-create" &&
+      parsedLearnCommand.setName &&
+      parsedLearnCommand.targetIds?.length
+    ) {
+      const saved = createOrUpdateTargetSet({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        name: parsedLearnCommand.setName,
+        targetIds: parsedLearnCommand.targetIds,
+      });
+      await params.sendReply(
+        saved
+          ? formatTargetSetSavedReply({
+              setName: parsedLearnCommand.setName,
+              targetIds: parsedLearnCommand.targetIds,
+            })
+          : "目标组保存失败，请检查名称和目标列表。",
+      );
+      return true;
+    }
+
+    if (
+      parsedLearnCommand.scope === "target-set-apply" &&
+      parsedLearnCommand.setName &&
+      parsedLearnCommand.instruction
+    ) {
+      const applied = applyTargetSetLearningRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        name: parsedLearnCommand.setName,
+        instruction: parsedLearnCommand.instruction,
+      });
+      await params.sendReply(
+        applied.length > 0
+          ? formatLearnAppliedReply({
+              scope: "target-set",
+              setName: parsedLearnCommand.setName,
+              targetIds: applied.map((item) => item.targetId),
+              instruction: parsedLearnCommand.instruction,
+              ruleId: applied[0]?.ruleId,
+            })
+          : `未找到目标组 \`${parsedLearnCommand.setName}\`，或该目标组为空。`,
+      );
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "list") {
+      const rules = listScopedLearningRules({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+      })
+        .slice(0, 20)
+        .map((rule) => {
+          const scope = rule.scope === "target" ? `target(${rule.targetId})` : "global";
+          const status = rule.enabled ? "enabled" : "disabled";
+          return `- [${scope}] ${rule.ruleId} (${status}) => ${rule.instruction}`;
+        });
+      const targetSets = listLearningTargetSets({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+      })
+        .slice(0, 10)
+        .map((targetSet) => `- [target-set] ${targetSet.name} => ${targetSet.targetIds.join(", ")}`);
+      await params.sendReply(formatLearnListReply([...rules, ...targetSets]));
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "disable" && parsedLearnCommand.ruleId) {
+      const result = disableManualRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        ruleId: parsedLearnCommand.ruleId,
+      });
+      await params.sendReply(
+        formatLearnDisabledReply({
+          ruleId: parsedLearnCommand.ruleId,
+          existed: result.existed,
+          scope: result.scope,
+          targetId: result.targetId,
+        }),
+      );
+      return true;
+    }
+
+    if (parsedLearnCommand.scope === "delete" && parsedLearnCommand.ruleId) {
+      const result = deleteManualRule({
+        storePath: params.accountStorePath,
+        accountId: params.accountId,
+        ruleId: parsedLearnCommand.ruleId,
+      });
+      await params.sendReply(
+        formatLearnDeletedReply({
+          ruleId: parsedLearnCommand.ruleId,
+          existed: result.existed,
+          scope: result.scope,
+          targetId: result.targetId,
+        }),
+      );
+      return true;
+    }
+  }
+
+  const forcedContent: MessageContent = {
+    text: params.extractedText,
+    messageType: params.messageType,
+  };
+  const manualForcedReply = resolveManualForcedReply({
+    storePath: params.accountStorePath,
+    accountId: params.accountId,
+    targetId: params.data.conversationId,
+    content: forcedContent,
+  });
+  if (manualForcedReply) {
+    await params.sendReply(manualForcedReply);
+    return true;
+  }
+
+  return false;
+}

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -8,6 +8,7 @@ import { createDynamicAckReactionController } from "./ack-reaction/dynamic-ack-r
 import { extractAttachmentText } from "./attachment-text-extractor";
 import { getAccessToken } from "./auth";
 import { createAICard, finishAICard, isCardInTerminalState } from "./card-service";
+import { handleInboundCommandDispatch } from "./command/inbound-command-dispatch-service";
 import { resolveAckReactionSetting, resolveGroupConfig, resolveRobotCode } from "./config";
 import { AICardStatus } from "./types";
 import {
@@ -16,35 +17,10 @@ import {
   removeCardRun,
 } from "./card/card-run-registry";
 import {
-  applyManualTargetLearningRule,
-  applyManualTargetsLearningRule,
-  applyManualGlobalLearningRule,
-  applyManualSessionLearningNote,
-  applyTargetSetLearningRule,
   buildLearningContextBlock,
-  createOrUpdateTargetSet,
-  deleteManualRule,
-  disableManualRule,
   isLearningEnabled,
-  listLearningTargetSets,
-  listScopedLearningRules,
-  resolveManualForcedReply,
 } from "./feedback-learning-service";
 import { formatGroupMembers, noteGroupMember } from "./targeting/group-members-store";
-import {
-  formatLearnAppliedReply,
-  formatLearnCommandHelp,
-  formatLearnDeletedReply,
-  formatLearnDisabledReply,
-  formatLearnListReply,
-  formatOwnerOnlyDeniedReply,
-  formatOwnerStatusReply,
-  formatTargetSetSavedReply,
-  formatWhereAmIReply,
-  formatWhoAmIReply,
-  isLearningOwner,
-  parseLearnCommand,
-} from "./learning-command-service";
 import { setCurrentLogger } from "./logger-context";
 import { prepareMediaInput, resolveOutboundMediaType } from "./media-utils";
 import {
@@ -69,16 +45,6 @@ import { createReplyStrategy } from "./reply-strategy";
 import type { DeliverPayload } from "./reply-strategy";
 import { getDingTalkRuntime } from "./runtime";
 import { sendBySession, sendMessage, sendProactiveMedia } from "./send-service";
-import {
-  formatSessionAliasBoundReply,
-  formatSessionAliasClearedReply,
-  formatSessionAliasReply,
-  formatSessionAliasSetReply,
-  formatSessionAliasUnboundReply,
-  formatSessionAliasValidationErrorReply,
-  parseSessionCommand,
-  validateSessionAlias,
-} from "./session-command-service";
 import { acquireSessionLock } from "./session-lock";
 import {
   clearSessionPeerOverride,
@@ -694,423 +660,31 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   });
 
   const to = isDirect ? senderId : groupId;
-  const parsedLearnCommand = parseLearnCommand(extractedContent.text);
-  const parsedSessionCommand = parseSessionCommand(extractedContent.text);
-  const isOwner = isLearningOwner({
+  const commandHandled = await handleInboundCommandDispatch({
     cfg,
-    config: dingtalkConfig,
-    senderId,
-    rawSenderId: data.senderId,
-  });
-  if (isDirect && parsedLearnCommand.scope === "whoami") {
-    await sendBySession(
-      dingtalkConfig,
-      sessionWebhook,
-      formatWhoAmIReply({
-        senderId,
-        rawSenderId: data.senderId,
-        senderStaffId: data.senderStaffId,
-        isOwner,
-      }),
-      { log },
-    );
-    return;
-  }
-  if (parsedLearnCommand.scope === "whereami") {
-    await sendBySession(
-      dingtalkConfig,
-      sessionWebhook,
-      formatWhereAmIReply({
-        conversationId: data.conversationId,
-        conversationType: isDirect ? "dm" : "group",
-        peerId: sessionPeer.peerId,
-      }),
-      { log },
-    );
-    return;
-  }
-  if (isDirect && parsedLearnCommand.scope === "owner-status") {
-    await sendBySession(
-      dingtalkConfig,
-      sessionWebhook,
-      formatOwnerStatusReply({
-        senderId,
-        rawSenderId: data.senderId,
-        isOwner,
-      }),
-      { log },
-    );
-    return;
-  }
-  if (parsedLearnCommand.scope === "help") {
-    await sendBySession(dingtalkConfig, sessionWebhook, formatLearnCommandHelp(), { log });
-    return;
-  }
-  if (
-    (parsedLearnCommand.scope === "global" ||
-      parsedLearnCommand.scope === "session" ||
-      parsedLearnCommand.scope === "here" ||
-      parsedLearnCommand.scope === "target" ||
-      parsedLearnCommand.scope === "targets" ||
-      parsedLearnCommand.scope === "list" ||
-      parsedLearnCommand.scope === "disable" ||
-      parsedLearnCommand.scope === "delete" ||
-      parsedLearnCommand.scope === "target-set-create" ||
-      parsedLearnCommand.scope === "target-set-apply" ||
-      parsedSessionCommand.scope === "session-alias-show" ||
-      parsedSessionCommand.scope === "session-alias-set" ||
-      parsedSessionCommand.scope === "session-alias-clear" ||
-      parsedSessionCommand.scope === "session-alias-bind" ||
-      parsedSessionCommand.scope === "session-alias-unbind") &&
-    !isOwner
-  ) {
-    await sendBySession(dingtalkConfig, sessionWebhook, formatOwnerOnlyDeniedReply(), { log });
-    return;
-  }
-  if (isOwner) {
-    if (parsedSessionCommand.scope === "session-alias-show") {
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatSessionAliasReply({
-          sourceKind: currentSessionSourceKind,
-          sourceId: currentSessionSourceId,
-          peerId: sessionPeer.peerId,
-          aliasSource: peerIdOverride ? "override" : "default",
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedSessionCommand.scope === "session-alias-set" && parsedSessionCommand.peerId) {
-      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
-      if (aliasValidationError) {
-        await sendBySession(
-          dingtalkConfig,
-          sessionWebhook,
-          formatSessionAliasValidationErrorReply(aliasValidationError),
-          { log },
-        );
-        return;
-      }
-      setSessionPeerOverride({
-        storePath: accountStorePath,
-        accountId,
-        sourceKind: currentSessionSourceKind,
-        sourceId: currentSessionSourceId,
-        peerId: parsedSessionCommand.peerId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatSessionAliasSetReply({
-          sourceKind: currentSessionSourceKind,
-          sourceId: currentSessionSourceId,
-          peerId: parsedSessionCommand.peerId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedSessionCommand.scope === "session-alias-clear") {
-      clearSessionPeerOverride({
-        storePath: accountStorePath,
-        accountId,
-        sourceKind: currentSessionSourceKind,
-        sourceId: currentSessionSourceId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatSessionAliasClearedReply({
-          sourceKind: currentSessionSourceKind,
-          sourceId: currentSessionSourceId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedSessionCommand.scope === "session-alias-bind" &&
-      parsedSessionCommand.sourceKind &&
-      parsedSessionCommand.sourceId &&
-      parsedSessionCommand.peerId
-    ) {
-      const aliasValidationError = validateSessionAlias(parsedSessionCommand.peerId);
-      if (aliasValidationError) {
-        await sendBySession(
-          dingtalkConfig,
-          sessionWebhook,
-          formatSessionAliasValidationErrorReply(aliasValidationError),
-          { log },
-        );
-        return;
-      }
-      setSessionPeerOverride({
-        storePath: accountStorePath,
-        accountId,
-        sourceKind: parsedSessionCommand.sourceKind,
-        sourceId: parsedSessionCommand.sourceId,
-        peerId: parsedSessionCommand.peerId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatSessionAliasBoundReply({
-          sourceKind: parsedSessionCommand.sourceKind,
-          sourceId: parsedSessionCommand.sourceId,
-          peerId: parsedSessionCommand.peerId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedSessionCommand.scope === "session-alias-unbind" &&
-      parsedSessionCommand.sourceKind &&
-      parsedSessionCommand.sourceId
-    ) {
-      const existed = clearSessionPeerOverride({
-        storePath: accountStorePath,
-        accountId,
-        sourceKind: parsedSessionCommand.sourceKind,
-        sourceId: parsedSessionCommand.sourceId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatSessionAliasUnboundReply({
-          sourceKind: parsedSessionCommand.sourceKind,
-          sourceId: parsedSessionCommand.sourceId,
-          existed,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "global" && parsedLearnCommand.instruction) {
-      const applied = applyManualGlobalLearningRule({
-        storePath: accountStorePath,
-        accountId,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnAppliedReply({
-          scope: "global",
-          instruction: parsedLearnCommand.instruction,
-          ruleId: applied?.ruleId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "session" && parsedLearnCommand.instruction) {
-      applyManualSessionLearningNote({
-        storePath: accountStorePath,
-        accountId,
-        targetId: data.conversationId,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnAppliedReply({
-          scope: "session",
-          instruction: parsedLearnCommand.instruction,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "here" && parsedLearnCommand.instruction) {
-      const applied = applyManualTargetLearningRule({
-        storePath: accountStorePath,
-        accountId,
-        targetId: data.conversationId,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnAppliedReply({
-          scope: "target",
-          targetId: data.conversationId,
-          instruction: parsedLearnCommand.instruction,
-          ruleId: applied?.ruleId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedLearnCommand.scope === "target" &&
-      parsedLearnCommand.targetId &&
-      parsedLearnCommand.instruction
-    ) {
-      const applied = applyManualTargetLearningRule({
-        storePath: accountStorePath,
-        accountId,
-        targetId: parsedLearnCommand.targetId,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnAppliedReply({
-          scope: "target",
-          targetId: parsedLearnCommand.targetId,
-          instruction: parsedLearnCommand.instruction,
-          ruleId: applied?.ruleId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedLearnCommand.scope === "targets" &&
-      parsedLearnCommand.targetIds?.length &&
-      parsedLearnCommand.instruction
-    ) {
-      const applied = applyManualTargetsLearningRule({
-        storePath: accountStorePath,
-        accountId,
-        targetIds: parsedLearnCommand.targetIds,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnAppliedReply({
-          scope: "targets",
-          targetIds: parsedLearnCommand.targetIds,
-          instruction: parsedLearnCommand.instruction,
-          ruleId: applied[0]?.ruleId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedLearnCommand.scope === "target-set-create" &&
-      parsedLearnCommand.setName &&
-      parsedLearnCommand.targetIds?.length
-    ) {
-      const saved = createOrUpdateTargetSet({
-        storePath: accountStorePath,
-        accountId,
-        name: parsedLearnCommand.setName,
-        targetIds: parsedLearnCommand.targetIds,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        saved
-          ? formatTargetSetSavedReply({
-              setName: parsedLearnCommand.setName,
-              targetIds: parsedLearnCommand.targetIds,
-            })
-          : "目标组保存失败，请检查名称和目标列表。",
-        { log },
-      );
-      return;
-    }
-    if (
-      parsedLearnCommand.scope === "target-set-apply" &&
-      parsedLearnCommand.setName &&
-      parsedLearnCommand.instruction
-    ) {
-      const applied = applyTargetSetLearningRule({
-        storePath: accountStorePath,
-        accountId,
-        name: parsedLearnCommand.setName,
-        instruction: parsedLearnCommand.instruction,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        applied.length > 0
-          ? formatLearnAppliedReply({
-              scope: "target-set",
-              setName: parsedLearnCommand.setName,
-              targetIds: applied.map((item) => item.targetId),
-              instruction: parsedLearnCommand.instruction,
-              ruleId: applied[0]?.ruleId,
-            })
-          : `未找到目标组 \`${parsedLearnCommand.setName}\`，或该目标组为空。`,
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "list") {
-      const rules = listScopedLearningRules({ storePath: accountStorePath, accountId })
-        .slice(0, 20)
-        .map((rule) => {
-          const scope = rule.scope === "target" ? `target(${rule.targetId})` : "global";
-          const status = rule.enabled ? "enabled" : "disabled";
-          return `- [${scope}] ${rule.ruleId} (${status}) => ${rule.instruction}`;
-        });
-      const targetSets = listLearningTargetSets({ storePath: accountStorePath, accountId })
-        .slice(0, 10)
-        .map(
-          (targetSet) => `- [target-set] ${targetSet.name} => ${targetSet.targetIds.join(", ")}`,
-        );
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnListReply([...rules, ...targetSets]),
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "disable" && parsedLearnCommand.ruleId) {
-      const result = disableManualRule({
-        storePath: accountStorePath,
-        accountId,
-        ruleId: parsedLearnCommand.ruleId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnDisabledReply({
-          ruleId: parsedLearnCommand.ruleId,
-          existed: result.existed,
-          scope: result.scope,
-          targetId: result.targetId,
-        }),
-        { log },
-      );
-      return;
-    }
-    if (parsedLearnCommand.scope === "delete" && parsedLearnCommand.ruleId) {
-      const result = deleteManualRule({
-        storePath: accountStorePath,
-        accountId,
-        ruleId: parsedLearnCommand.ruleId,
-      });
-      await sendBySession(
-        dingtalkConfig,
-        sessionWebhook,
-        formatLearnDeletedReply({
-          ruleId: parsedLearnCommand.ruleId,
-          existed: result.existed,
-          scope: result.scope,
-          targetId: result.targetId,
-        }),
-        { log },
-      );
-      return;
-    }
-  }
-  const manualForcedReply = resolveManualForcedReply({
-    storePath: accountStorePath,
     accountId,
-    targetId: data.conversationId,
-    content: extractedContent,
+    dingtalkConfig,
+    senderId,
+    isDirect,
+    extractedText: extractedContent.text,
+    messageType: extractedContent.messageType,
+    data: {
+      conversationId: data.conversationId,
+      senderId: data.senderId,
+      senderStaffId: data.senderStaffId,
+    },
+    accountStorePath,
+    currentSessionSourceKind,
+    currentSessionSourceId,
+    peerIdOverride,
+    sessionPeer,
+    sendReply: async (text: string) => {
+      await sendBySession(dingtalkConfig, sessionWebhook, text, { log });
+    },
+    clearSessionPeerOverride,
+    setSessionPeerOverride,
   });
-  if (manualForcedReply) {
-    await sendBySession(dingtalkConfig, sessionWebhook, manualForcedReply, { log });
+  if (commandHandled) {
     return;
   }
   // 3) Select response mode (card vs markdown).

--- a/tests/unit/inbound-command-dispatch-service.test.ts
+++ b/tests/unit/inbound-command-dispatch-service.test.ts
@@ -1,0 +1,310 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MessageContent } from "../../src/types";
+import * as feedbackLearningService from "../../src/feedback-learning-service";
+import {
+  applyManualGlobalLearningRule,
+  applyManualTargetLearningRule,
+} from "../../src/feedback-learning-service";
+import { handleInboundCommandDispatch } from "../../src/command/inbound-command-dispatch-service";
+import {
+  clearSessionPeerOverride,
+  getSessionPeerOverride,
+  setSessionPeerOverride,
+} from "../../src/session-peer-store";
+
+describe("inbound-command-dispatch-service", () => {
+  let tempDir = "";
+  let storePath = "";
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dt-inbound-command-dispatch-"));
+    storePath = path.join(tempDir, "session-store.json");
+  });
+
+  afterEach(() => {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDir = "";
+    storePath = "";
+  });
+
+  function buildParams(overrides: Partial<Parameters<typeof handleInboundCommandDispatch>[0]> = {}) {
+    const sendReply = vi.fn().mockResolvedValue(undefined);
+    return {
+      params: {
+        cfg: { commands: { ownerAllowFrom: ["dingtalk:owner-test-id"] } },
+        accountId: "main",
+        dingtalkConfig: { allowFrom: ["owner-test-id"] } as any,
+        senderId: "owner-test-id",
+        isDirect: true,
+        extractedText: "hello",
+        messageType: "text" as MessageContent["messageType"],
+        data: {
+          conversationId: "cid_dm_1",
+          senderId: "owner-test-id",
+          senderStaffId: "staff_1",
+        },
+        accountStorePath: storePath,
+        currentSessionSourceKind: "direct" as const,
+        currentSessionSourceId: "owner-test-id",
+        peerIdOverride: undefined,
+        sessionPeer: {
+          peerId: "peer-default",
+        },
+        sendReply,
+        clearSessionPeerOverride,
+        setSessionPeerOverride,
+        ...overrides,
+      },
+      sendReply,
+    };
+  }
+
+  it("returns whoami reply for direct command", async () => {
+    const { params, sendReply } = buildParams({
+      extractedText: "/learn whoami",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("senderId");
+    expect(sendReply.mock.calls[0]?.[0]).toContain("owner-test-id");
+  });
+
+  it("writes session alias override for owner command", async () => {
+    const { params, sendReply } = buildParams({
+      extractedText: "/session-alias set shared-dev",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("shared-dev");
+    expect(getSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "direct",
+      sourceId: "owner-test-id",
+    })).toBe("shared-dev");
+  });
+
+  it("denies owner-only write commands for non-owner senders", async () => {
+    const { params, sendReply } = buildParams({
+      senderId: "guest-user",
+      data: {
+        conversationId: "cid_dm_1",
+        senderId: "guest-user",
+        senderStaffId: "staff_2",
+      },
+      extractedText: "/learn global 只允许 owner 写入",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("仅允许 owner 使用");
+  });
+
+  it("denies owner-only write commands for non-owner group senders", async () => {
+    const { params, sendReply } = buildParams({
+      isDirect: false,
+      senderId: "guest-user",
+      currentSessionSourceKind: "group",
+      currentSessionSourceId: "cid_group_guest",
+      data: {
+        conversationId: "cid_group_guest",
+        senderId: "guest-user",
+        senderStaffId: "staff_guest",
+      },
+      extractedText: "/session-alias show",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("仅允许 owner 使用");
+  });
+
+  it("clears existing session alias override", async () => {
+    setSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "direct",
+      sourceId: "owner-test-id",
+      peerId: "shared-dev",
+    });
+    const { params, sendReply } = buildParams({
+      extractedText: "/session-alias clear",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("已清除当前会话共享会话别名");
+    expect(getSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "direct",
+      sourceId: "owner-test-id",
+    })).toBeUndefined();
+  });
+
+  it("rejects invalid session alias values", async () => {
+    const { params, sendReply } = buildParams({
+      extractedText: "/session-alias set shared:dev",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("共享会话别名不合法");
+    expect(getSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "direct",
+      sourceId: "owner-test-id",
+    })).toBeUndefined();
+  });
+
+  it("binds and unbinds a remote group alias for owner commands", async () => {
+    const { params: bindParams, sendReply: bindReply } = buildParams({
+      extractedText: "/session-alias bind group cid_group_9 team-room",
+    });
+
+    await expect(handleInboundCommandDispatch(bindParams)).resolves.toBe(true);
+
+    expect(bindReply).toHaveBeenCalledTimes(1);
+    expect(getSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "group",
+      sourceId: "cid_group_9",
+    })).toBe("team-room");
+
+    const { params: unbindParams, sendReply: unbindReply } = buildParams({
+      extractedText: "/session-alias unbind group cid_group_9",
+    });
+
+    await expect(handleInboundCommandDispatch(unbindParams)).resolves.toBe(true);
+
+    expect(unbindReply).toHaveBeenCalledTimes(1);
+    expect(unbindReply.mock.calls[0]?.[0]).toContain("已解除共享会话别名绑定");
+    expect(getSessionPeerOverride({
+      storePath,
+      accountId: "main",
+      sourceKind: "group",
+      sourceId: "cid_group_9",
+    })).toBeUndefined();
+  });
+
+  it("returns whereami details for group commands", async () => {
+    const { params, sendReply } = buildParams({
+      isDirect: false,
+      extractedText: "/learn whereami",
+      data: {
+        conversationId: "cid_group_1",
+        senderId: "owner-test-id",
+        senderStaffId: "staff_1",
+      },
+      currentSessionSourceKind: "group",
+      currentSessionSourceId: "cid_group_1",
+      sessionPeer: {
+        peerId: "cid_group_1",
+      },
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("conversationType: `group`");
+    expect(sendReply.mock.calls[0]?.[0]).toContain("cid_group_1");
+  });
+
+  it("lists saved learning rules and target sets", async () => {
+    applyManualGlobalLearningRule({
+      storePath,
+      accountId: "main",
+      instruction: "全局规则一",
+    });
+    const { params, sendReply } = buildParams({
+      extractedText: "/learn list",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("[global]");
+    expect(sendReply.mock.calls[0]?.[0]).toContain("全局规则一");
+  });
+
+  it("returns forced reply when a manual global rule exactly matches", async () => {
+    applyManualGlobalLearningRule({
+      storePath,
+      accountId: "main",
+      instruction: "当用户问“暗号是多少”时，必须回答“天王盖地虎”。",
+    });
+    const { params, sendReply } = buildParams({
+      extractedText: "暗号是多少",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("天王盖地虎");
+  });
+
+  it("passes through the original messageType for forced reply resolution", async () => {
+    const spy = vi.spyOn(feedbackLearningService, "resolveManualForcedReply").mockReturnValue(null);
+    const { params } = buildParams({
+      extractedText: "图片口令",
+      messageType: "picture",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(false);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]?.content).toMatchObject({
+      text: "图片口令",
+      messageType: "picture",
+    });
+    spy.mockRestore();
+  });
+
+  it("prefers target forced reply over global forced reply", async () => {
+    applyManualGlobalLearningRule({
+      storePath,
+      accountId: "main",
+      instruction: "当用户问“暗号是多少”时，必须回答“全局答案”。",
+    });
+    applyManualTargetLearningRule({
+      storePath,
+      accountId: "main",
+      targetId: "cid_dm_1",
+      instruction: "当用户问“暗号是多少”时，必须回答“当前会话答案”。",
+    });
+    const { params, sendReply } = buildParams({
+      extractedText: "暗号是多少",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(true);
+
+    expect(sendReply).toHaveBeenCalledTimes(1);
+    expect(sendReply.mock.calls[0]?.[0]).toContain("当前会话答案");
+  });
+
+  it("returns false for non-command text", async () => {
+    const { params, sendReply } = buildParams({
+      extractedText: "随便聊一句普通话",
+    });
+
+    await expect(handleInboundCommandDispatch(params)).resolves.toBe(false);
+
+    expect(sendReply).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景
当前 `src/inbound-handler.ts` 同时承担了：
- 入站编排
- slash 命令解析
- owner 鉴权后的命令执行
- session alias 命令回包
- feedback learning 命令回包

这会让 `inbound-handler.ts` 持续膨胀，也会让命令相关修改更容易影响入站主流程。

根据仓库当前文档要求：
- `inbound-handler.ts` 应保持编排层职责
- slash command 相关逻辑属于 `command` 域
- 新代码优先按逻辑域落位，而不是继续堆在 `src/` 根目录

## 改动
- 新增 `src/command/inbound-command-dispatch-service.ts`
- 将现有 upstream 已存在的入站命令早返回逻辑从 `src/inbound-handler.ts` 抽离
- `src/inbound-handler.ts` 仅保留一次命令分发调用，继续承担编排角色

## 范围控制
这是一个纯结构重构 PR：
- 不引入 `314 / 331 / 367 / 380 / 382` 的功能内容
- 不改变现有 upstream 已有命令的行为语义
- 不做大规模目录迁移，只做一处符合架构文档的小边界优化

## 验证
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run tests/unit/inbound-handler.test.ts -t 'handleDingTalkMessage returns owner status for slash command|handleDingTalkMessage blocks learn control command for non-owner|handleDingTalkMessage does not treat owner plain text as learn help|handleDingTalkMessage blocks learn control command for non-owner in group'`
