### PR TITLE
fix(types): remove redundant ackReaction union lint

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,9 @@ import type {
 import { mergeAccountWithDefaults } from "./config";
 
 export type AckReactionMode = "off" | "emoji" | "kaomoji";
-export type AckReactionConfigValue = AckReactionMode | string;
+// Accept arbitrary strings for backward compatibility; the recommended
+// explicit modes remain: "off" | "emoji" | "kaomoji".
+export type AckReactionConfigValue = string;
 
 export interface DingtalkPluginModule {
   id: string;


### PR DESCRIPTION
## Summary
- fix the redundant union lint failure introduced after PR #314 by changing `AckReactionConfigValue` from `AckReactionMode | string` to `string`
- keep `AckReactionMode` for the explicit normalized modes used elsewhere
- add a short comment clarifying that arbitrary strings remain accepted for backward compatibility while the recommended explicit modes are `off` / `emoji` / `kaomoji`

## Why
`AckReactionMode | string` collapses to `string` in TypeScript, so `typescript-eslint/no-redundant-type-constituents` flags it and CI fails on main. This change keeps runtime behavior unchanged because schema validation is still handled by `AckReactionSchema` in `src/config-schema.ts`.

## Validation
- `pnpm exec oxlint --type-aware src/types.ts src/config.ts src/config-schema.ts`
- `pnpm exec tsc --noEmit`
