### PR TITLE
test(inbound): align ack reaction cleanup expectations

### DIFF
--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -3926,10 +3926,11 @@ describe("inbound-handler", () => {
   });
 
   it("handleDingTalkMessage continues when native ack reaction attach fails", async () => {
-    mockedAxiosPost.mockRejectedValueOnce(new Error("reaction failed"));
+    vi.useFakeTimers();
+    mockedAxiosPost.mockRejectedValue(new Error("reaction failed"));
 
-    await expect(
-      handleDingTalkMessage({
+    try {
+      const handlePromise = handleDingTalkMessage({
         cfg: {},
         accountId: "main",
         sessionWebhook: "https://session.webhook",
@@ -3952,64 +3953,74 @@ describe("inbound-handler", () => {
           sessionWebhook: "https://session.webhook",
           createAt: Date.now(),
         },
-      } as any),
-    ).resolves.toBeUndefined();
+      } as any);
 
-    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
-    const sentTexts = shared.sendMessageMock.mock.calls.map((call: any[]) => String(call[2] ?? ""));
-    expect(sentTexts.some((text: string) => text.includes("思考中"))).toBe(false);
+      await vi.runAllTimersAsync();
+      await expect(handlePromise).resolves.toBeUndefined();
+
+      expect(mockedAxiosPost).toHaveBeenCalledTimes(3);
+      expect(
+        mockedAxiosPost.mock.calls.every((call) =>
+          String(call[0] || "").includes("/robot/emotion/reply"),
+        ),
+      ).toBe(true);
+      const sentTexts = shared.sendMessageMock.mock.calls.map((call: any[]) => String(call[2] ?? ""));
+      expect(sentTexts.some((text: string) => text.includes("思考中"))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("handleDingTalkMessage does not recall when native ack reaction attach fails", async () => {
     vi.useFakeTimers();
-    mockedAxiosPost.mockRejectedValueOnce(new Error("reaction failed"));
+    mockedAxiosPost.mockRejectedValue(new Error("reaction failed"));
 
     try {
-      await expect(
-        handleDingTalkMessage({
-          cfg: {},
-          accountId: "main",
+      const handlePromise = handleDingTalkMessage({
+        cfg: {},
+        accountId: "main",
+        sessionWebhook: "https://session.webhook",
+        log: undefined,
+        dingtalkConfig: {
+          clientId: "ding_client",
+          clientSecret: "secret",
+          dmPolicy: "open",
+          messageType: "markdown",
+          ackReaction: "🤔思考中",
+        } as any,
+        data: {
+          msgId: "m5_reaction_fail_no_recall",
+          msgtype: "text",
+          text: { content: "hello" },
+          conversationType: "1",
+          conversationId: "cid_ok",
+          senderId: "user_1",
+          chatbotUserId: "bot_1",
           sessionWebhook: "https://session.webhook",
-          log: undefined,
-          dingtalkConfig: {
-            clientId: "ding_client",
-            clientSecret: "secret",
-            dmPolicy: "open",
-            messageType: "markdown",
-            ackReaction: "🤔思考中",
-          } as any,
-          data: {
-            msgId: "m5_reaction_fail_no_recall",
-            msgtype: "text",
-            text: { content: "hello" },
-            conversationType: "1",
-            conversationId: "cid_ok",
-            senderId: "user_1",
-            chatbotUserId: "bot_1",
-            sessionWebhook: "https://session.webhook",
-            createAt: Date.now(),
-          },
-        } as any),
-      ).resolves.toBeUndefined();
+          createAt: Date.now(),
+        },
+      } as any);
 
-      await vi.advanceTimersByTimeAsync(6000);
+      await vi.runAllTimersAsync();
+      await expect(handlePromise).resolves.toBeUndefined();
 
-      expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
-      expect(mockedAxiosPost).toHaveBeenCalledWith(
-        "https://api.dingtalk.com/v1.0/robot/emotion/reply",
-        expect.any(Object),
-        expect.any(Object),
-      );
+      expect(mockedAxiosPost).toHaveBeenCalledTimes(3);
+      expect(
+        mockedAxiosPost.mock.calls.every((call) =>
+          String(call[0] || "").includes("/robot/emotion/reply"),
+        ),
+      ).toBe(true);
     } finally {
       vi.useRealTimers();
     }
   });
 
   it("handleDingTalkMessage does not fall back to standalone thinking message when reaction attach fails", async () => {
-    mockedAxiosPost.mockRejectedValueOnce(new Error("reaction failed"));
+    vi.useFakeTimers();
+    mockedAxiosPost.mockRejectedValue(new Error("reaction failed"));
 
-    await expect(
-      handleDingTalkMessage({
+    try {
+      const handlePromise = handleDingTalkMessage({
         cfg: {},
         accountId: "main",
         sessionWebhook: "https://session.webhook",
@@ -4032,12 +4043,17 @@ describe("inbound-handler", () => {
           sessionWebhook: "https://session.webhook",
           createAt: Date.now(),
         },
-      } as any),
-    ).resolves.toBeUndefined();
+      } as any);
 
-    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
-    const sentTexts = shared.sendMessageMock.mock.calls.map((call: any[]) => String(call[2] ?? ""));
-    expect(sentTexts.some((text: string) => text.includes("思考中"))).toBe(false);
+      await vi.runAllTimersAsync();
+      await expect(handlePromise).resolves.toBeUndefined();
+
+      expect(mockedAxiosPost).toHaveBeenCalledTimes(3);
+      const sentTexts = shared.sendMessageMock.mock.calls.map((call: any[]) => String(call[2] ?? ""));
+      expect(sentTexts.some((text: string) => text.includes("思考中"))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("handleDingTalkMessage ignores thinking and tool card updates when card is already finalized", async () => {


### PR DESCRIPTION
## Summary
- fix the failing `inbound-handler` regression tests introduced after #314 changed dynamic ack reaction cleanup timing
- update the native ack reaction failure-path tests to match the current retry behavior (3 reply attempts)
- advance fake timers correctly so the attach-failure tests no longer leave the suite in a broken timer state

## Why
PR #314 changed the cleanup model from fire-and-forget recall-after-release to bounded dynamic cleanup before releasing the session lock. The implementation is behaving consistently with that new model, but several tests still assumed the old timing and single-attempt behavior, which caused `tests/unit/inbound-handler.test.ts` to fail on `main`.

## Validation
- `pnpm exec vitest run tests/unit/inbound-handler.test.ts`
- `pnpm test`
