### PR TITLE
fix: acknowledge DingTalk callback immediately to prevent redelivery

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -638,6 +638,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
             if (!dedupKey) {
               ctx.log?.warn?.(`[${account.accountId}] No message ID available for deduplication`);
               stats.noMessageId += 1;
+              acknowledge();
               await handleDingTalkMessage({
                 cfg,
                 accountId: account.accountId,
@@ -647,7 +648,6 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
                 dingtalkConfig: config,
               });
               stats.processed += 1;
-              acknowledge();
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
                 logInboundCounters(ctx.log, account.accountId, "periodic");
               }
@@ -674,11 +674,13 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
                   `[${account.accountId}] Skipping in-flight duplicate message: ${dedupKey}`,
                 );
                 stats.inflightSkipped += 1;
+                acknowledge();
                 logInboundCounters(ctx.log, account.accountId, "inflight-skipped");
                 return;
               }
             }
 
+            acknowledge();
             processingDedupKeys.set(dedupKey, Date.now());
             try {
               await handleDingTalkMessage({
@@ -691,7 +693,6 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
               });
               stats.processed += 1;
               markMessageProcessed(dedupKey);
-              acknowledge();
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
                 logInboundCounters(ctx.log, account.accountId, "periodic");
               }

--- a/tests/integration/gateway-inbound-flow.test.ts
+++ b/tests/integration/gateway-inbound-flow.test.ts
@@ -208,15 +208,18 @@ describe('gateway inbound callback pipeline', () => {
 
         await shared.listeners.TOPIC_ROBOT?.(payload);
         expect(shared.markMessageProcessedMock).not.toHaveBeenCalled();
-        expect(shared.socketCallBackResponseMock).not.toHaveBeenCalled();
+        // Early ack: acknowledge() is called before the handler, so even on failure the callback is acked
+        expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(1);
+        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_retry', { success: true });
         expect(ctx.log.info).toHaveBeenCalledWith(expect.stringContaining('Inbound counters (failed)'));
 
         await shared.listeners.TOPIC_ROBOT?.(payload);
         expect(shared.handleDingTalkMessageMock).toHaveBeenCalledTimes(2);
         expect(shared.markMessageProcessedMock).toHaveBeenCalledTimes(1);
         expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_retry');
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(1);
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_retry', { success: true });
+        // Both attempts ack immediately
+        expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(2);
+        expect(shared.socketCallBackResponseMock).toHaveBeenNthCalledWith(2, 'stream_msg_retry', { success: true });
     });
 
     it('does not acknowledge malformed payloads when parse fails', async () => {
@@ -278,9 +281,10 @@ describe('gateway inbound callback pipeline', () => {
 
         expect(shared.markMessageProcessedMock).toHaveBeenCalledTimes(1);
         expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_inflight');
-        expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(1);
+        // Both the first message and the in-flight duplicate are acked immediately
+        expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(2);
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_inflight_1', { success: true });
-        expect(shared.socketCallBackResponseMock).not.toHaveBeenCalledWith('stream_msg_inflight_2', { success: true });
+        expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_inflight_2', { success: true });
     });
 
     it('releases stale in-flight lock after ttl and allows reprocessing', async () => {


### PR DESCRIPTION
## Problem

DingTalk Stream callback acknowledgement (`socketCallBackResponse`) is delayed until after the full message processing completes (including LLM call). Since LLM calls can take 30+ seconds, DingTalk times out waiting for the callback response and redelivers the message, causing duplicate processing.

## Root Cause

In `channel.ts`, the `acknowledge()` function was called **after** `handleDingTalkMessage()` completes. DingTalk Stream protocol expects callback responses within ~5-15 seconds.

## Fix

Move `acknowledge()` to be called **immediately** upon receiving the message, before starting the long-running processing. This is safe because:

- The in-memory dedup (`processingDedupKeys` + `isMessageProcessed`) still prevents double processing
- Early ack tells DingTalk "I received the message" without implying "I finished processing"
- If processing fails after ack, the message is already logged and can be retried by the application layer

## Evidence from logs (before fix)

```
08:20:32.113 [AICard] Creating card (1st delivery)
08:20:32.469 Inbound: text="a和b结合吧..."
08:20:48.695 [AICard] Creating card (2nd delivery, 16s later!)
08:20:49.114 Inbound: text="a和b结合吧..." (same message)
```

Fixes #390