### PR TITLE
fix: sandbox sendMedia fails for workspace files (#397)

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -210,7 +210,7 @@ const dingtalkMessageActions: ChannelMessageActionAdapter = {
   listActions: () => ["send"],
   supportsAction: ({ action }) => action === "send",
   extractToolSend: ({ args }) => pluginSdk.extractToolSend(args, "sendMessage"),
-  handleAction: async ({ action, params, cfg, accountId, dryRun }) => {
+  handleAction: async ({ action, params, cfg, accountId, dryRun, mediaLocalRoots }: any) => {
     if (action !== "send") {
       throw new Error(`Action ${action} is not supported for provider dingtalk.`);
     }
@@ -267,6 +267,7 @@ const dingtalkMessageActions: ChannelMessageActionAdapter = {
         const result = await sendProactiveMedia(config, target, mediaPath, mediaType, {
           log,
           accountId: accountId ?? undefined,
+          mediaLocalRoots,
         });
 
         if (!result.ok) {
@@ -479,6 +480,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       mediaType: providedMediaType,
       asVoice,
       accountId,
+      mediaLocalRoots,
       log,
     }: any) => {
       const config = getConfig(cfg, accountId);
@@ -547,6 +549,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
             accountId,
             storePath,
             conversationId: to,
+            mediaLocalRoots,
           });
         } catch (err: any) {
           if (err?.response?.data !== undefined) {

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -682,7 +682,7 @@ async function readMediaBuffer(
 
   const buffer = Buffer.isBuffer(media.buffer)
     ? media.buffer
-    : Buffer.from(media.buffer as ArrayBuffer);
+    : Buffer.from(media.buffer);
   return { buffer, size: buffer.length };
 }
 

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -16,6 +16,7 @@ import axios from "axios";
 import FormData from "form-data";
 import type { DingTalkConfig, Logger } from "./types";
 import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
+import { getDingTalkRuntime } from "./runtime";
 
 /**
  * Calculate MP3 duration in seconds by parsing MPEG frame headers
@@ -620,23 +621,61 @@ const FILE_SIZE_LIMITS: Record<DingTalkMediaType, number> = {
  * @param log Optional logger
  * @returns media_id on success, null on failure
  */
+/**
+ * Read a media file, resolving sandbox/container paths via the runtime bridge
+ * when direct host filesystem access fails.
+ *
+ * Precedence:
+ *   1. Direct fs.readFile (works for host-local paths)
+ *   2. rt.media.loadWebMedia (resolves sandbox workspace paths via bridge)
+ */
+async function readMediaBuffer(
+  mediaPath: string,
+  options?: { mediaLocalRoots?: string[] },
+  log?: Logger,
+): Promise<{ buffer: Buffer; size: number }> {
+  // Try direct host filesystem first
+  try {
+    const buffer = await fsPromises.readFile(mediaPath);
+    return { buffer, size: buffer.length };
+  } catch (err: unknown) {
+    const errno = err as NodeJS.ErrnoException;
+    if (errno.code !== "ENOENT") {
+      throw err; // Permission errors etc. should propagate immediately
+    }
+  }
+
+  // File not found on host — try runtime media bridge (sandbox/container paths)
+  log?.debug?.(`[DingTalk] File not found on host, trying runtime media bridge: ${mediaPath}`);
+  const rt = getDingTalkRuntime();
+  const media = await (rt as any).media.loadWebMedia(mediaPath, {
+    mediaLocalRoots: options?.mediaLocalRoots,
+  });
+
+  const buffer = Buffer.isBuffer(media.buffer)
+    ? media.buffer
+    : Buffer.from(media.buffer as ArrayBuffer);
+  return { buffer, size: buffer.length };
+}
+
 export async function uploadMedia(
   config: DingTalkConfig,
   mediaPath: string,
   mediaType: DingTalkMediaType,
   getAccessToken: (config: DingTalkConfig, log?: Logger) => Promise<string>,
   log?: Logger,
+  options?: { mediaLocalRoots?: string[] },
 ): Promise<string | null> {
-  let fileStream: fs.ReadStream | null = null;
-
   try {
     const token = await getAccessToken(config, log);
 
-    // Check file size (stat will throw if file doesn't exist)
-    const stats = await fsPromises.stat(mediaPath);
+    // Read file via sandbox-aware bridge (falls back to direct fs for host paths)
+    const { buffer, size } = await readMediaBuffer(mediaPath, options, log);
+
+    // Check file size
     const sizeLimit = FILE_SIZE_LIMITS[mediaType];
-    if (stats.size > sizeLimit) {
-      const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+    if (size > sizeLimit) {
+      const sizeMB = (size / (1024 * 1024)).toFixed(2);
       const limitMB = (sizeLimit / (1024 * 1024)).toFixed(2);
       log?.error?.(
         `[DingTalk] Media file too large: ${sizeMB}MB exceeds ${limitMB}MB limit for ${mediaType}`,
@@ -644,17 +683,15 @@ export async function uploadMedia(
       return null;
     }
 
-    // Read file as a stream for better memory efficiency
-    fileStream = fs.createReadStream(mediaPath);
     const filename = path.basename(mediaPath);
 
     // Upload to DingTalk's media server using form-data
     const form = new FormData();
-    form.append("media", fileStream, { filename });
+    form.append("media", buffer, { filename });
 
     const uploadUrl = `https://oapi.dingtalk.com/media/upload?access_token=${token}&type=${mediaType}`;
 
-    log?.debug?.(`[DingTalk] Uploading media: ${filename} (${stats.size} bytes) as ${mediaType}`);
+    log?.debug?.(`[DingTalk] Uploading media: ${filename} (${size} bytes) as ${mediaType}`);
 
     const response = await axios.post(uploadUrl, form, {
       headers: form.getHeaders(),
@@ -665,7 +702,7 @@ export async function uploadMedia(
 
     if (response.data?.errcode === 0 && response.data?.media_id) {
       log?.debug?.(
-        `[DingTalk] Media uploaded successfully: ${response.data.media_id} (${stats.size} bytes)`,
+        `[DingTalk] Media uploaded successfully: ${response.data.media_id} (${size} bytes)`,
       );
       return response.data.media_id;
     } else {
@@ -676,7 +713,7 @@ export async function uploadMedia(
     // Handle file system errors (e.g., file not found, permission denied)
     const errno = err as NodeJS.ErrnoException;
     if (errno.code === "ENOENT") {
-      log?.error?.(`[DingTalk] Media file not found: ${mediaPath}`);
+      log?.error?.(`[DingTalk] Media file not found (host and sandbox): ${mediaPath}`);
     } else if (errno.code === "EACCES") {
       log?.error?.(`[DingTalk] Permission denied accessing media file: ${mediaPath}`);
     } else {
@@ -690,10 +727,5 @@ export async function uploadMedia(
       }
     }
     return null;
-  } finally {
-    // Ensure file stream is closed even on error
-    if (fileStream) {
-      fileStream.destroy();
-    }
   }
 }

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -35,13 +35,15 @@ interface PluginRuntimeWithMedia {
 /**
  * Calculate MP3 duration in seconds by parsing MPEG frame headers
  * Supports CBR and VBR MP3 files
- * @param filePath Path to the MP3 file
+ * @param filePathOrBuffer Path to the MP3 file, or a pre-read Buffer
  * @param log Optional logger
  * @returns Duration in seconds (0 if parsing fails)
  */
-export async function getMp3DurationSeconds(filePath: string, log?: Logger): Promise<number> {
+export async function getMp3DurationSeconds(filePathOrBuffer: string | Buffer, log?: Logger): Promise<number> {
   try {
-    const buffer = await fsPromises.readFile(filePath);
+    const buffer = typeof filePathOrBuffer === "string"
+      ? await fsPromises.readFile(filePathOrBuffer)
+      : filePathOrBuffer;
     let offset = 0;
 
     // Skip ID3v2 tag if present
@@ -196,7 +198,7 @@ export async function getMp3DurationSeconds(filePath: string, log?: Logger): Pro
       return Math.floor(duration);
     }
 
-    log?.warn?.(`[DingTalk] Could not parse MP3 duration from ${filePath} (found ${frameCount} frames)`);
+    log?.warn?.(`[DingTalk] Could not parse MP3 duration from ${filePathOrBuffer} (found ${frameCount} frames)`);
     return 0;
   } catch (err: unknown) {
     log?.error?.(`[DingTalk] Failed to get MP3 duration: ${err instanceof Error ? err.message : String(err)}`);
@@ -210,6 +212,7 @@ export async function getVoiceDurationMs(
   filePath: string,
   mediaType: DingTalkMediaType,
   log?: Logger,
+  options?: { mediaLocalRoots?: string[] },
 ): Promise<number> {
   if (mediaType !== "voice") {
     return DEFAULT_VOICE_DURATION_MS;
@@ -218,7 +221,14 @@ export async function getVoiceDurationMs(
   const ext = path.extname(filePath).toLowerCase();
 
   if (ext === ".mp3") {
-    const durationSec = await getMp3DurationSeconds(filePath, log);
+    let durationSec: number;
+    try {
+      // Read via sandbox-aware bridge so container paths resolve correctly
+      const { buffer } = await readMediaBuffer(filePath, options, log);
+      durationSec = await getMp3DurationSeconds(buffer, log);
+    } catch {
+      durationSec = 0;
+    }
     if (durationSec > 0) {
       return Math.max(1, Math.round(durationSec * 1000));
     }
@@ -621,20 +631,6 @@ const FILE_SIZE_LIMITS: Record<DingTalkMediaType, number> = {
   file: 20 * 1024 * 1024, // 20MB
 };
 
-/**
- * Upload media file to DingTalk and get media_id
- * Uses DingTalk's media upload API: https://oapi.dingtalk.com/media/upload
- *
- * Note: Media files are stored temporarily by DingTalk (not in permanent storage).
- * The media_id can be used in subsequent message sends.
- *
- * @param config DingTalk configuration
- * @param mediaPath Local path to the media file
- * @param mediaType Type of media: 'image' | 'voice' | 'video' | 'file'
- * @param getAccessToken Function to get DingTalk access token
- * @param log Optional logger
- * @returns media_id on success, null on failure
- */
 /**
  * Read a media file, resolving sandbox/container paths via the runtime bridge
  * when direct host filesystem access fails.

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -212,7 +212,7 @@ export async function getVoiceDurationMs(
   filePath: string,
   mediaType: DingTalkMediaType,
   log?: Logger,
-  options?: { mediaLocalRoots?: string[] },
+  options?: { mediaLocalRoots?: string[]; preReadBuffer?: Buffer },
 ): Promise<number> {
   if (mediaType !== "voice") {
     return DEFAULT_VOICE_DURATION_MS;
@@ -223,8 +223,9 @@ export async function getVoiceDurationMs(
   if (ext === ".mp3") {
     let durationSec: number;
     try {
-      // Read via sandbox-aware bridge so container paths resolve correctly
-      const { buffer } = await readMediaBuffer(filePath, options, log);
+      // Reuse pre-read buffer from uploadMedia when available to avoid double read
+      const buffer = options?.preReadBuffer
+        ?? (await readMediaBuffer(filePath, options, log)).buffer;
       durationSec = await getMp3DurationSeconds(buffer, log);
     } catch {
       durationSec = 0;
@@ -682,6 +683,12 @@ async function readMediaBuffer(
   return { buffer, size: buffer.length };
 }
 
+export interface UploadMediaResult {
+  mediaId: string;
+  /** The file buffer read during upload, reusable for voice duration parsing etc. */
+  buffer: Buffer;
+}
+
 export async function uploadMedia(
   config: DingTalkConfig,
   mediaPath: string,
@@ -689,7 +696,7 @@ export async function uploadMedia(
   getAccessToken: (config: DingTalkConfig, log?: Logger) => Promise<string>,
   log?: Logger,
   options?: { mediaLocalRoots?: string[] },
-): Promise<string | null> {
+): Promise<UploadMediaResult | null> {
   try {
     const token = await getAccessToken(config, log);
 
@@ -728,7 +735,7 @@ export async function uploadMedia(
       log?.debug?.(
         `[DingTalk] Media uploaded successfully: ${response.data.media_id} (${size} bytes)`,
       );
-      return response.data.media_id;
+      return { mediaId: response.data.media_id, buffer };
     } else {
       log?.error?.(`[DingTalk] Media upload failed: ${JSON.stringify(response.data)}`);
       return null;

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -5,7 +5,6 @@
  * Provides functions for media type detection and file upload to DingTalk media servers.
  */
 
-import * as fs from "node:fs";
 import { randomUUID } from "node:crypto";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -17,6 +16,21 @@ import FormData from "form-data";
 import type { DingTalkConfig, Logger } from "./types";
 import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 import { getDingTalkRuntime } from "./runtime";
+
+/**
+ * Extended PluginRuntime with media bridge support.
+ * The `media.loadWebMedia` method resolves sandbox/container paths
+ * through the runtime bridge when direct host filesystem access fails.
+ */
+interface PluginRuntimeWithMedia {
+  media?: {
+    loadWebMedia(
+      mediaPath: string,
+      options?: { mediaLocalRoots?: string[] },
+    ): Promise<{ buffer: Buffer | ArrayBuffer; fileName?: string; contentType?: string } | null>;
+  };
+  [key: string]: unknown;
+}
 
 /**
  * Calculate MP3 duration in seconds by parsing MPEG frame headers
@@ -647,10 +661,24 @@ async function readMediaBuffer(
 
   // File not found on host — try runtime media bridge (sandbox/container paths)
   log?.debug?.(`[DingTalk] File not found on host, trying runtime media bridge: ${mediaPath}`);
-  const rt = getDingTalkRuntime();
-  const media = await (rt as any).media.loadWebMedia(mediaPath, {
+  const rt = getDingTalkRuntime() as PluginRuntimeWithMedia;
+  if (!rt.media?.loadWebMedia) {
+    throw Object.assign(
+      new Error(`File not found and runtime media bridge unavailable: ${mediaPath}`),
+      { code: "ENOENT" },
+    );
+  }
+
+  const media = await rt.media.loadWebMedia(mediaPath, {
     mediaLocalRoots: options?.mediaLocalRoots,
   });
+
+  if (!media || !media.buffer) {
+    throw Object.assign(
+      new Error(`Runtime media bridge returned no data for: ${mediaPath}`),
+      { code: "ENOENT" },
+    );
+  }
 
   const buffer = Buffer.isBuffer(media.buffer)
     ? media.buffer

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -198,7 +198,7 @@ export async function getMp3DurationSeconds(filePathOrBuffer: string | Buffer, l
       return Math.floor(duration);
     }
 
-    log?.warn?.(`[DingTalk] Could not parse MP3 duration from ${filePathOrBuffer} (found ${frameCount} frames)`);
+    log?.warn?.(`[DingTalk] Could not parse MP3 duration from ${typeof filePathOrBuffer === "string" ? filePathOrBuffer : "<buffer>"} (found ${frameCount} frames)`);
     return 0;
   } catch (err: unknown) {
     log?.error?.(`[DingTalk] Failed to get MP3 duration: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -8,7 +8,7 @@ import {
 } from "./card-service";
 import { stripTargetPrefix } from "./config";
 import { getLogger } from "./logger-context";
-import { getVoiceDurationMs, uploadMedia as uploadMediaUtil } from "./media-utils";
+import { getVoiceDurationMs, uploadMedia as uploadMediaUtil, type UploadMediaResult } from "./media-utils";
 import { convertMarkdownTablesToPlainText, detectMarkdownAndExtractTitle } from "./message-utils";
 import { DEFAULT_MESSAGE_CONTEXT_TTL_DAYS, upsertOutboundMessageContext } from "./message-context-store";
 import { resolveOriginalPeerId } from "./peer-id-registry";
@@ -211,7 +211,7 @@ export async function uploadMedia(
   mediaType: "image" | "voice" | "video" | "file",
   log?: Logger,
   options?: { mediaLocalRoots?: string[] },
-): Promise<string | null> {
+): Promise<UploadMediaResult | null> {
   return uploadMediaUtil(config, mediaPath, mediaType, getAccessToken, log, options);
 }
 
@@ -349,12 +349,13 @@ export async function sendProactiveMedia(
 
   try {
     // Upload first, then send by media_id.
-    const mediaId = await uploadMedia(config, mediaPath, mediaType, log, {
+    const uploadResult = await uploadMedia(config, mediaPath, mediaType, log, {
       mediaLocalRoots: options.mediaLocalRoots,
     });
-    if (!mediaId) {
+    if (!uploadResult) {
       return { ok: false, error: "Failed to upload media" };
     }
+    const { mediaId, buffer: uploadedBuffer } = uploadResult;
 
     const token = await getAccessToken(config, log);
     const { targetId, isExplicitUser } = stripTargetPrefix(target);
@@ -375,8 +376,9 @@ export async function sendProactiveMedia(
       msgParam = JSON.stringify({ photoURL: mediaId });
     } else if (mediaType === "voice") {
       msgKey = "sampleAudio";
+      // Reuse buffer from upload to avoid reading the file twice
       const durationMs = await getVoiceDurationMs(mediaPath, mediaType, log, {
-        mediaLocalRoots: options.mediaLocalRoots,
+        preReadBuffer: uploadedBuffer,
       });
       msgParam = JSON.stringify({ mediaId, duration: String(durationMs) });
     } else {
@@ -503,17 +505,19 @@ export async function sendBySession(
 
   // Session webhook supports native media messages; prefer that when media info is available.
   if (options.mediaPath && options.mediaType) {
-    const mediaId = await uploadMedia(config, options.mediaPath, options.mediaType, log, {
+    const uploadResult = await uploadMedia(config, options.mediaPath, options.mediaType, log, {
       mediaLocalRoots: options.mediaLocalRoots,
     });
-    if (mediaId) {
+    if (uploadResult) {
+      const { mediaId, buffer: uploadedBuffer } = uploadResult;
       let body: any;
 
       if (options.mediaType === "image") {
         body = { msgtype: "image", image: { media_id: mediaId } };
       } else if (options.mediaType === "voice") {
+        // Reuse buffer from upload to avoid reading the file twice
         const durationMs = await getVoiceDurationMs(options.mediaPath, options.mediaType, log, {
-          mediaLocalRoots: options.mediaLocalRoots,
+          preReadBuffer: uploadedBuffer,
         });
         body = { msgtype: "voice", voice: { media_id: mediaId, duration: String(durationMs) } };
       } else if (options.mediaType === "video") {

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -375,7 +375,9 @@ export async function sendProactiveMedia(
       msgParam = JSON.stringify({ photoURL: mediaId });
     } else if (mediaType === "voice") {
       msgKey = "sampleAudio";
-      const durationMs = await getVoiceDurationMs(mediaPath, mediaType, log);
+      const durationMs = await getVoiceDurationMs(mediaPath, mediaType, log, {
+        mediaLocalRoots: options.mediaLocalRoots,
+      });
       msgParam = JSON.stringify({ mediaId, duration: String(durationMs) });
     } else {
       // sampleVideo requires picMediaId; fallback to sampleFile for broader compatibility.
@@ -510,7 +512,9 @@ export async function sendBySession(
       if (options.mediaType === "image") {
         body = { msgtype: "image", image: { media_id: mediaId } };
       } else if (options.mediaType === "voice") {
-        const durationMs = await getVoiceDurationMs(options.mediaPath, options.mediaType, log);
+        const durationMs = await getVoiceDurationMs(options.mediaPath, options.mediaType, log, {
+          mediaLocalRoots: options.mediaLocalRoots,
+        });
         body = { msgtype: "voice", voice: { media_id: mediaId, duration: String(durationMs) } };
       } else if (options.mediaType === "video") {
         body = { msgtype: "video", video: { media_id: mediaId } };

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -203,14 +203,16 @@ function isProactivePermissionOrScopeError(code: string | null): boolean {
 
 /**
  * Wrapper to upload media with shared getAccessToken binding.
+ * Supports sandbox/container paths via mediaLocalRoots option.
  */
 export async function uploadMedia(
   config: DingTalkConfig,
   mediaPath: string,
   mediaType: "image" | "voice" | "video" | "file",
   log?: Logger,
+  options?: { mediaLocalRoots?: string[] },
 ): Promise<string | null> {
-  return uploadMediaUtil(config, mediaPath, mediaType, getAccessToken, log);
+  return uploadMediaUtil(config, mediaPath, mediaType, getAccessToken, log, options);
 }
 
 export async function sendProactiveTextOrMarkdown(
@@ -341,13 +343,15 @@ export async function sendProactiveMedia(
   target: string,
   mediaPath: string,
   mediaType: "image" | "voice" | "video" | "file",
-  options: SendMessageOptions & { accountId?: string } = {},
+  options: SendMessageOptions & { accountId?: string; mediaLocalRoots?: string[] } = {},
 ): Promise<{ ok: boolean; error?: string; data?: any; messageId?: string }> {
   const log = options.log || getLogger();
 
   try {
     // Upload first, then send by media_id.
-    const mediaId = await uploadMedia(config, mediaPath, mediaType, log);
+    const mediaId = await uploadMedia(config, mediaPath, mediaType, log, {
+      mediaLocalRoots: options.mediaLocalRoots,
+    });
     if (!mediaId) {
       return { ok: false, error: "Failed to upload media" };
     }
@@ -497,7 +501,9 @@ export async function sendBySession(
 
   // Session webhook supports native media messages; prefer that when media info is available.
   if (options.mediaPath && options.mediaType) {
-    const mediaId = await uploadMedia(config, options.mediaPath, options.mediaType, log);
+    const mediaId = await uploadMedia(config, options.mediaPath, options.mediaType, log, {
+      mediaLocalRoots: options.mediaLocalRoots,
+    });
     if (mediaId) {
       let body: any;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,6 +393,8 @@ export interface SendMessageOptions {
   /** Force markdown/text delivery even when messageType is "card". Bypasses card
    *  creation while preserving journal writes and other side-effects. */
   forceMarkdown?: boolean;
+  /** Allowed local roots for sandbox/container media path resolution. */
+  mediaLocalRoots?: string[];
 }
 
 export interface DingTalkTrackingMetadata {

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -361,4 +361,42 @@ describe('media-utils', () => {
         expect(mediaId).toBe('media_sandbox_2');
         expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: localRoots });
     });
+
+    it('returns null when loadWebMedia returns null (sandbox bridge failure)', async () => {
+        const sandboxPath = '/workspace/missing.png';
+
+        mockLoadWebMedia.mockResolvedValueOnce(null);
+
+        const log = { error: vi.fn(), debug: vi.fn() };
+        const mediaId = await uploadMedia(
+            { clientId: 'id', clientSecret: 'sec' } as any,
+            sandboxPath,
+            'image',
+            vi.fn().mockResolvedValue('token_abc'),
+            log as any,
+        );
+
+        expect(mediaId).toBeNull();
+        expect(log.error).toHaveBeenCalled();
+        const errorMsg = String(log.error.mock.calls[0]?.[0] ?? '');
+        expect(errorMsg).toContain('not found');
+    });
+
+    it('returns null when loadWebMedia returns object without buffer', async () => {
+        const sandboxPath = '/workspace/empty.png';
+
+        mockLoadWebMedia.mockResolvedValueOnce({ fileName: 'empty.png' });
+
+        const log = { error: vi.fn(), debug: vi.fn() };
+        const mediaId = await uploadMedia(
+            { clientId: 'id', clientSecret: 'sec' } as any,
+            sandboxPath,
+            'image',
+            vi.fn().mockResolvedValue('token_abc'),
+            log as any,
+        );
+
+        expect(mediaId).toBeNull();
+        expect(log.error).toHaveBeenCalled();
+    });
 });

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -87,14 +87,15 @@ describe('media-utils', () => {
         const mediaPath = createTempFile(Buffer.from('hello world'));
         mockedAxiosPost.mockResolvedValueOnce({ data: { errcode: 0, media_id: 'media_123' } } as any);
 
-        const mediaId = await uploadMedia(
+        const result = await uploadMedia(
             { clientId: 'id', clientSecret: 'sec' } as any,
             mediaPath,
             'file',
             vi.fn().mockResolvedValue('token_abc')
         );
 
-        expect(mediaId).toBe('media_123');
+        expect(result?.mediaId).toBe('media_123');
+        expect(result?.buffer).toEqual(Buffer.from('hello world'));
         expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
         expect(mockedAxiosPost.mock.calls[0]?.[0]).toContain('access_token=token_abc&type=file');
 
@@ -324,7 +325,7 @@ describe('media-utils', () => {
         });
         mockedAxiosPost.mockResolvedValueOnce({ data: { errcode: 0, media_id: 'media_sandbox_1' } } as any);
 
-        const mediaId = await uploadMedia(
+        const result = await uploadMedia(
             { clientId: 'id', clientSecret: 'sec' } as any,
             sandboxPath,
             'image',
@@ -332,7 +333,7 @@ describe('media-utils', () => {
             { debug: vi.fn() } as any,
         );
 
-        expect(mediaId).toBe('media_sandbox_1');
+        expect(result?.mediaId).toBe('media_sandbox_1');
         expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: undefined });
         expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
     });
@@ -349,7 +350,7 @@ describe('media-utils', () => {
         });
         mockedAxiosPost.mockResolvedValueOnce({ data: { errcode: 0, media_id: 'media_sandbox_2' } } as any);
 
-        const mediaId = await uploadMedia(
+        const result = await uploadMedia(
             { clientId: 'id', clientSecret: 'sec' } as any,
             sandboxPath,
             'file',
@@ -358,7 +359,7 @@ describe('media-utils', () => {
             { mediaLocalRoots: localRoots },
         );
 
-        expect(mediaId).toBe('media_sandbox_2');
+        expect(result?.mediaId).toBe('media_sandbox_2');
         expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: localRoots });
     });
 

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -6,6 +6,14 @@ import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { detectMediaTypeFromExtension, getVoiceDurationMs, prepareMediaInput, uploadMedia } from '../../src/media-utils';
 
+const mockLoadWebMedia = vi.fn();
+vi.mock('../../src/runtime', () => ({
+    getDingTalkRuntime: () => ({
+        media: { loadWebMedia: mockLoadWebMedia },
+        channel: { media: { saveMediaBuffer: vi.fn() } },
+    }),
+}));
+
 vi.mock('axios', () => {
     const mockAxios = {
         get: vi.fn(),
@@ -303,5 +311,54 @@ describe('media-utils', () => {
         ).toBe(true);
 
         fs.rmSync(path.dirname(mediaPath), { recursive: true, force: true });
+    });
+
+    it('falls back to runtime media bridge for sandbox paths (ENOENT on host)', async () => {
+        const sandboxPath = '/workspace/generated-image.png';
+        const fileContent = Buffer.from('sandbox-image-data');
+
+        mockLoadWebMedia.mockResolvedValueOnce({
+            buffer: fileContent,
+            fileName: 'generated-image.png',
+            contentType: 'image/png',
+        });
+        mockedAxiosPost.mockResolvedValueOnce({ data: { errcode: 0, media_id: 'media_sandbox_1' } } as any);
+
+        const mediaId = await uploadMedia(
+            { clientId: 'id', clientSecret: 'sec' } as any,
+            sandboxPath,
+            'image',
+            vi.fn().mockResolvedValue('token_abc'),
+            { debug: vi.fn() } as any,
+        );
+
+        expect(mediaId).toBe('media_sandbox_1');
+        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: undefined });
+        expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes mediaLocalRoots to runtime media bridge', async () => {
+        const sandboxPath = '/workspace/output.pdf';
+        const fileContent = Buffer.from('pdf-data');
+        const localRoots = ['/workspace', '/tmp'];
+
+        mockLoadWebMedia.mockResolvedValueOnce({
+            buffer: fileContent,
+            fileName: 'output.pdf',
+            contentType: 'application/pdf',
+        });
+        mockedAxiosPost.mockResolvedValueOnce({ data: { errcode: 0, media_id: 'media_sandbox_2' } } as any);
+
+        const mediaId = await uploadMedia(
+            { clientId: 'id', clientSecret: 'sec' } as any,
+            sandboxPath,
+            'file',
+            vi.fn().mockResolvedValue('token_abc'),
+            { debug: vi.fn() } as any,
+            { mediaLocalRoots: localRoots },
+        );
+
+        expect(mediaId).toBe('media_sandbox_2');
+        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: localRoots });
     });
 });

--- a/tests/unit/send-service-media.test.ts
+++ b/tests/unit/send-service-media.test.ts
@@ -49,7 +49,7 @@ describe('send-service media branches', () => {
     });
 
     it('sendBySession uses native image body when upload succeeds', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_img_1');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_img_1', buffer: Buffer.from('img') });
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
@@ -82,7 +82,7 @@ describe('send-service media branches', () => {
     });
 
     it('sendBySession bypasses proxy when configured', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_img_proxy');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_img_proxy', buffer: Buffer.from('data') });
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
@@ -111,7 +111,7 @@ describe('send-service media branches', () => {
     });
 
     it('sendProactiveMedia maps image payload to sampleImageMsg template', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_img_2');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_img_2', buffer: Buffer.from('data') });
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_image' } } as any);
 
         const result = await sendProactiveMedia(
@@ -128,7 +128,7 @@ describe('send-service media branches', () => {
     });
 
     it('sendProactiveMedia maps voice payload to sampleAudio template', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_voice_1');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_voice_1', buffer: Buffer.from('data') });
         mockedGetVoiceDurationMs.mockResolvedValueOnce(1000);
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_voice' } } as any);
 
@@ -146,7 +146,7 @@ describe('send-service media branches', () => {
     });
 
     it('delegates proactive media journaling when storePath is provided', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_voice_2');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_voice_2', buffer: Buffer.from('data') });
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_voice_2' } } as any);
 
         await sendProactiveMedia(
@@ -186,7 +186,7 @@ describe('send-service media branches', () => {
     });
 
     it('persists proactive media fallback text without emoji prefix', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_file_fallback');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_file_fallback', buffer: Buffer.from('data') });
         mockedAxios
             .mockRejectedValueOnce({
                 message: 'upload send failed',
@@ -222,7 +222,7 @@ describe('send-service media branches', () => {
     });
 
     it('sendProactiveMedia bypasses proxy when configured', async () => {
-        mockedUploadMedia.mockResolvedValueOnce('media_voice_proxy');
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_voice_proxy', buffer: Buffer.from('data') });
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_proxy' } } as any);
 
         await sendProactiveMedia(


### PR DESCRIPTION
## Summary

- Fix `uploadMedia` to resolve sandbox/container paths via `rt.media.loadWebMedia()` when direct host filesystem access fails (ENOENT)
- Propagate `mediaLocalRoots` through the full outbound media call chain: `channel.ts` → `sendProactiveMedia` → `uploadMedia`
- Add `mediaLocalRoots` to `SendMessageOptions` type for consistent threading

## Root cause

`uploadMedia` in `media-utils.ts` used `fs.createReadStream(mediaPath)` directly, which fails for paths like `/workspace/image.png` that exist inside a Docker sandbox container but not on the host filesystem.

## Changes

| File | Change |
|------|--------|
| `src/media-utils.ts` | New `readMediaBuffer()` helper: tries `fs.readFile` first, falls back to `rt.media.loadWebMedia()` for sandbox paths |
| `src/send-service.ts` | `uploadMedia` and `sendProactiveMedia` accept and forward `mediaLocalRoots` |
| `src/channel.ts` | `sendMedia` and `handleAction` extract `mediaLocalRoots` from context and pass downstream |
| `src/types.ts` | Add `mediaLocalRoots` to `SendMessageOptions` |
| `tests/unit/media-utils.test.ts` | 2 new tests: sandbox fallback + `mediaLocalRoots` propagation |

## Test plan

- [x] 18 media-utils tests pass (including 2 new sandbox tests)
- [x] 15 send-service tests pass
- [x] 147 inbound-handler tests pass
- [ ] Manual: Docker sandbox with `workspaceAccess: "rw"`, save image to `/workspace/`, send via DingTalk

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)