### PR TITLE
fix: fallback to quoted previewText when reply text is empty

### DIFF
--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -443,7 +443,7 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
     }
 
     return {
-      text: textContent,
+      text: textContent || quoted?.previewText || "",
       messageType: "text",
       quoted: quoted ?? undefined,
       atMentions,

--- a/tests/unit/message-utils.test.ts
+++ b/tests/unit/message-utils.test.ts
@@ -434,6 +434,29 @@ describe('message-utils', () => {
         expect(content.text).toContain('钉钉文档');
     });
 
+    it('引用消息正文为空时使用 quoted previewText 兜底', () => {
+        const message = {
+            msgtype: 'text',
+            text: {
+                content: ' ',
+                isReplyMsg: true,
+                repliedMsg: {
+                    msgType: 'text',
+                    msgId: 'msgbVA2Abf4IB/d2lvXE1utZg==',
+                    content: { text: '如果你能看到这条消息，请回复"我看到了"' },
+                },
+            },
+            isInAtList: true,
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.text).toBeTruthy();
+        expect(content.text).toContain('如果你能看到这条消息');
+        expect(content.quoted?.msgId).toBe('msgbVA2Abf4IB/d2lvXE1utZg==');
+        expect(content.quoted?.previewText).toBe('如果你能看到这条消息，请回复"我看到了"');
+    });
+
     it('原始钉钉文档消息 URL 缺少必需参数时安全降级', () => {
         const message = {
             msgId: 'doc_msg',


### PR DESCRIPTION
## Summary

- v3.4.0 回归：用户在群聊中「仅引用消息 + @Bot，不输入额外文字」时，消息被静默丢弃，机器人无任何响应
- 根因：PR #317 重构移除了 `quotedPrefix` 定义但保留了引用，PR #378 修复崩溃时移除了引用拼接，导致空正文引用消息的 `text` 为空串，在 `inbound-handler:348` 的 `if (!text) return` 处被丢弃
- 修复：`extractMessageContent` 返回 text 时，当正文为空但存在引用消息，用 `quoted.previewText` 兜底

## Changes

**`src/message-utils.ts`** — 1 行兜底逻辑

```diff
  return {
-   text: textContent,
+   text: textContent || quoted?.previewText || "",
```

**`tests/unit/message-utils.test.ts`** — 新增 1 个测试用例，模拟钉钉实际 payload（`content: " "`）

## Impact

仅当 `textContent` 为空且有 `quoted.previewText` 时生效，其他场景走原路径：

| 下游使用点 | 影响 |
|------------|------|
| `inbound-handler:348` 空检查 | **修复目标** — 消息不再被丢弃 |
| `inbound-handler:354` sub-agent 上下文拼接 | 无影响 — previewText 不含 `[引用...]` 前缀 |
| `inbound-handler:599-600` learn/session 命令解析 | 无影响 — 引用原文不匹配命令格式 |
| `inbound-handler:1089` message context store | 正面 — 存了有意义的文本 |
| `inbound-handler:1492-1502` agent runtime body | 正面 — agent 拿到引用原文作为输入 |
| `inbound-handler:1566` 日志 | 正面 — 有可读日志 |

## Test plan

- [x] 新增 failing test 复现 bug，修复后通过
- [x] 全量 645 tests 通过，无副作用
- [x] type-check 0 errors, lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)