### PR TITLE
ci: harden docs pages workflow setup

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -27,16 +27,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "pnpm"


### PR DESCRIPTION
## Summary
- enable GitHub Pages setup more explicitly in the docs workflow via `actions/configure-pages`
- update the docs workflow setup actions to newer major versions where applicable
- keep the workflow change isolated from the broader docs migration already merged in `#436`

## Test Plan
- [x] `pnpm run docs:build`
