### PR TITLE
fix: add timeout and host logging for inbound media download

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -241,6 +241,7 @@ type ReplyChunkInfo = {
 };
 
 const INBOUND_MEDIA_DOWNLOAD_TIMEOUT_MS = 15_000;
+const DINGTALK_API_HOST = "api.dingtalk.com";
 
 /**
  * Download DingTalk media file via runtime media service (sandbox-compatible).
@@ -253,6 +254,8 @@ export async function downloadMedia(
 ): Promise<MediaFile | null> {
   const rt = getDingTalkRuntime();
   let downloadUrl: string | undefined;
+  let requestStage = "auth";
+  let requestHost = DINGTALK_API_HOST;
   const formatAxiosErrorData = (value: unknown): string | undefined => {
     if (value === null || value === undefined) {
       return undefined;
@@ -285,7 +288,11 @@ export async function downloadMedia(
     return null;
   }
   try {
+    requestStage = "auth";
+    requestHost = DINGTALK_API_HOST;
     const token = await getAccessToken(config, log);
+    requestStage = "exchange";
+    requestHost = DINGTALK_API_HOST;
     const response = await axios.post(
       "https://api.dingtalk.com/v1.0/robot/messageFiles/download",
       { downloadCode, robotCode },
@@ -300,6 +307,14 @@ export async function downloadMedia(
       );
       return null;
     }
+    requestStage = "download";
+    requestHost = (() => {
+      try {
+        return new URL(downloadUrl).host || "unknown";
+      } catch {
+        return "unknown";
+      }
+    })();
     const mediaResponse = await axios.get(downloadUrl, {
       responseType: "arraybuffer",
       timeout: INBOUND_MEDIA_DOWNLOAD_TIMEOUT_MS,
@@ -316,16 +331,6 @@ export async function downloadMedia(
     return { path: saved.path, mimeType: saved.contentType ?? contentType };
   } catch (err: any) {
     if (log?.error) {
-      const downloadHost = (() => {
-        if (!downloadUrl) {
-          return "unknown";
-        }
-        try {
-          return new URL(downloadUrl).host || "unknown";
-        } catch {
-          return "unknown";
-        }
-      })();
       if (axios.isAxiosError(err)) {
         const status = err.response?.status;
         const statusText = err.response?.statusText;
@@ -333,7 +338,7 @@ export async function downloadMedia(
         const code = err.code ? ` code=${err.code}` : "";
         const statusLabel = status ? ` status=${status}${statusText ? ` ${statusText}` : ""}` : "";
         log.error(
-          `[DingTalk] Failed to download media: host=${downloadHost}${statusLabel}${code} message=${err.message}`,
+          `[DingTalk] Failed to download media: stage=${requestStage} host=${requestHost}${statusLabel}${code} message=${err.message}`,
         );
         if (err.response?.data !== undefined) {
           log.error(formatDingTalkErrorPayloadLog("inbound.downloadMedia", err.response.data));
@@ -341,7 +346,9 @@ export async function downloadMedia(
           log.error(`[DingTalk] downloadMedia response data: ${dataDetail}`);
         }
       } else {
-        log.error(`[DingTalk] Failed to download media: host=${downloadHost} ${err.message}`);
+        log.error(
+          `[DingTalk] Failed to download media: stage=${requestStage} host=${requestHost} message=${err.message}`,
+        );
       }
     }
     return null;

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -286,7 +286,63 @@ describe("inbound-handler", () => {
 
     expect(result).toBeNull();
     expect(log.error).toHaveBeenCalledWith(
-      expect.stringContaining("host=download.url"),
+      expect.stringContaining("stage=download host=download.url"),
+    );
+  });
+
+  it("downloadMedia logs the auth stage when token retrieval fails", async () => {
+    const log = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    mockedGetAccessToken.mockRejectedValueOnce(new Error("token failed"));
+
+    const result = await downloadMedia(
+      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      "download_code_1",
+      log as any,
+    );
+
+    expect(result).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("stage=auth host=api.dingtalk.com message=token failed"),
+    );
+  });
+
+  it("downloadMedia logs the exchange stage when messageFiles/download fails", async () => {
+    const log = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    mockedAxiosPost.mockRejectedValueOnce({
+      isAxiosError: true,
+      code: "ECONNRESET",
+      message: "socket hang up",
+      request: {},
+    });
+
+    const result = await downloadMedia(
+      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      "download_code_1",
+      log as any,
+    );
+
+    expect(result).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("stage=exchange host=api.dingtalk.com"),
+    );
+  });
+
+  it("downloadMedia keeps message= prefix for non-Axios download failures", async () => {
+    const log = { debug: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+    mockedAxiosPost.mockResolvedValueOnce({
+      data: { downloadUrl: "https://download.url/file" },
+    } as any);
+    mockedAxiosGet.mockRejectedValueOnce(new Error("plain failure"));
+
+    const result = await downloadMedia(
+      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      "download_code_1",
+      log as any,
+    );
+
+    expect(result).toBeNull();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining("stage=download host=download.url message=plain failure"),
     );
   });
 


### PR DESCRIPTION
## 背景

Issue #442 暴露了一个入站附件下载的稳定性问题：

`downloadMedia()` 在拿到 DingTalk 返回的 `downloadUrl` 之后，会再发起一次实际文件下载请求；但这第二跳 `axios.get()` 没有显式 `timeout`。在企业内网、代理或 OSS 网络路径受限的环境下，这个请求可能一直挂到操作系统层面的 TCP 超时，导致：

- 当前消息处理链路长时间阻塞
- 用户侧长时间无响应
- 最终日志只有 `ETIMEDOUT`，缺少可定位具体网络出口问题的关键信息

这个问题不仅影响普通附件消息，也会影响复用 `downloadMedia()` 的引用图片、引用文件等恢复路径。

## 目标

这次 PR 只解决 Issue #442 对应的两个核心问题，不扩大范围：

- 让入站附件下载在异常网络环境下尽快失败，而不是被动等待系统级超时
- 让失败日志带上足够的诊断信息，至少能看出是哪个下载 host 不可达

不在这次 PR 中引入更大范围的下载策略调整，例如 IPv4-only retry、额外配置项或下载链路重构。

## 实现

### 1. 为第二跳附件下载增加显式超时
在 `src/inbound-handler.ts` 的 `downloadMedia()` 中，为 `downloadUrl` 的实际下载请求增加固定超时：

- `timeout: 15_000`

这样在 OSS 地址不可达或网络策略拦截时，会更快返回失败，避免整条消息链路卡住接近两分钟。

### 2. 在错误日志中补充下载 host
保留 `downloadUrl` 并在 catch 中解析 host，在主错误日志中输出：

- `host=<hostname>`
- `status/code/message`

这样线上出现 `ETIMEDOUT`、连接失败或其他网络错误时，可以直接判断是哪个下载地址出问题，而不需要额外抓包或手工复现。

### 3. 补充回归测试
在 `tests/unit/inbound-handler.test.ts` 中新增回归覆盖：

- 断言第二跳 `axios.get()` 包含 `timeout`
- 断言下载失败时日志中包含 `host=...`

同时把测试里的 axios mock 与 `axios.isAxiosError(...)` 的实际调用方式对齐，保证用例能稳定覆盖该分支。

## 验证

- `pnpm exec vitest run tests/unit/inbound-handler.test.ts`
- `pnpm test`
- `pnpm type-check`
- `pnpm lint`

补充说明：`pnpm lint` 为 `0 error`，但仓库当前仍存在既有 warning；本 PR 未新增 lint error。

Fixes #442
