### PR TITLE
refactor: remove dead config fields corpId, agentId, robotCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,6 @@ openclaw configure --section channels
       "enabled": true,
       "clientId": "dingxxxxxx",
       "clientSecret": "your-app-secret",
-      "robotCode": "dingxxxxxx",
-      "corpId": "dingxxxxxx",
-      "agentId": "123456789",
       "dmPolicy": "open",
       "groupPolicy": "open",
       "messageType": "markdown"

--- a/docs/archive/dingtalk-plugin-promo.zh-CN.md
+++ b/docs/archive/dingtalk-plugin-promo.zh-CN.md
@@ -103,9 +103,8 @@ openclaw configure --section channels
 
 建议按向导填写：
 
-- `Client ID` = AppKey
+- `Client ID` = AppKey（同时作为钉钉 API 中的 robot code，无需单独配置）
 - `Client Secret` = AppSecret
-- 进阶项（推荐填全以获得更好的兼容性）：`Robot Code`、`Corp ID`、`Agent ID`
 - 选择回复模式：
   - 常规场景：`markdown`
   - AI 对话沉浸体验：`card`（需配置 `cardTemplateId` / `cardTemplateKey`）

--- a/docs/plans/2026-03-28-pr-380-http-callback-hardening.md
+++ b/docs/plans/2026-03-28-pr-380-http-callback-hardening.md
@@ -172,7 +172,7 @@ Expected: FAIL because HTTP currently bypasses dedup and in-flight protection.
 - [ ] **Step 4: Extract the reusable guard**
 
 Create `src/inbound-dispatch-guard.ts` with one helper that:
-- derives `dedupKey` from `robotCode || clientId || accountId` and `msgId`
+- derives `dedupKey` from `clientId || accountId` (same scope as `resolveRobotCode` / API `robotCode`) and `msgId`
 - checks `isMessageProcessed()`
 - manages the existing in-flight TTL map behavior
 - calls `handleDingTalkMessage()`

--- a/docs/user/getting-started/configure.md
+++ b/docs/user/getting-started/configure.md
@@ -19,7 +19,7 @@ openclaw configure --section channels
 1. 选择 `dingtalk`
 2. 输入 `Client ID`
 3. 输入 `Client Secret`
-4. 视情况补充 `Robot Code`、`Corp ID`、`Agent ID`
+4. 确认凭证与钉钉开放平台一致（`clientId` 同时用作钉钉 API 中的 robot code；无需单独填写企业 ID 或钉钉应用 ID）
 5. 选择消息模式
 6. 选择私聊与群聊策略
 
@@ -40,9 +40,6 @@ openclaw configure --section channels
       "enabled": true,
       "clientId": "dingxxxxxx",
       "clientSecret": "your-app-secret",
-      "robotCode": "dingxxxxxx",
-      "corpId": "dingxxxxxx",
-      "agentId": "123456789",
       "dmPolicy": "open",
       "groupPolicy": "open",
       "messageType": "markdown"

--- a/docs/user/getting-started/permissions.md
+++ b/docs/user/getting-started/permissions.md
@@ -59,11 +59,8 @@ message=auth level of org is not enough
 
 从开发者后台获取：
 
-- `Client ID`
+- `Client ID`（与开放平台 AppKey 一致；插件将其同时用作钉钉 API 请求中的 `robotCode`）
 - `Client Secret`
-- `Robot Code`
-- `Corp ID`
-- `Agent ID`
 
 ## 6. 配置联动
 

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -7,11 +7,8 @@
 | 选项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | `enabled` | boolean | `true` | 是否启用插件 |
-| `clientId` | string | 必填 | 钉钉 AppKey |
+| `clientId` | string | 必填 | 钉钉 AppKey；同时作为钉钉 API 请求中的 `robotCode` |
 | `clientSecret` | string | 必填 | 钉钉 AppSecret |
-| `robotCode` | string | - | 机器人代码 |
-| `corpId` | string | - | 企业 ID |
-| `agentId` | string | - | 应用 ID |
 | `dmPolicy` | string | `open` | 私聊策略 |
 | `groupPolicy` | string | `open` | 群聊策略 |
 | `allowFrom` | string[] | `[]` | 私聊白名单 |
@@ -36,6 +33,10 @@
 | `initialReconnectDelay` | number | `1000` | 初始重连延迟 |
 | `maxReconnectDelay` | number | `60000` | 最大重连延迟 |
 | `reconnectJitter` | number | `0.3` | 重连抖动因子 |
+
+## 关于 `clientId` 与钉钉 `robotCode`
+
+钉钉开放接口的请求体里仍会携带 `robotCode` 字段。本插件不提供单独的 `robotCode`、`corpId` 或钉钉应用 `agentId` 配置项：`clientId` 会作为机器人代码用于相关 API 调用。
 
 ## 关于 `displayNameResolution`
 

--- a/scripts/dingtalk-stream-monitor.mjs
+++ b/scripts/dingtalk-stream-monitor.mjs
@@ -56,9 +56,6 @@ function parseArgs(argv) {
   const out = {
     clientId: process.env.DINGTALK_CLIENT_ID?.trim() || "",
     clientSecret: process.env.DINGTALK_CLIENT_SECRET?.trim() || "",
-    robotCode: process.env.DINGTALK_ROBOT_CODE?.trim() || "",
-    corpId: process.env.DINGTALK_CORP_ID?.trim() || "",
-    agentId: process.env.DINGTALK_AGENT_ID?.trim() || "",
     sdkDebug: process.env.DINGTALK_MONITOR_SDK_DEBUG === "1",
     sdkKeepAlive: process.env.DINGTALK_MONITOR_SDK_KEEPALIVE !== "0",
     durationSec: Number.parseInt(process.env.DINGTALK_MONITOR_DURATION_SEC ?? "0", 10) || 0,
@@ -77,15 +74,6 @@ function parseArgs(argv) {
       i += 1;
     } else if (arg === "--client-secret" && next) {
       out.clientSecret = next.trim();
-      i += 1;
-    } else if (arg === "--robot-code" && next) {
-      out.robotCode = next.trim();
-      i += 1;
-    } else if (arg === "--corp-id" && next) {
-      out.corpId = next.trim();
-      i += 1;
-    } else if (arg === "--agent-id" && next) {
-      out.agentId = next.trim();
       i += 1;
     } else if (arg === "--summary-every" && next) {
       out.summaryEverySec = Number.parseInt(next, 10) || out.summaryEverySec;
@@ -241,9 +229,6 @@ async function main() {
     envFile: envLoadResult.resolved,
     envFileLoaded: envLoadResult.loaded,
     clientId: mask(clientId),
-    robotCode: mask(args.robotCode || clientId),
-    corpId: mask(args.corpId),
-    agentId: args.agentId ? String(args.agentId) : "",
     sdkDebug: args.sdkDebug,
     sdkKeepAlive: args.sdkKeepAlive,
     durationSec: args.durationSec,

--- a/src/ack-reaction-service.ts
+++ b/src/ack-reaction-service.ts
@@ -23,7 +23,6 @@ type AckReactionLogger = {
 type AckReactionTarget = {
   msgId: string;
   conversationId: string;
-  robotCode?: string;
   reactionName?: string;
 };
 
@@ -50,7 +49,7 @@ function resolveAckReactionRequest(
   config: DingTalkConfig,
   data: AckReactionTarget,
 ): ResolvedAckReactionRequest | null {
-  const robotCode = (data.robotCode || config.robotCode || config.clientId || "").trim();
+  const robotCode = (config.clientId || "").trim();
   const reactionName =
     (data.reactionName || DINGTALK_NATIVE_ACK_REACTION).trim() || DINGTALK_NATIVE_ACK_REACTION;
   if (!robotCode || !data.msgId || !data.conversationId) {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -20,9 +20,6 @@ const DingTalkAccountConfigShape = {
   /** DingTalk App Secret (Client Secret) - required for authentication */
   clientSecret: z.string().optional(),
 
-  /** DingTalk Robot Code for media download */
-  robotCode: z.string().optional(),
-
   /** Direct message policy: open, pairing, or allowlist */
   dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional().default("open"),
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,11 +143,10 @@ export const resolveUserPath = resolveRelativePath;
 
 /**
  * Resolve the robot code used by DingTalk APIs.
- * Falls back to clientId so existing deployments can omit robotCode when they
- * use the same identifier for both values.
+ * DingTalk robotCode is always equal to clientId; this helper trims whitespace.
  */
-export function resolveRobotCode(config: Pick<DingTalkConfig, "clientId" | "robotCode">): string {
-  return (config.robotCode || config.clientId || "").trim();
+export function resolveRobotCode(config: Pick<DingTalkConfig, "clientId">): string {
+  return (config.clientId || "").trim();
 }
 
 export function resolveGroupConfig(

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -283,7 +283,7 @@ export async function downloadMedia(
   const robotCode = resolveRobotCode(config);
   if (!robotCode) {
     if (log?.error) {
-      log.error("[DingTalk] downloadMedia requires clientId or robotCode to be configured.");
+      log.error("[DingTalk] downloadMedia requires clientId to be configured.");
     }
     return null;
   }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -115,7 +115,6 @@ function applyAccountConfig(params: {
   const payload: Partial<DingTalkConfig> = {
     ...(input.clientId ? { clientId: input.clientId } : {}),
     ...(input.clientSecret ? { clientSecret: input.clientSecret } : {}),
-    ...(input.robotCode ? { robotCode: input.robotCode } : {}),
     ...(input.dmPolicy ? { dmPolicy: input.dmPolicy } : {}),
     ...(input.groupPolicy ? { groupPolicy: input.groupPolicy } : {}),
     ...(input.allowFrom && input.allowFrom.length > 0 ? { allowFrom: input.allowFrom } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,6 @@ export type AckReactionConfigValue = string;
 export interface DingTalkConfig extends OpenClawConfig {
   clientId: string;
   clientSecret: string;
-  robotCode?: string;
   name?: string;
   enabled?: boolean;
   dmPolicy?: "open" | "pairing" | "allowlist";
@@ -93,7 +92,6 @@ export interface DingTalkChannelConfig {
   enabled?: boolean;
   clientId: string;
   clientSecret: string;
-  robotCode?: string;
   name?: string;
   dmPolicy?: "open" | "pairing" | "allowlist";
   groupPolicy?: "open" | "allowlist" | "disabled";
@@ -756,7 +754,6 @@ export function resolveDingTalkAccount(
     const config: DingTalkConfig = {
       clientId: dingtalk?.clientId ?? "",
       clientSecret: dingtalk?.clientSecret ?? "",
-      robotCode: dingtalk?.robotCode,
       name: dingtalk?.name,
       enabled: dingtalk?.enabled,
       dmPolicy: dingtalk?.dmPolicy,

--- a/tests/integration/error-payload-logging.test.ts
+++ b/tests/integration/error-payload-logging.test.ts
@@ -44,7 +44,7 @@ describe('error payload logging integration', () => {
         const log = { error: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', messageType: 'markdown' },
+            { clientId: 'id', clientSecret: 'sec', messageType: 'markdown' },
             'user_123',
             'hello',
             { log }

--- a/tests/integration/gateway-inbound-flow.test.ts
+++ b/tests/integration/gateway-inbound-flow.test.ts
@@ -87,7 +87,7 @@ function createStartContext() {
         cfg: {},
         account: {
             accountId: 'main',
-            config: { clientId: 'ding_id', clientSecret: 'ding_secret', robotCode: 'robot_1' },
+            config: { clientId: 'ding_id', clientSecret: 'ding_secret' },
         },
         log: {
             info: vi.fn(),
@@ -146,7 +146,7 @@ describe('gateway inbound callback pipeline', () => {
 
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(1);
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_1', { success: true });
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_1');
+        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('ding_id:msg_1');
         expect(shared.handleDingTalkMessageMock).toHaveBeenCalledTimes(1);
         expect(shared.handleDingTalkMessageMock).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -216,7 +216,7 @@ describe('gateway inbound callback pipeline', () => {
         await shared.listeners.TOPIC_ROBOT?.(payload);
         expect(shared.handleDingTalkMessageMock).toHaveBeenCalledTimes(2);
         expect(shared.markMessageProcessedMock).toHaveBeenCalledTimes(1);
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_retry');
+        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('ding_id:msg_retry');
         // Both attempts ack immediately
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(2);
         expect(shared.socketCallBackResponseMock).toHaveBeenNthCalledWith(2, 'stream_msg_retry', { success: true });
@@ -280,7 +280,7 @@ describe('gateway inbound callback pipeline', () => {
         await second;
 
         expect(shared.markMessageProcessedMock).toHaveBeenCalledTimes(1);
-        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('robot_1:msg_inflight');
+        expect(shared.markMessageProcessedMock).toHaveBeenCalledWith('ding_id:msg_inflight');
         // Both the first message and the in-flight duplicate are acked immediately
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledTimes(2);
         expect(shared.socketCallBackResponseMock).toHaveBeenCalledWith('stream_msg_inflight_1', { success: true });

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -81,7 +81,7 @@ describe('card-service', () => {
         });
 
         const card = await createAICard(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'cidA1B2C3'
         );
 
@@ -104,7 +104,7 @@ describe('card-service', () => {
         mockedAxios.post.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         await createAICard(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'robot_1' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'manager123'
         );
 
@@ -112,7 +112,7 @@ describe('card-service', () => {
         expect(body.openSpaceId).toBe('dtv1.card//IM_ROBOT.manager123');
         expect(body.imRobotOpenDeliverModel).toEqual({
             spaceType: 'IM_ROBOT',
-            robotCode: 'robot_1',
+            robotCode: 'id',
             extension: { dynamicSummary: 'true' },
         });
     });
@@ -125,7 +125,6 @@ describe('card-service', () => {
                 clientId: 'id',
                 clientSecret: 'sec',
                 cardTemplateId: 'tmpl.schema',
-                robotCode: 'robot_1',
                 bypassProxyForSend: true,
             } as any,
             'manager123'
@@ -481,7 +480,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const card = await createAICard(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'cid_pending',
             undefined,
             { accountId: 'main', storePath }
@@ -521,7 +520,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const recovered = await recoverPendingCardsForAccount(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'main',
             storePath
         );
@@ -555,7 +554,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const finalized = await finalizeActiveCardsForAccount(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'main',
             'stop-reason',
             storePath
@@ -584,7 +583,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const result = await sendProactiveCardText(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'cid_proactive',
             'proactive done'
         );
@@ -621,7 +620,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const recovered = await recoverPendingCardsForAccount(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'main',
             storePath
         );
@@ -645,7 +644,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const card = await createAICard(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'cid_pending_track',
             undefined,
             { accountId: 'main', storePath }
@@ -660,7 +659,7 @@ describe('card-service', () => {
         mockedAxios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
 
         const recovered = await recoverPendingCardsForAccount(
-            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
             'main',
             storePath
         );

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -237,7 +237,7 @@ describe("inbound-handler", () => {
     } as any);
 
     const result = await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
     );
 
@@ -256,7 +256,7 @@ describe("inbound-handler", () => {
     } as any);
 
     await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
     );
 
@@ -279,7 +279,7 @@ describe("inbound-handler", () => {
     });
 
     const result = await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
       log as any,
     );
@@ -295,7 +295,7 @@ describe("inbound-handler", () => {
     mockedGetAccessToken.mockRejectedValueOnce(new Error("token failed"));
 
     const result = await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
       log as any,
     );
@@ -316,7 +316,7 @@ describe("inbound-handler", () => {
     });
 
     const result = await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
       log as any,
     );
@@ -335,7 +335,7 @@ describe("inbound-handler", () => {
     mockedAxiosGet.mockRejectedValueOnce(new Error("plain failure"));
 
     const result = await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
       log as any,
     );
@@ -359,7 +359,7 @@ describe("inbound-handler", () => {
     } as any);
 
     await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1", mediaMaxMb: 50 } as any,
+      { clientId: "id", clientSecret: "sec", mediaMaxMb: 50 } as any,
       "download_code_1",
     );
 
@@ -384,7 +384,7 @@ describe("inbound-handler", () => {
     } as any);
 
     await downloadMedia(
-      { clientId: "id", clientSecret: "sec", robotCode: "robot_1" } as any,
+      { clientId: "id", clientSecret: "sec" } as any,
       "download_code_1",
     );
 
@@ -393,7 +393,7 @@ describe("inbound-handler", () => {
     expect(call[2]).toBe("inbound");
   });
 
-  it("downloadMedia falls back to clientId when robotCode is missing", async () => {
+  it("downloadMedia uses clientId as robotCode", async () => {
     const runtime = buildRuntime();
     shared.getRuntimeMock.mockReturnValue(runtime);
 
@@ -2545,7 +2545,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_group_file_quote_1",
         msgtype: "text",
@@ -2592,7 +2592,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_origin_msg",
         msgtype: "interactiveCard",
@@ -2659,7 +2659,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_origin_msg_extract",
         msgtype: "interactiveCard",
@@ -2727,7 +2727,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_origin_msg_extract_error",
         msgtype: "interactiveCard",
@@ -2792,7 +2792,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_quote_msg",
         msgtype: "text",
@@ -2870,7 +2870,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_quote_msg_filename",
         msgtype: "text",
@@ -2936,7 +2936,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_quote_msg_cached_filename",
         msgtype: "text",
@@ -2992,7 +2992,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_group_file_name",
         msgtype: "text",
@@ -3055,7 +3055,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_group_file_name_conflict",
         msgtype: "text",
@@ -3125,7 +3125,7 @@ describe("inbound-handler", () => {
         dingtalkConfig: {
           groupPolicy: "open",
           messageType: "markdown",
-          robotCode: "robot_1",
+          clientId: "robot_1",
           journalTTLDays: 30,
         } as any,
         data: {
@@ -3191,7 +3191,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_group_doc_name_conflict",
         msgtype: "text",
@@ -3238,7 +3238,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "doc_quote_group_msg",
         msgtype: "text",
@@ -3292,7 +3292,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "group_doc_quote",
         msgtype: "text",
@@ -3377,7 +3377,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_group_file_quote_2",
         msgtype: "text",
@@ -4916,7 +4916,7 @@ describe("inbound-handler", () => {
         groupPolicy: "allowlist",
         allowFrom: ["cid_group_1"],
         messageType: "card",
-        robotCode: "robot_1",
+        clientId: "robot_1",
         groups: { cid_group_1: { systemPrompt: "group prompt" } },
       } as any,
       data: {
@@ -6327,7 +6327,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "msg_attach_concat",
         msgtype: "interactiveCard",
@@ -6393,7 +6393,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_file_dl_777",
         msgtype: "text",
@@ -6467,7 +6467,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { groupPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_file_step1_guard",
         msgtype: "text",
@@ -6726,7 +6726,7 @@ describe("inbound-handler", () => {
       accountId: "main",
       sessionWebhook: "https://session.webhook",
       log: undefined,
-      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", robotCode: "robot_1" } as any,
+      dingtalkConfig: { dmPolicy: "open", messageType: "markdown", clientId: "robot_1" } as any,
       data: {
         msgId: "m_file_sandbox",
         msgtype: "file",

--- a/tests/unit/message-transform.test.ts
+++ b/tests/unit/message-transform.test.ts
@@ -22,7 +22,6 @@ const mockedAxios = vi.mocked(axios);
 const config: DingTalkConfig = {
     clientId: 'ding-client-id',
     clientSecret: 'client-secret',
-    robotCode: 'ding-client-id',
 } as DingTalkConfig;
 
 describe('message payload transform', () => {

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -118,7 +118,6 @@ describe("dingtalk setup wizard", () => {
         expect(result.accountId).toBe("default");
         expect(dingtalkConfig.clientId).toBe("ding_client");
         expect(dingtalkConfig.clientSecret).toBe("ding_secret");
-        expect(dingtalkConfig.robotCode).toBeUndefined();
         expect((dingtalkConfig as any).corpId).toBeUndefined();
         expect((dingtalkConfig as any).agentId).toBeUndefined();
         expect(dingtalkConfig.messageType).toBe("card");
@@ -134,7 +133,7 @@ describe("dingtalk setup wizard", () => {
         expect(note).toHaveBeenCalled();
     });
 
-    it("generic setup input no longer stores legacy code as robotCode", () => {
+    it("generic setup input stores clientId and clientSecret without legacy fields", () => {
         const cfg = dingtalkSetupAdapter.applyAccountConfig({
             cfg: {} as any,
             accountId: "default",
@@ -148,7 +147,6 @@ describe("dingtalk setup wizard", () => {
         const dingtalkConfig = cfg.channels?.dingtalk;
         expect(dingtalkConfig?.clientId).toBe("ding_client");
         expect(dingtalkConfig?.clientSecret).toBe("ding_secret");
-        expect((dingtalkConfig as any)?.robotCode).toBeUndefined();
     });
 
     it("configure with disabled groupPolicy skips groupAllowFrom prompt", async () => {

--- a/tests/unit/send-service-advanced.test.ts
+++ b/tests/unit/send-service-advanced.test.ts
@@ -62,7 +62,7 @@ describe('send-service advanced branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_123' } } as any);
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', messageType: 'card', cardTemplateId: 'tmpl' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card', cardTemplateId: 'tmpl' } as any,
             'manager123',
             'text',
             { accountId: 'main' } as any,
@@ -82,7 +82,7 @@ describe('send-service advanced branches', () => {
         });
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', messageType: 'card', cardTemplateId: 'tmpl' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card', cardTemplateId: 'tmpl' } as any,
             'manager123',
             'text',
             { accountId: 'main' } as any,
@@ -109,7 +109,7 @@ describe('send-service advanced branches', () => {
         });
 
         await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', messageType: 'card', cardTemplateId: 'tmpl' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card', cardTemplateId: 'tmpl' } as any,
             'manager123',
             'card proactive text',
             {
@@ -156,7 +156,7 @@ describe('send-service advanced branches', () => {
         const log = { error: vi.fn() };
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             'text',
             { log: log as any }
@@ -190,7 +190,7 @@ describe('send-service advanced branches', () => {
         const log = { error: vi.fn(), debug: vi.fn() };
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             '0341234567',
             'text',
             { log: log as any, accountId: 'main' } as any,
@@ -211,7 +211,7 @@ describe('send-service advanced branches', () => {
         });
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'manager123',
             'text',
             { accountId: 'main' } as any,
@@ -229,7 +229,7 @@ describe('send-service advanced branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { errcode: 0, errmsg: 'ok', msgid: 'legacy_msg_2' } } as any);
 
         await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             'hello session',
             {
@@ -272,7 +272,7 @@ describe('send-service advanced branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'proactive_q_1' } } as any);
 
         await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             'hello proactive',
             {
@@ -301,7 +301,7 @@ describe('send-service advanced branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'proactive_q_dm_1' } } as any);
 
         await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'user_target_123',
             'hello proactive dm',
             {

--- a/tests/unit/send-service-card.test.ts
+++ b/tests/unit/send-service-card.test.ts
@@ -41,7 +41,7 @@ describe('sendMessage card mode', () => {
         mockedAxios.mockResolvedValue({ data: { processQueryKey: 'q_skip' } } as any);
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', messageType: 'card', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card' } as any,
             'cidA1B2C3',
             'stream content',
             { card, sessionWebhook: 'https://session.webhook' }
@@ -62,7 +62,7 @@ describe('sendMessage card mode', () => {
         cardMocks.streamAICardMock.mockResolvedValue(undefined);
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', messageType: 'card', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card' } as any,
             'cidA1B2C3',
             ' world',
             { card, cardUpdateMode: 'append' } as any,
@@ -78,7 +78,7 @@ describe('sendMessage card mode', () => {
         mockedAxios.mockResolvedValue({ data: { processQueryKey: 'q_456' } } as any);
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', messageType: 'card', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card' } as any,
             'cidA1B2C3',
             'fallback text',
             { card, sessionWebhook: 'https://session.webhook' }
@@ -103,7 +103,6 @@ describe('sendMessage card mode', () => {
                 clientId: 'id',
                 clientSecret: 'sec',
                 messageType: 'card',
-                robotCode: 'id',
                 cardTemplateId: 'tmpl.schema',
             } as any,
             'cidA1B2C3',
@@ -133,7 +132,7 @@ describe('sendMessage card mode', () => {
         mockedAxios.mockResolvedValue({ data: { processQueryKey: 'q_789' } } as any);
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', messageType: 'card', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card' } as any,
             'cidA1B2C3',
             'no card text',
             { sessionWebhook: 'https://session.webhook' }
@@ -150,7 +149,7 @@ describe('sendMessage card mode', () => {
         cardMocks.streamAICardMock.mockRejectedValue(new Error('stream failed'));
 
         const result = await sendMessage(
-            { clientId: 'id', clientSecret: 'sec', messageType: 'card', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec', messageType: 'card' } as any,
             'cidA1B2C3',
             'appended',
             { card, cardUpdateMode: 'append' } as any

--- a/tests/unit/send-service-media.test.ts
+++ b/tests/unit/send-service-media.test.ts
@@ -53,7 +53,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'https://session.webhook',
             'ignored text',
             { mediaPath: '/tmp/a.png', mediaType: 'image' }
@@ -68,7 +68,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'https://session.webhook',
             'ignored text',
             {
@@ -93,7 +93,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'https://session.webhook',
             'fallback text',
             { mediaPath: '/tmp/a.png', mediaType: 'image', useMarkdown: false }
@@ -111,7 +111,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { ok: true } } as any);
 
         await sendBySession(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', bypassProxyForSend: true } as any,
+            { clientId: 'id', clientSecret: 'sec', bypassProxyForSend: true } as any,
             'https://session.webhook',
             'ignored text',
             { mediaPath: '/tmp/a.png', mediaType: 'image' }
@@ -125,7 +125,7 @@ describe('send-service media branches', () => {
         mockedUploadMedia.mockResolvedValueOnce(null);
 
         const result = await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             '/tmp/a.pdf',
             'file'
@@ -140,7 +140,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_image' } } as any);
 
         const result = await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             '/tmp/a.png',
             'image'
@@ -157,7 +157,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_image_roots' } } as any);
 
         await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'cidA1B2C3',
             '/tmp/a.png',
             'image',
@@ -180,7 +180,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_voice' } } as any);
 
         const result = await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'user_123',
             '/tmp/a.amr',
             'voice'
@@ -197,7 +197,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_voice_2' } } as any);
 
         await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'user_123',
             '/tmp/a.amr',
             'voice',
@@ -246,7 +246,7 @@ describe('send-service media branches', () => {
             .mockResolvedValueOnce({ data: { processQueryKey: 'fallback_q_1' } } as any);
 
         const result = await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id' } as any,
+            { clientId: 'id', clientSecret: 'sec' } as any,
             'user_123',
             '/tmp/a.pdf',
             'file',
@@ -279,7 +279,7 @@ describe('send-service media branches', () => {
         mockedAxios.mockResolvedValueOnce({ data: { processQueryKey: 'q_proxy' } } as any);
 
         await sendProactiveMedia(
-            { clientId: 'id', clientSecret: 'sec', robotCode: 'id', bypassProxyForSend: true } as any,
+            { clientId: 'id', clientSecret: 'sec', bypassProxyForSend: true } as any,
             'user_123',
             '/tmp/a.amr',
             'voice'

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -24,7 +24,6 @@ describe('types helpers', () => {
                 dingtalk: {
                     clientId: 'cli_default',
                     clientSecret: 'sec_default',
-                    robotCode: 'robot_default',
                     dmPolicy: 'allowlist',
                     displayNameResolution: 'all',
                 },
@@ -35,7 +34,6 @@ describe('types helpers', () => {
 
         expect(account.accountId).toBe('default');
         expect(account.clientId).toBe('cli_default');
-        expect(account.robotCode).toBe('robot_default');
         expect(account.displayNameResolution).toBe('all');
         expect(account.configured).toBe(true);
     });


### PR DESCRIPTION
## Summary

移除三个无用的配置字段，简化配置表面：

- **`corpId`**（企业 ID）：源码中零引用，从未被消费
- **`agentId`**（钉钉应用 ID）：源码中零引用，从未被消费（注：OpenClaw agent 路由的 `agentId` 不受影响）
- **`robotCode`**（机器人代码）：始终等于 `clientId`，直接使用 `clientId` 即可

## Changes

### 源码
- `config-schema.ts` — 移除 `robotCode` Zod 字段定义
- `types.ts` — 从 `DingTalkConfig` / `DingTalkChannelConfig` 移除 `robotCode`
- `config.ts` — `resolveRobotCode()` 简化为只读取 `clientId`
- `ack-reaction-service.ts` — 移除 `AckReactionTarget.robotCode`，直接用 `config.clientId`
- `onboarding.ts` — 移除 `robotCode` 传递
- `inbound-handler.ts` — 更新错误日志措辞

### 测试（9 个文件）
- 移除所有配置对象中的 `robotCode`
- 保留 DingTalk API payload 断言中的 `robotCode`（这是 API 字段名，不是配置）

### 文档（6 个文件 + 1 个脚本）
- 从配置参考、快速开始、权限说明中移除 `corpId` / `agentId` / `robotCode`
- 说明 `clientId` 同时作为 API `robotCode` 使用
- `dingtalk-stream-monitor.mjs` 移除对应 CLI 参数

## 向后兼容

用户配置中残留的 `robotCode` / `corpId` / `agentId` 会被 Zod schema 静默忽略（`.passthrough()` 不启用），不会导致错误。`resolveRobotCode()` 仍然作为内部 helper 存在，确保所有 API 调用正确传递 robotCode 字段。

## Test plan

- [x] 677 个测试全部通过
- [x] TypeScript 编译通过（0 项目内错误）
- [x] oxlint 通过（0 错误）

Made with [Cursor](https://cursor.com)