### PR TITLE
fix: align loadWebMedia options key with SDK signature to fix sandbox media send

### DIFF
--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -26,7 +26,7 @@ interface PluginRuntimeWithMedia {
   media?: {
     loadWebMedia(
       mediaPath: string,
-      options?: { mediaLocalRoots?: string[] },
+      options?: { localRoots?: readonly string[] | "any" },
     ): Promise<{ buffer: Buffer | ArrayBuffer; fileName?: string; contentType?: string } | null>;
   };
   [key: string]: unknown;
@@ -667,7 +667,7 @@ async function readMediaBuffer(
   }
 
   const media = await rt.media.loadWebMedia(mediaPath, {
-    mediaLocalRoots: options?.mediaLocalRoots,
+    localRoots: options?.mediaLocalRoots,
   });
 
   if (!media || !media.buffer) {

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -334,7 +334,7 @@ describe('media-utils', () => {
         );
 
         expect(result?.mediaId).toBe('media_sandbox_1');
-        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: undefined });
+        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { localRoots: undefined });
         expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
     });
 
@@ -360,7 +360,7 @@ describe('media-utils', () => {
         );
 
         expect(result?.mediaId).toBe('media_sandbox_2');
-        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { mediaLocalRoots: localRoots });
+        expect(mockLoadWebMedia).toHaveBeenCalledWith(sandboxPath, { localRoots: localRoots });
     });
 
     it('returns null when loadWebMedia returns null (sandbox bridge failure)', async () => {


### PR DESCRIPTION
## 背景

#458 中 @songchenghao 分析发现，sandbox 模式下出站媒体发送失败的根因是 readMediaBuffer 调用 rt.media.loadWebMedia 时传入的 options key 与 SDK 实际签名不匹配。

## 根因

src/media-utils.ts 中 readMediaBuffer() 传给 SDK 的参数名是 mediaLocalRoots：

readMediaBuffer 调用: { mediaLocalRoots: options?.mediaLocalRoots }

但 SDK (openclaw/dist/plugin-sdk/web/media.d.ts) 实际接受的参数名是 localRoots：

SDK 签名: { localRoots?: readonly string[] | 'any' }

JS/TS 不会对多余属性报错，SDK 静默忽略 mediaLocalRoots，将 localRoots 视为 undefined，导致沙箱路径白名单未传入，文件读取被拒绝。

## 修复

- 修正 PluginRuntimeWithMedia 接口定义，将 mediaLocalRoots 改为 localRoots，类型对齐 SDK
- 修正 readMediaBuffer() 调用处 key 为 localRoots
- 同步更新测试断言

## 验证 TODO

- [x] npx vitest run tests/unit/media-utils.test.ts 通过
- [x] npx vitest run tests/unit/send-service-media.test.ts 通过
- [x] npm run type-check 无新增错误

Ref: #458