### PR TITLE
feat(messaging): upload local markdown images before send

### DIFF
--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -37,6 +37,53 @@ import type {
 
 export { detectMediaTypeFromExtension } from "./media-utils";
 
+const MARKDOWN_LOCAL_IMAGE_RE =
+  /!\[([^\]]*)\]\((file:\/\/\/[^)]+|\/(?:tmp|var|private|Users|home|root)[^)]+|[A-Za-z]:[\\/][^)]+)\)/g;
+
+function decodeMarkdownLocalImagePath(rawPath: string): string {
+  const unescapedPath = rawPath.replace(/\\ /g, " ");
+  if (unescapedPath.startsWith("file://")) {
+    try {
+      return decodeURIComponent(unescapedPath.replace("file://", ""));
+    } catch {
+      return unescapedPath.replace("file://", "");
+    }
+  }
+  return unescapedPath;
+}
+
+async function replaceMarkdownLocalImages(params: {
+  config: DingTalkConfig;
+  text: string;
+  log?: Logger;
+  mediaLocalRoots?: string[];
+}): Promise<string> {
+  const matches = [...params.text.matchAll(MARKDOWN_LOCAL_IMAGE_RE)];
+  if (matches.length === 0) {
+    return params.text;
+  }
+
+  let result = params.text;
+  for (const match of matches) {
+    const [fullMatch, altText, rawPath] = match;
+    const mediaPath = decodeMarkdownLocalImagePath(rawPath);
+    const uploadResult = await uploadMedia(params.config, mediaPath, "image", params.log, {
+      mediaLocalRoots: params.mediaLocalRoots,
+    });
+
+    if (!uploadResult?.mediaId) {
+      params.log?.warn?.(
+        `[DingTalk] Markdown local image upload failed, keep original reference: ${mediaPath}`,
+      );
+      continue;
+    }
+
+    result = result.replace(fullMatch, () => `![${altText}](${uploadResult.mediaId})`);
+  }
+
+  return result;
+}
+
 type ProactiveTextSendResult = AxiosResponse | { tracking: DingTalkTrackingMetadata };
 
 function isTrackingResult(result: ProactiveTextSendResult): result is { tracking: DingTalkTrackingMetadata } {
@@ -252,7 +299,16 @@ export async function sendProactiveTextOrMarkdown(
     ? "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
     : "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend";
 
-  const normalizedText = config.convertMarkdownTables !== false ? convertMarkdownTablesToPlainText(text) : text;
+  const textWithUploadedLocalImages = await replaceMarkdownLocalImages({
+    config,
+    text,
+    log,
+    mediaLocalRoots: options.mediaLocalRoots,
+  });
+  const normalizedText =
+    config.convertMarkdownTables !== false
+      ? convertMarkdownTablesToPlainText(textWithUploadedLocalImages)
+      : textWithUploadedLocalImages;
   const { useMarkdown, title } = detectMarkdownAndExtractTitle(normalizedText, options, "OpenClaw 提醒");
 
   log?.debug?.(
@@ -531,7 +587,16 @@ export async function sendBySession(
   }
 
   // Fallback to text/markdown reply payload.
-  const normalizedText = config.convertMarkdownTables !== false ? convertMarkdownTablesToPlainText(text) : text;
+  const textWithUploadedLocalImages = await replaceMarkdownLocalImages({
+    config,
+    text,
+    log,
+    mediaLocalRoots: options.mediaLocalRoots,
+  });
+  const normalizedText =
+    config.convertMarkdownTables !== false
+      ? convertMarkdownTablesToPlainText(textWithUploadedLocalImages)
+      : textWithUploadedLocalImages;
   const { useMarkdown, title } = detectMarkdownAndExtractTitle(normalizedText, options, "Clawdbot 消息");
   const chunks = splitMarkdownChunks(normalizedText, DINGTALK_TEXT_CHUNK_LIMIT);
 

--- a/tests/unit/message-transform.test.ts
+++ b/tests/unit/message-transform.test.ts
@@ -5,6 +5,14 @@ vi.mock('../../src/auth', () => ({
     getAccessToken: vi.fn().mockResolvedValue('mock-access-token'),
 }));
 
+vi.mock('../../src/media-utils', async () => {
+    const actual = await vi.importActual<typeof import('../../src/media-utils')>('../../src/media-utils');
+    return {
+        ...actual,
+        uploadMedia: vi.fn(),
+    };
+});
+
 vi.mock('axios', () => {
     const mockAxios = vi.fn();
     return {
@@ -15,9 +23,11 @@ vi.mock('axios', () => {
 
 import { convertMarkdownTablesToPlainText } from '../../src/message-utils';
 import { sendBySession, sendProactiveTextOrMarkdown } from '../../src/send-service';
+import { uploadMedia } from '../../src/media-utils';
 import type { DingTalkConfig } from '../../src/types';
 
 const mockedAxios = vi.mocked(axios);
+const mockedUploadMedia = vi.mocked(uploadMedia);
 
 const config: DingTalkConfig = {
     clientId: 'ding-client-id',
@@ -27,6 +37,7 @@ const config: DingTalkConfig = {
 describe('message payload transform', () => {
     beforeEach(() => {
         mockedAxios.mockReset();
+        mockedUploadMedia.mockReset();
     });
 
     it('should convert markdown reply to DingTalk session webhook payload', async () => {
@@ -144,5 +155,64 @@ describe('message payload transform', () => {
         const input = '```md\n| a | b |\n| --- | --- |\n| 1 | 2 |\n```';
 
         expect(convertMarkdownTablesToPlainText(input)).toBe(input);
+    });
+
+    it('rewrites markdown local image syntax into uploaded media id before session send', async () => {
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_img_local_1', buffer: Buffer.from('img') } as any);
+        mockedAxios.mockResolvedValue({ data: { success: true } });
+
+        await sendBySession(
+            config,
+            'https://example-session-webhook',
+            '![示意图](/tmp/demo.png)',
+            { useMarkdown: true },
+        );
+
+        expect(mockedUploadMedia).toHaveBeenCalledWith(
+            config,
+            '/tmp/demo.png',
+            'image',
+            expect.any(Function),
+            undefined,
+            { mediaLocalRoots: undefined },
+        );
+
+        const request = mockedAxios.mock.calls[0]?.[0] as {
+            data: { markdown?: { text: string } };
+        };
+        expect(request.data.markdown?.text).toBe('![示意图](media_img_local_1)');
+    });
+
+    it('preserves media ids containing replacement tokens like $&', async () => {
+        mockedUploadMedia.mockResolvedValueOnce({ mediaId: 'media_$&_1', buffer: Buffer.from('img') } as any);
+        mockedAxios.mockResolvedValue({ data: { success: true } });
+
+        await sendBySession(
+            config,
+            'https://example-session-webhook',
+            '![示意图](/tmp/demo.png)',
+            { useMarkdown: true },
+        );
+
+        const request = mockedAxios.mock.calls[0]?.[0] as {
+            data: { markdown?: { text: string } };
+        };
+        expect(request.data.markdown?.text).toBe('![示意图](media_$&_1)');
+    });
+
+    it('does not rewrite bare local paths in plain text replies', async () => {
+        mockedAxios.mockResolvedValue({ data: { processQueryKey: 'q_plain' } });
+
+        await sendProactiveTextOrMarkdown(
+            config,
+            'cidA1B2C3',
+            '图片路径是 /tmp/demo.png，请检查',
+        );
+
+        expect(mockedUploadMedia).not.toHaveBeenCalled();
+        const request = mockedAxios.mock.calls[0]?.[0] as {
+            data: { msgParam: string };
+        };
+        expect(JSON.parse(request.data.msgParam)).toEqual({ content: '图片路径是 /tmp/demo.png，请检查' });
     });
 });


### PR DESCRIPTION
## 背景
当前 `soimy/openclaw-channel-dingtalk` 已支持显式媒体发送（`mediaPath/mediaType`），但当回复文本中直接包含本地 Markdown 图片路径（如 `![alt](/tmp/a.png)`）时，发送链路不会自动上传图片，最终只会把本地路径原样发给钉钉，用户侧无法直接看到图片。

参考 `DingTalk-Real-AI/dingtalk-openclaw-connector` 的发送前本地图片后处理思路，这一轮仅引入一个受限版本：只处理显式 Markdown 图片语法中的本地路径，不处理纯文本裸路径，避免把“讨论路径本身”的场景误判成图片发送。

借鉴来源：
- https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector

## 目标
- 在不改动现有显式媒体发送链路的前提下，补齐文本发送前的本地 Markdown 图片上传替换能力
- 仅支持 `![alt](local-path)` 形式
- 不支持纯文本裸路径自动转图
- 上传失败时保持原文，不静默改坏消息内容

## 实现
- 在 `src/send-service.ts` 新增受限版 `replaceMarkdownLocalImages()`
- 仅匹配 Markdown 图片语法中的本地绝对路径或 `file:///` 引用
- 复用现有 `uploadMedia(...)` 上传图片，并在发送前把路径替换成返回的 `media_id`
- 将该后处理接入：
  - `sendBySession(...)`
  - `sendProactiveTextOrMarkdown(...)`
- 不处理裸路径，保持现有文本/媒体链路边界
- 按 reviewer 意见补充：
  - 使用 replacer function，避免 `media_id` 中的 `$` 触发 `String.replace` 特殊展开
  - 去掉当前并不真正支持的 `MEDIA:` / `attachment:///` 前缀匹配

## 实现 TODO
- [x] 在文本发送前增加受限版 Markdown 本地图片上传替换
- [x] 保持显式媒体发送链路不变
- [x] 只处理 Markdown 图片语法，不处理裸路径
- [x] 修复 reviewer 提到的 `$` 替换字符串风险
- [x] 去掉无效的 `MEDIA:` / `attachment:///` 匹配
- [x] 补充边界测试

## 验证 TODO
- [x] `pnpm exec vitest run tests/unit/message-transform.test.ts tests/unit/send-service-media.test.ts tests/unit/send-service-advanced.test.ts`
- [x] `pnpm exec tsc -p tsconfig.json --noEmit`
