### PR TITLE
fix(plugin-sdk): align scoped imports with latest sdk

### DIFF
--- a/src/card/card-action-handler.ts
+++ b/src/card/card-action-handler.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { CardCallbackAnalysis } from "../card-callback-service";
 import type { DingTalkConfig, Logger } from "../types";
 import { resolveCardRun } from "./card-run-registry";

--- a/src/card/card-stop-handler.ts
+++ b/src/card/card-stop-handler.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { getAccessToken } from "../auth";
 import { finishStoppedAICard, hideCardStopButton } from "../card-service";
 import { dispatchDingTalkCardStopCommand } from "../command/card-stop-command";

--- a/src/command/card-stop-command.ts
+++ b/src/command/card-stop-command.ts
@@ -1,25 +1,7 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveNativeCommandSessionTargets } from "openclaw/plugin-sdk/command-auth";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { getDingTalkRuntime } from "../runtime";
 import type { Logger } from "../types";
-
-/**
- * Local implementation of the same logic as
- * `resolveNativeCommandSessionTargets` from `openclaw/plugin-sdk/command-auth`.
- *
- * Inlined because the CI openclaw package does not yet export that sub-path.
- * Replace with a direct import once the upstream package is updated.
- */
-function resolveNativeCommandSessionTargets(params: {
-  agentId: string;
-  sessionPrefix: string;
-  userId: string;
-  targetSessionKey: string;
-}): { sessionKey: string; commandTargetSessionKey: string } {
-  return {
-    sessionKey: `agent:${params.agentId}:${params.sessionPrefix}:${params.userId}`,
-    commandTargetSessionKey: params.targetSessionKey,
-  };
-}
 
 /**
  * Dispatch a native targeted `/stop` command through the OpenClaw SDK,
@@ -35,8 +17,8 @@ function resolveNativeCommandSessionTargets(params: {
  * and executes `abortEmbeddedPiRun` + `clearSessionQueues`.
  *
  * Accesses SDK functions via `getDingTalkRuntime().channel.reply` — the same
- * pattern used by `inbound-handler.ts` — to avoid direct sub-path imports
- * that may not be available in the CI openclaw package version.
+ * pattern used by `inbound-handler.ts` — while reusing the upstream native
+ * command session-target helper exported by the plugin SDK.
  */
 export async function dispatchDingTalkCardStopCommand(params: {
   cfg: OpenClawConfig;

--- a/tests/integration/channel-config-status.test.ts
+++ b/tests/integration/channel-config-status.test.ts
@@ -8,7 +8,7 @@ import {
   upsertObservedUserTarget,
 } from "../../src/targeting/target-directory-store";
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("openclaw/plugin-sdk/core", () => ({
   buildChannelConfigSchema: vi.fn((schema: unknown) => schema),
 }));
 

--- a/tests/integration/gateway-inbound-flow.test.ts
+++ b/tests/integration/gateway-inbound-flow.test.ts
@@ -14,7 +14,7 @@ const shared = vi.hoisted(() => ({
     connectionConfig: undefined as any,
 }));
 
-vi.mock('openclaw/plugin-sdk', () => ({
+vi.mock('openclaw/plugin-sdk/core', () => ({
     buildChannelConfigSchema: vi.fn((schema: unknown) => schema),
 }));
 

--- a/tests/integration/gateway-start-flow.test.ts
+++ b/tests/integration/gateway-start-flow.test.ts
@@ -13,7 +13,7 @@ const shared = vi.hoisted(() => ({
     dwClientConfig: undefined as any,
 }));
 
-vi.mock('openclaw/plugin-sdk', () => ({
+vi.mock('openclaw/plugin-sdk/core', () => ({
     buildChannelConfigSchema: vi.fn((schema: unknown) => schema),
 }));
 

--- a/tests/integration/send-lifecycle.test.ts
+++ b/tests/integration/send-lifecycle.test.ts
@@ -5,7 +5,7 @@ const { sendMessageMock, getRuntimeMock } = vi.hoisted(() => ({
     getRuntimeMock: vi.fn(),
 }));
 
-vi.mock('openclaw/plugin-sdk', () => ({
+vi.mock('openclaw/plugin-sdk/core', () => ({
     buildChannelConfigSchema: vi.fn((schema: unknown) => schema),
 }));
 

--- a/tests/integration/send-media-flow.test.ts
+++ b/tests/integration/send-media-flow.test.ts
@@ -8,7 +8,7 @@ const { resolveOutboundMediaTypeMock, prepareMediaInputMock, sendProactiveMediaM
     getRuntimeMock: vi.fn(),
 }));
 
-vi.mock('openclaw/plugin-sdk', () => ({
+vi.mock('openclaw/plugin-sdk/core', () => ({
     buildChannelConfigSchema: vi.fn((schema: unknown) => schema),
 }));
 

--- a/tests/unit/sdk-import-structure.test.ts
+++ b/tests/unit/sdk-import-structure.test.ts
@@ -8,6 +8,9 @@ const directSdkFiles = [
     "index.ts",
     "src/channel.ts",
     "src/config.ts",
+    "src/card/card-action-handler.ts",
+    "src/card/card-stop-handler.ts",
+    "src/command/card-stop-command.ts",
     "src/onboarding.ts",
     "src/runtime.ts",
     "src/types.ts",
@@ -17,6 +20,11 @@ const directSdkFiles = [
 ];
 
 const scopedSdkTestFiles = [
+    "tests/integration/channel-config-status.test.ts",
+    "tests/integration/gateway-inbound-flow.test.ts",
+    "tests/integration/gateway-start-flow.test.ts",
+    "tests/integration/send-lifecycle.test.ts",
+    "tests/integration/send-media-flow.test.ts",
     "tests/integration/status-probe.test.ts",
     "tests/unit/agent-name-matcher.test.ts",
 ];
@@ -33,11 +41,33 @@ describe("plugin-sdk import structure", () => {
         }
     });
 
+    it("keeps production code on scoped plugin-sdk subpaths instead of the root barrel", () => {
+        for (const relativePath of directSdkFiles) {
+            const content = readFileSync(resolve(repoRoot, relativePath), "utf8");
+            expect(content).not.toMatch(/from\s+["']openclaw\/plugin-sdk["']/);
+        }
+    });
+
     it("keeps tests on scoped plugin-sdk subpaths instead of the root barrel", () => {
         for (const relativePath of scopedSdkTestFiles) {
             const content = readFileSync(resolve(repoRoot, relativePath), "utf8");
             expect(content).not.toMatch(/from\s+["']openclaw\/plugin-sdk["']/);
         }
+    });
+
+    it("does not keep a tsconfig path alias for the deprecated plugin-sdk root barrel", () => {
+        const tsconfig = JSON.parse(readFileSync(resolve(repoRoot, "tsconfig.json"), "utf8")) as {
+            compilerOptions?: {
+                paths?: Record<string, string[]>;
+            };
+        };
+        expect(tsconfig.compilerOptions?.paths?.["openclaw/plugin-sdk"]).toBeUndefined();
+    });
+
+    it("does not keep the temporary local stop-command shim once command-auth exports it", () => {
+        const content = readFileSync(resolve(repoRoot, "src/command/card-stop-command.ts"), "utf8");
+        expect(content).not.toMatch(/Inlined because the CI openclaw package does not yet export that sub-path/);
+        expect(content).not.toMatch(/function\s+resolveNativeCommandSessionTargets\s*\(/);
     });
 
     it("does not keep openclaw in devDependencies where plugin install omits it", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,14 +29,6 @@
     "useDefineForClassFields": false,
     "types": ["node", "vitest/globals"],
     "paths": {
-      "openclaw/plugin-sdk": [
-        "../openclaw/dist/plugin-sdk/index.d.ts",
-        "../../dist/plugin-sdk/index.d.ts",
-        "../openclaw/dist/plugin-sdk/plugin-sdk/index.d.ts",
-        "../../dist/plugin-sdk/plugin-sdk/index.d.ts",
-        "../openclaw/src/plugin-sdk/index.ts",
-        "../../src/plugin-sdk/index.ts"
-      ],
       "openclaw/plugin-sdk/*": [
         "../openclaw/dist/plugin-sdk/*.d.ts",
         "../../dist/plugin-sdk/*.d.ts",


### PR DESCRIPTION
## 背景
- OpenClaw `v2026.3.31` 开始收紧 plugin-sdk 兼容入口，仓库内仍残留少量 `openclaw/plugin-sdk` root barrel 导入与一处本地 stop-command shim。
- 这些用法当前未导致运行失败，但会增加后续跟进上游 SDK 调整时的维护成本。

## 目标
- 将生产代码与测试中的 root barrel 用法迁移到 scoped plugin-sdk subpath。
- 移除已经可以直接依赖上游导出的 `resolveNativeCommandSessionTargets` 本地 shim。
- 清理 `tsconfig` 中不再需要的 root barrel 路径映射，并补充回归测试约束。

## 实现
- 将 card stop 相关生产代码中的 `OpenClawConfig` 类型导入切换到 `openclaw/plugin-sdk/core`。
- 将 `src/command/card-stop-command.ts` 改为直接使用 `openclaw/plugin-sdk/command-auth` 导出的 `resolveNativeCommandSessionTargets`。
- 将相关集成测试中的 `vi.mock("openclaw/plugin-sdk")` 迁移到 `vi.mock("openclaw/plugin-sdk/core")`。
- 删除 `tsconfig.json` 中对 `openclaw/plugin-sdk` root barrel 的显式路径映射。
- 扩展 `tests/unit/sdk-import-structure.test.ts`，覆盖生产代码 scoped import、测试 scoped import、root barrel path alias 与 stop-command shim 约束。

## 实现 TODO
- [x] 对齐生产代码 scoped plugin-sdk imports
- [x] 移除 stop-command 的本地兼容 shim
- [x] 对齐测试 mock 与 import 结构约束
- [x] 清理 root barrel tsconfig path alias

## 验证 TODO
- [x] `npx vitest run tests/unit/sdk-import-structure.test.ts tests/unit/card-stop-command.test.ts`
- [x] `npm run type-check`
- [x] `npm test`
- [x] `npm run lint`（0 errors，保留仓库现有 warnings）