### PR TITLE
fix(routing): skip sub-agent routing for slash commands like /new /stop

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1276,13 +1276,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // tryFastAbortFromMessage (inside the SDK) kill any in-flight generation immediately,
   // rather than waiting for it to finish before the stop message is processed.
   //
-  // In group chats, DingTalk typically strips @BotName from text.content at the
-  // protocol level before delivery, but as a defensive measure we also strip leading
-  // @mention tokens here (e.g. "@Bot 停止" → "停止") to match the SDK's own behavior
-  // in tryFastAbortFromMessage (which calls stripMentions for group messages).
-  const textForAbortCheck = !isDirect
-    ? inboundText.replace(/^(?:@\S+\s+)*/u, "").trim()
-    : inboundText;
+  // Strip leading @mention tokens before the abort check so that messages like
+  // "@Agent /stop" are correctly recognised as abort requests in both DM and group
+  // chats. In groups DingTalk usually strips @BotName at the protocol level, but
+  // in DMs with multi-agent routing the @mention prefix survives all the way here.
+  const textForAbortCheck = inboundText.replace(/^(?:@\S+\s+)*/u, "").trim();
   if (isAbortRequestText(textForAbortCheck)) {
     log?.info?.(
       `[DingTalk] Abort request detected, bypassing session lock for session=${route.sessionKey}`,

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -101,6 +101,8 @@ export async function resolveSubAgentRoute(params: {
   // routing so they reach the framework's own command handling layer.
   // Strip leading @mention tokens first since DM text may look like "@Agent /new".
   const textWithoutMentions = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
+  // NOTE: Keep in sync with OpenClaw framework commands.
+  // When new top-level slash commands are added, update this list.
   const isSlashCommand = /^\/(?:new|stop|clear|compact|reasoning|model|config|session|whereami|whoami)\b/.test(textWithoutMentions);
 
   if (

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -8,6 +8,7 @@
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import { maybeResolveTextAlias } from "openclaw/plugin-sdk/command-auth";
 import { resolveAtAgents } from "./agent-name-matcher";
 import { resolveRobotCode } from "../config";
 import { parseLearnCommand } from "../learning-command-service";
@@ -101,9 +102,7 @@ export async function resolveSubAgentRoute(params: {
   // routing so they reach the framework's own command handling layer.
   // Strip leading @mention tokens first since DM text may look like "@Agent /new".
   const textWithoutMentions = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
-  // NOTE: Keep in sync with OpenClaw framework commands.
-  // When new top-level slash commands are added, update this list.
-  const isSlashCommand = /^\/(?:new|stop|clear|compact|reasoning|model|config|session|whereami|whoami)\b/.test(textWithoutMentions);
+  const isSlashCommand = maybeResolveTextAlias(textWithoutMentions, cfg) !== null;
 
   if (
     atMentions.length === 0 ||

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -93,16 +93,22 @@ export async function resolveSubAgentRoute(params: {
   const atMentions = extractedContent.atMentions || [];
   // DM has no @picker list from DingTalk; only group chats provide atUsers for real-user hints.
   const atUserDingtalkIds = isGroup ? extractedContent.atUserDingtalkIds : undefined;
-  // Strip quoted prefix before checking /learn to avoid false positives
-  // when the quoted message itself contains a /learn command.
+  // Strip quoted prefix before checking commands to avoid false positives
+  // when the quoted message itself contains a command.
   const textForCommandCheck = extractedContent.text.replace(/^\[引用[^\]]*\]\s*/, "");
   const isLearnCommand = parseLearnCommand(textForCommandCheck).scope !== "unknown";
+  // Slash commands like /new, /stop, /reasoning etc. must bypass sub-agent
+  // routing so they reach the framework's own command handling layer.
+  // Strip leading @mention tokens first since DM text may look like "@Agent /new".
+  const textWithoutMentions = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
+  const isSlashCommand = /^\/(?:new|stop|clear|compact|reasoning|model|config|session|whereami|whoami)\b/.test(textWithoutMentions);
 
   if (
     atMentions.length === 0 ||
     !cfg.agents?.list ||
     cfg.agents.list.length === 0 ||
-    isLearnCommand
+    isLearnCommand ||
+    isSlashCommand
   ) {
     return null;
   }

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -7374,6 +7374,46 @@ describe("inbound-handler", () => {
       expect(shared.acquireSessionLockMock).not.toHaveBeenCalled();
       expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     });
+
+    it("strips leading @mention from DM message before abort check", async () => {
+      // In multi-agent DM, text like "@Agent /stop" must still bypass the session
+      // lock after resolveSubAgentRoute returns null for slash commands.
+      shared.extractMessageContentMock.mockReturnValue({
+        text: "@Agent /stop",
+        messageType: "text",
+        atMentions: [{ name: "Agent" }],
+      });
+      shared.isAbortRequestTextMock.mockImplementation((text: string) => text === "/stop");
+      shared.sendBySessionMock.mockResolvedValue({ data: {} });
+
+      const rt = buildRuntime();
+      vi.mocked(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).mockImplementationOnce(
+        async ({ dispatcherOptions }: any) => {
+          await dispatcherOptions.deliver({ text: "已停止响应" });
+          return { queuedFinal: true, counts: { final: 1 } };
+        },
+      );
+      shared.getRuntimeMock.mockReturnValue(rt);
+
+      await handleDingTalkMessage({
+        cfg: {},
+        accountId: "main",
+        sessionWebhook: "https://session.webhook/abort",
+        log: undefined,
+        dingtalkConfig: { dmPolicy: "open" } as any,
+        data: {
+          ...baseData,
+          msgId: "abort_dm_mention",
+          text: { content: "@Agent /stop" },
+          conversationType: "1",
+          conversationId: "cid_dm_abort",
+        },
+      } as any);
+
+      // @mention stripped in DM → "/stop" matches → session lock should NOT be acquired
+      expect(shared.acquireSessionLockMock).not.toHaveBeenCalled();
+      expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("handleDingTalkMessage does not inject [media_path:] into body — sets MediaPath on ctx instead", async () => {

--- a/tests/unit/targeting/dm-subagent-routing.test.ts
+++ b/tests/unit/targeting/dm-subagent-routing.test.ts
@@ -19,6 +19,24 @@ vi.mock("../../../src/send-service", () => ({
   sendBySession: vi.fn(),
 }));
 
+const KNOWN_COMMANDS = new Set([
+  "/new", "/stop", "/clear", "/compact", "/reasoning", "/model",
+  "/config", "/session", "/session-alias", "/whoami", "/whereami",
+  "/help", "/status", "/tools", "/reset", "/think", "/verbose",
+  "/bash", "/activation", "/agents", "/restart", "/usage",
+]);
+
+vi.mock("openclaw/plugin-sdk/command-auth", () => ({
+  maybeResolveTextAlias: (raw: string) => {
+    const trimmed = raw.trim().toLowerCase();
+    if (!trimmed.startsWith("/")) return null;
+    const token = trimmed.match(/^\/([^\s:]+)(?:\s|$)/);
+    if (!token) return null;
+    const key = `/${token[1]}`;
+    return KNOWN_COMMANDS.has(key) ? key : null;
+  },
+}));
+
 function makeDmMessage(text: string): DingTalkInboundMessage {
   return {
     msgtype: "text",

--- a/tests/unit/targeting/dm-subagent-routing.test.ts
+++ b/tests/unit/targeting/dm-subagent-routing.test.ts
@@ -174,4 +174,71 @@ describe("resolveSubAgentRoute in DM", () => {
     expect(result).toBeNull();
     expect(mockedSendBySession).not.toHaveBeenCalled();
   });
+
+  it.each(["/new", "/stop", "/clear", "/compact", "/reasoning stream", "/reasoning on", "/model", "/config", "/session"])(
+    "skips sub-agent routing for slash command '%s' with @mention",
+    async (command) => {
+      const extractedContent: MessageContent = {
+        text: `@agent-alpha ${command}`,
+        messageType: "text",
+        atMentions: [{ name: "agent-alpha" }],
+      };
+
+      const result = await resolveSubAgentRoute({
+        extractedContent,
+        cfg,
+        isGroup: false,
+        dingtalkConfig,
+        sessionWebhook: "https://session.webhook",
+        senderId: "user-001",
+        log,
+      });
+
+      expect(result).toBeNull();
+      expect(mockedSendBySession).not.toHaveBeenCalled();
+    },
+  );
+
+  it("skips sub-agent routing for slash commands in group chat", async () => {
+    const extractedContent: MessageContent = {
+      text: "/new",
+      messageType: "text",
+      atMentions: [{ name: "agent-alpha" }],
+      atUserDingtalkIds: [],
+    };
+
+    const result = await resolveSubAgentRoute({
+      extractedContent,
+      cfg,
+      isGroup: true,
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      senderId: "user-001",
+      log,
+    });
+
+    expect(result).toBeNull();
+    expect(mockedSendBySession).not.toHaveBeenCalled();
+  });
+
+  it("still routes to sub-agent for normal @mention messages", async () => {
+    const extractedContent: MessageContent = {
+      text: "@agent-alpha 你好",
+      messageType: "text",
+      atMentions: [{ name: "agent-alpha" }],
+    };
+
+    const result = await resolveSubAgentRoute({
+      extractedContent,
+      cfg,
+      isGroup: false,
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      senderId: "user-001",
+      log,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.matchedAgents[0]?.agentId).toBe("agent-alpha");
+  });
 });

--- a/tests/unit/targeting/dm-subagent-routing.test.ts
+++ b/tests/unit/targeting/dm-subagent-routing.test.ts
@@ -175,7 +175,7 @@ describe("resolveSubAgentRoute in DM", () => {
     expect(mockedSendBySession).not.toHaveBeenCalled();
   });
 
-  it.each(["/new", "/stop", "/clear", "/compact", "/reasoning stream", "/reasoning on", "/model", "/config", "/session"])(
+  it.each(["/new", "/stop", "/clear", "/compact", "/reasoning stream", "/reasoning on", "/model", "/config", "/session", "/whoami", "/whereami", "/session-alias show", "/session-alias clear"])(
     "skips sub-agent routing for slash command '%s' with @mention",
     async (command) => {
       const extractedContent: MessageContent = {


### PR DESCRIPTION
## Summary

- `@agent /new`、`@agent /stop`、`@agent /reasoning stream` 等斜杠命令在多 agent 模式下失效，因为 `resolveSubAgentRoute` 检测到 `@mention` 后直接将消息路由到 sub-agent，导致斜杠命令永远到不了框架自身的 command dispatch 层
- 在 `resolveSubAgentRoute` 中新增斜杠命令检测：先剥离前导 `@mention` token，再检查是否为 `/new`、`/stop`、`/clear`、`/compact`、`/reasoning`、`/model`、`/config`、`/session`、`/whereami`、`/whoami`，命中则 `return null` 走正常命令处理链路
- 新增测试覆盖：9 个斜杠命令的参数化测试 + 群聊场景 + 确认普通 `@mention` 消息仍正常路由到 sub-agent

## Test plan

- [x] `vitest run tests/unit/targeting/dm-subagent-routing.test.ts` — 21 tests passed
- [ ] 手动验证：多 agent 群中发送 `@助手 /new` 确认会话重置
- [ ] 手动验证：多 agent 群中发送 `@助手 /stop` 确认会话停止
- [ ] 手动验证：发送 `@助手 /reasoning stream` 确认正常切换推理模式
- [ ] 手动验证：普通 `@助手 你好` 仍正常路由到对应 sub-agent

Fixes #460

