### PR TITLE
Add optional peer dependency for openclaw

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,11 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.24"
   },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "compat": {
       "pluginApi": ">=2026.3.24"


### PR DESCRIPTION
优化依赖包体积，整体发布包体积能减少大约500MB