### PR TITLE
fix(inbound): trim blocked quoted chain context

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -32,7 +32,7 @@ import {
 } from "./message-context-store";
 import { extractMessageContent } from "./message-utils";
 import { deliverBtwReply, stripLeadingMentions } from "./messaging/btw-deliver";
-import { resolveQuotedRuntimeContext } from "./messaging/quoted-context";
+import { getQuotedChainEntrySenderId, resolveQuotedRuntimeContext } from "./messaging/quoted-context";
 import {
   buildInboundQuotedRef,
   createReplyQuotedRef,
@@ -151,16 +151,55 @@ function filterQuotedRuntimeContext(params: {
       ? isSenderAllowed({ allow, senderId })
       : false;
 
-  if (senderAllowed) {
+  if (!senderAllowed && mode !== "allowlist_quote") {
+    return null;
+  }
+
+  if (context.chain.length <= 1) {
+    return senderAllowed
+      ? context
+      : {
+          ...context,
+          untrustedContext: undefined,
+        };
+  }
+
+  const filteredChain = [context.chain[0]];
+  for (const entry of context.chain.slice(1)) {
+    if (entry.direction === "outbound") {
+      filteredChain.push(entry);
+      continue;
+    }
+
+    const chainSenderId = resolveQuotedVisibilitySenderId({
+      quotedSenderId: getQuotedChainEntrySenderId(entry),
+      currentSenderId,
+      currentSenderOriginalId,
+    });
+    const entryAllowed =
+      allow.hasEntries && !!chainSenderId
+        ? isSenderAllowed({ allow, senderId: chainSenderId })
+        : false;
+    if (!entryAllowed) {
+      break;
+    }
+    filteredChain.push(entry);
+  }
+
+  if (senderAllowed && filteredChain.length === context.chain.length) {
     return context;
   }
-  if (mode === "allowlist_quote") {
-    return {
-      ...context,
-      untrustedContext: undefined,
-    };
-  }
-  return null;
+
+  return {
+    ...context,
+    chain: filteredChain,
+    untrustedContext:
+      filteredChain.length > 1
+        ? JSON.stringify({
+            quotedChain: filteredChain.slice(1),
+          })
+        : undefined,
+  };
 }
 
 function readSessionReasoningLevel(params: {

--- a/src/messaging/quoted-context.ts
+++ b/src/messaging/quoted-context.ts
@@ -5,6 +5,7 @@ import { resolveQuotedRecord } from "./quoted-ref";
 const DEFAULT_MAX_DEPTH = 3;
 const DEFAULT_PER_HOP_BODY_LIMIT = 1200;
 const DEFAULT_TOTAL_BODY_LIMIT = 3600;
+const QUOTED_CHAIN_ENTRY_SENDER_ID = Symbol("quotedChainEntrySenderId");
 
 export interface QuotedChainEntry {
   depth: number;
@@ -29,6 +30,10 @@ export interface QuotedRuntimePreview {
   messageType?: string;
   senderId?: string;
 }
+
+type QuotedChainEntryInternal = QuotedChainEntry & {
+  [QUOTED_CHAIN_ENTRY_SENDER_ID]?: string;
+};
 
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
@@ -136,7 +141,7 @@ function buildChainEntry(params: {
     return null;
   }
   const body = truncateBody(resolveRecordBody(params.record), limit);
-  return {
+  const entry: QuotedChainEntryInternal = {
     depth: params.depth,
     direction: params.record.direction,
     messageType: deriveMessageType(params.record),
@@ -144,6 +149,19 @@ function buildChainEntry(params: {
     body,
     createdAt: params.record.createdAt,
   };
+  if (typeof params.record.senderId === "string" && params.record.senderId.trim()) {
+    Object.defineProperty(entry, QUOTED_CHAIN_ENTRY_SENDER_ID, {
+      value: params.record.senderId.trim(),
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return entry;
+}
+
+export function getQuotedChainEntrySenderId(entry: QuotedChainEntry): string | undefined {
+  return (entry as QuotedChainEntryInternal)[QUOTED_CHAIN_ENTRY_SENDER_ID];
 }
 
 export function resolveQuotedRuntimeContext(params: {

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -2553,6 +2553,164 @@ describe("inbound-handler", () => {
     });
   });
 
+  it("drops blocked deeper quoted-chain context in group allowlist mode even when the first quoted hop is allowlisted", async () => {
+    const baseTs = Date.now();
+    const runtime = buildRuntime();
+    runtime.channel.session.resolveStorePath = vi
+      .fn()
+      .mockReturnValueOnce("/tmp/store.json")
+      .mockReturnValueOnce("/tmp/agent-store.json");
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+    messageContextStore.upsertInboundMessageContext({
+      storePath: "/tmp/store.json",
+      accountId: "main",
+      conversationId: "cid_group_quote_visibility",
+      msgId: "chain_leaf_blocked_1",
+      createdAt: baseTs - 3000,
+      messageType: "text",
+      text: "第三跳外部上下文",
+      senderId: "blocked_user",
+      senderName: "外部成员",
+      topic: null,
+    });
+    messageContextStore.upsertInboundMessageContext({
+      storePath: "/tmp/store.json",
+      accountId: "main",
+      conversationId: "cid_group_quote_visibility",
+      msgId: "chain_head_allowed_1",
+      createdAt: baseTs - 1000,
+      messageType: "text",
+      text: "第一跳允许上下文",
+      senderId: "allowed_user",
+      senderName: "白名单成员",
+      quotedRef: {
+        targetDirection: "inbound",
+        key: "msgId",
+        value: "chain_leaf_blocked_1",
+      },
+      topic: null,
+    });
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "继续这个群聊话题",
+      messageType: "text",
+      quoted: {
+        msgId: "chain_head_allowed_1",
+      },
+    });
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        groupPolicy: "allowlist",
+        allowFrom: ["cid_group_quote_visibility"],
+        groupAllowFrom: ["manager8031", "allowed_user"],
+        contextVisibility: "allowlist",
+        messageType: "markdown",
+      } as any,
+      data: {
+        msgId: "m_quote_chain_group_allowlist_1",
+        msgtype: "text",
+        text: { content: "继续这个群聊话题", isReplyMsg: true },
+        originalMsgId: "chain_head_allowed_1",
+        conversationType: "2",
+        conversationId: "cid_group_quote_visibility",
+        senderId: "raw_sender_manager8031",
+        senderStaffId: "manager8031",
+        senderNick: "管理员",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: baseTs,
+      },
+    } as any);
+
+    const finalized = runtime.channel.reply.finalizeInboundContext.mock.calls[0]?.[0];
+    expect(finalized.ReplyToBody).toBe("第一跳允许上下文");
+    expect(finalized.ReplyToIsQuote).toBe(true);
+    expect(finalized.UntrustedContext).toBeUndefined();
+  });
+
+  it("keeps the first explicit quote but drops blocked deeper quoted-chain context in group allowlist_quote mode", async () => {
+    const baseTs = Date.now();
+    const runtime = buildRuntime();
+    runtime.channel.session.resolveStorePath = vi
+      .fn()
+      .mockReturnValueOnce("/tmp/store.json")
+      .mockReturnValueOnce("/tmp/agent-store.json");
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+    messageContextStore.upsertInboundMessageContext({
+      storePath: "/tmp/store.json",
+      accountId: "main",
+      conversationId: "cid_group_quote_visibility_quote_mode",
+      msgId: "chain_leaf_blocked_quote_mode_1",
+      createdAt: baseTs - 3000,
+      messageType: "text",
+      text: "第三跳外部上下文",
+      senderId: "blocked_user_2",
+      senderName: "外部成员二号",
+      topic: null,
+    });
+    messageContextStore.upsertInboundMessageContext({
+      storePath: "/tmp/store.json",
+      accountId: "main",
+      conversationId: "cid_group_quote_visibility_quote_mode",
+      msgId: "chain_head_blocked_quote_mode_1",
+      createdAt: baseTs - 1000,
+      messageType: "text",
+      text: "第一跳外部上下文",
+      senderId: "blocked_user_1",
+      senderName: "外部成员一号",
+      quotedRef: {
+        targetDirection: "inbound",
+        key: "msgId",
+        value: "chain_leaf_blocked_quote_mode_1",
+      },
+      topic: null,
+    });
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "继续这个群聊话题",
+      messageType: "text",
+      quoted: {
+        msgId: "chain_head_blocked_quote_mode_1",
+      },
+    });
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        groupPolicy: "allowlist",
+        allowFrom: ["cid_group_quote_visibility_quote_mode"],
+        groupAllowFrom: ["manager8031"],
+        contextVisibility: "allowlist_quote",
+        messageType: "markdown",
+      } as any,
+      data: {
+        msgId: "m_quote_chain_group_allowlist_quote_1",
+        msgtype: "text",
+        text: { content: "继续这个群聊话题", isReplyMsg: true },
+        originalMsgId: "chain_head_blocked_quote_mode_1",
+        conversationType: "2",
+        conversationId: "cid_group_quote_visibility_quote_mode",
+        senderId: "raw_sender_manager8031",
+        senderStaffId: "manager8031",
+        senderNick: "管理员",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: baseTs,
+      },
+    } as any);
+
+    const finalized = runtime.channel.reply.finalizeInboundContext.mock.calls[0]?.[0];
+    expect(finalized.ReplyToBody).toBe("第一跳外部上下文");
+    expect(finalized.ReplyToIsQuote).toBe(true);
+    expect(finalized.UntrustedContext).toBeUndefined();
+  });
+
   it("does not inject ReplyTo fields or chain context when quotedRef cannot be resolved", async () => {
     const runtime = buildRuntime();
     runtime.channel.session.resolveStorePath = vi


### PR DESCRIPTION
## 背景

`#499` 相关的上游对齐项大多已经在主干落地，但对照 `docs/plans/2026-04-06-dingtalk-context-visibility-and-subagent-session-alignment.md` 继续复核后，仍发现一个剩余偏差：

- `contextVisibility=allowlist` / `allowlist_quote` 目前只按第一跳 quoted sender 做可见性判断
- 当第一跳允许、但更深层 quoted chain 中仍有未授权 inbound hop 时，这些 deeper context 仍会通过 `UntrustedContext` 泄漏给 runtime

## 目标

- 收口 DingTalk `contextVisibility` 的最后一处明显行为偏差
- 让 group quote / quoted-chain 在 `allowlist` 与 `allowlist_quote` 下都符合计划中的多跳过滤预期
- 保持现有 `quotedChain` 对外 JSON 结构稳定，避免引入额外兼容性噪音

## 实现

- 在 `quoted-context` 内为 chain entry 挂载不可枚举的 sender 元数据，仅供运行时过滤使用，不改变已有序列化输出
- 在 `inbound-handler` 的 `filterQuotedRuntimeContext()` 中改为逐跳裁剪 chain：
  - `allowlist`：第一跳必须可见，后续 deeper inbound hop 仅保留连续 allowlisted 部分
  - `allowlist_quote`：保留第一跳显式 quote，但继续裁掉 deeper blocked chain
- 新增回归测试覆盖：
  - 第一跳 allowlisted、第二跳 blocked 时不再泄漏 `UntrustedContext`
  - `allowlist_quote` 保留第一跳显式引用但不保留 deeper blocked chain

## 实现 TODO

- [ ] 根据 review 反馈决定是否需要补一条 release note / docs 说明，明确这是 `#499` 后续收口

## 验证 TODO

- [x] `npm run type-check`
- [x] `pnpm test`
