### PR TITLE
fix(media): default audio files to attachment instead of voice message

### DIFF
--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -534,6 +534,12 @@ export function resolveOutboundMediaType(params: {
     return explicitType;
   }
 
+  // Audio files default to "file" (attachment) unless asVoice is explicitly set.
+  // This prevents mp3/wav/ogg/amr from being sent as voice messages unexpectedly.
+  if (detectedType === "voice") {
+    return "file";
+  }
+
   return detectedType;
 }
 

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -125,7 +125,7 @@ describe('media-utils', () => {
         expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.pdf', asVoice: false })).toBe('file');
     });
 
-    it('resolveOutboundMediaType respects explicit mediaType="voice" without asVoice', () => {
+    it('resolveOutboundMediaType respects explicit mediaType="voice" even when asVoice is false', () => {
         expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.mp3', mediaType: 'voice', asVoice: false })).toBe('voice');
     });
 

--- a/tests/unit/media-utils.test.ts
+++ b/tests/unit/media-utils.test.ts
@@ -4,7 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import axios from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { detectMediaTypeFromExtension, getVoiceDurationMs, prepareMediaInput, uploadMedia } from '../../src/media-utils';
+import { detectMediaTypeFromExtension, getVoiceDurationMs, prepareMediaInput, resolveOutboundMediaType, uploadMedia } from '../../src/media-utils';
 
 const mockLoadWebMedia = vi.fn();
 const { mockRunFfmpeg, mockRunFfprobe } = vi.hoisted(() => ({
@@ -103,6 +103,30 @@ describe('media-utils', () => {
         expect(detectMediaTypeFromExtension('/tmp/a.ogg')).toBe('voice');
         expect(detectMediaTypeFromExtension('/tmp/a.mp4')).toBe('video');
         expect(detectMediaTypeFromExtension('/tmp/a.pdf')).toBe('file');
+    });
+
+    it('resolveOutboundMediaType returns "file" for audio extensions when asVoice is false', () => {
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.mp3', asVoice: false })).toBe('file');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.wav', asVoice: false })).toBe('file');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.ogg', asVoice: false })).toBe('file');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.amr', asVoice: false })).toBe('file');
+    });
+
+    it('resolveOutboundMediaType returns "voice" for audio extensions when asVoice is true', () => {
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.mp3', asVoice: true })).toBe('voice');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.wav', asVoice: true })).toBe('voice');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.ogg', asVoice: true })).toBe('voice');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.amr', asVoice: true })).toBe('voice');
+    });
+
+    it('resolveOutboundMediaType respects explicit mediaType for non-audio files', () => {
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.png', mediaType: 'image', asVoice: false })).toBe('image');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.mp4', asVoice: false })).toBe('video');
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.pdf', asVoice: false })).toBe('file');
+    });
+
+    it('resolveOutboundMediaType respects explicit mediaType="voice" without asVoice', () => {
+        expect(resolveOutboundMediaType({ mediaPath: '/tmp/a.mp3', mediaType: 'voice', asVoice: false })).toBe('voice');
     });
 
     it('returns safe fallback duration for unparseable mp3', async () => {


### PR DESCRIPTION
## Summary

- `resolveOutboundMediaType` now downgrades detected `"voice"` to `"file"` when `asVoice` is not set, so audio files (.mp3/.wav/.ogg/.amr) are sent as file attachments by default
- Only when `asVoice=true` or explicit `mediaType="voice"` is provided will audio files be sent as voice messages
- Added 4 unit tests covering the fix, regression protection, and edge cases

Closes #516

## Test plan

- [x] `npx vitest run tests/unit/media-utils.test.ts` — 27 tests passed
- [x] `npx vitest run` — all 961 tests passed
- [x] 真机验证：发送 .mp3 文件（不带 `audioAsVoice`），确认收到的是文件附件而非语音消息
- [x] 真机验证：发送 .mp3 文件（带 `audioAsVoice=true`），确认仍然作为语音消息发送