### PR TITLE
fix(card): deliver markdown fallback when session-recovery updates a finished card

### DIFF
--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -373,7 +373,10 @@ export function createCardReplyStrategy(
         // Card was already finalized (e.g. first embedded run timed out).
         // If session-recovery triggered a second run that produced new content,
         // deliver it as a markdown fallback so the user sees the final result.
-        const recoveryText = finalTextForFallback
+        // The user may see partial overlap with the frozen card's content, but
+        // delivering the full answer is preferred over silence.
+        const recoveryText = getRenderedTimeline({ preferFinalAnswer: true })
+          || finalTextForFallback
           || controller.getLastAnswerContent()
           || controller.getLastContent();
         if (recoveryText) {

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -370,7 +370,35 @@ export function createCardReplyStrategy(
       }
 
       if (card.state === AICardStatus.FINISHED) {
-        log?.info?.("[DingTalk][Finalize] Skipping — card already FINISHED");
+        // Card was already finalized (e.g. first embedded run timed out).
+        // If session-recovery triggered a second run that produced new content,
+        // deliver it as a markdown fallback so the user sees the final result.
+        const recoveryText = finalTextForFallback
+          || controller.getLastAnswerContent()
+          || controller.getLastContent();
+        if (recoveryText) {
+          log?.info?.(
+            `[DingTalk][Finalize] Card already FINISHED — sending markdown fallback for session-recovery content ` +
+            `len=${recoveryText.length} preview="${recoveryText.slice(0, 80)}"`,
+          );
+          const sendResult = await sendMessage(ctx.config, ctx.to, recoveryText, {
+            sessionWebhook: ctx.sessionWebhook,
+            atUserId: !ctx.isDirect ? ctx.senderId : null,
+            log,
+            accountId: ctx.accountId,
+            storePath: ctx.storePath,
+            conversationId: ctx.groupId,
+            quotedRef: ctx.replyQuotedRef,
+            forceMarkdown: true,
+          });
+          if (!sendResult.ok) {
+            log?.warn?.(
+              `[DingTalk][Finalize] Markdown fallback after FINISHED card failed: ${sendResult.error}`,
+            );
+          }
+        } else {
+          log?.info?.("[DingTalk][Finalize] Skipping — card already FINISHED and no new content");
+        }
         lifecycleState = "sealed";
         return;
       }

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -691,11 +691,26 @@ describe("reply-strategy-card", () => {
             expect(phase3Index).toBeGreaterThan(tool2Index);
         });
 
-        it("skips finalize when card is already FINISHED", async () => {
+        it("skips finalize when card is already FINISHED and no new content", async () => {
             const card = makeCard({ state: AICardStatus.FINISHED });
             const strategy = createCardReplyStrategy(buildCtx(card));
             await strategy.finalize();
             expect(finishAICardMock).not.toHaveBeenCalled();
+            expect(sendMessageMock).not.toHaveBeenCalled();
+        });
+
+        it("sends markdown fallback when card is already FINISHED but session-recovery produced new content", async () => {
+            const card = makeCard({ state: AICardStatus.FINISHED });
+            const strategy = createCardReplyStrategy(buildCtx(card));
+            await strategy.deliver({ text: "recovery answer", mediaUrls: [], kind: "final" });
+            await strategy.finalize();
+            expect(finishAICardMock).not.toHaveBeenCalled();
+            expect(sendMessageMock).toHaveBeenCalledTimes(1);
+            const fallbackText = sendMessageMock.mock.calls[0][2];
+            expect(fallbackText).toContain("recovery answer");
+            expect(sendMessageMock.mock.calls[0][3]).toMatchObject({
+                forceMarkdown: true,
+            });
         });
 
         it("sends markdown fallback with the rendered timeline when card FAILED", async () => {

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -713,6 +713,31 @@ describe("reply-strategy-card", () => {
             });
         });
 
+        it("sends rendered timeline as FINISHED recovery fallback when reasoning content exists", async () => {
+            const card = makeCard({ state: AICardStatus.FINISHED });
+            const strategy = createCardReplyStrategy(buildCtx(card));
+            strategy.getReplyOptions().onReasoningStream?.({ text: "思考中" });
+            await strategy.deliver({ text: "final answer", mediaUrls: [], kind: "final" });
+            await strategy.finalize();
+            expect(finishAICardMock).not.toHaveBeenCalled();
+            expect(sendMessageMock).toHaveBeenCalledTimes(1);
+            const fallbackText = sendMessageMock.mock.calls[0][2];
+            expect(fallbackText).toContain("> 思考中");
+            expect(fallbackText).toContain("final answer");
+        });
+
+        it("logs warning but does not throw when FINISHED recovery fallback send fails", async () => {
+            sendMessageMock.mockResolvedValueOnce({ ok: false, error: "network error" });
+            const card = makeCard({ state: AICardStatus.FINISHED });
+            const logSpy = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+            const strategy = createCardReplyStrategy(buildCtx(card, { log: logSpy }));
+            await strategy.deliver({ text: "recovery content", mediaUrls: [], kind: "final" });
+            await expect(strategy.finalize()).resolves.not.toThrow();
+            expect(logSpy.warn).toHaveBeenCalledWith(
+                expect.stringContaining("Markdown fallback after FINISHED card failed"),
+            );
+        });
+
         it("sends markdown fallback with the rendered timeline when card FAILED", async () => {
             const card = makeCard();
             const strategy = createCardReplyStrategy(buildCtx(card));


### PR DESCRIPTION
## Summary

- When `finalize()` finds the AI Card already in FINISHED state (e.g. from a timed-out first embedded run), it now sends any new content from session-recovery as a **markdown fallback** instead of silently skipping
- If no new content is available, the behavior remains unchanged (skip silently)
- Reuses the existing `sendMessage + forceMarkdown` path, consistent with the FAILED card fallback pattern

Closes #513

## Test plan

- [x] `npx vitest run tests/unit/reply-strategy-card.test.ts` — 71 tests passed
- [x] `npx vitest run` — all 958 tests passed
- [x] 真机验证：构造 embedded run 超时场景（如 SMTP 连接超时 >120s），确认 session-recovery 的第二次 run 结果以 markdown 消息送达
- [x] 真机验证：正常完成场景不受影响，card 正常 finalize 后不会多发 markdown