### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/card/card-action-handler.ts
+++ b/src/card/card-action-handler.ts
@@ -27,17 +27,19 @@ export async function handleCardAction(params: {
     return { handled: false };
   }
 
-  // In group chats, only the user who initiated the conversation can stop it.
-  // Fail-closed: reject when clicker identity is missing but owner is known.
   const clickerUserId = params.analysis.userId;
   const record = resolveCardRun(outTrackId);
-  if (record?.ownerUserId) {
-    if (!clickerUserId || record.ownerUserId !== clickerUserId) {
-      params.log?.info?.(
-        `[${params.accountId}] [DingTalk][CardStop] rejected: clicker=${clickerUserId ?? "unknown"} owner=${record.ownerUserId}`,
-      );
-      return { handled: true };
-    }
+  if (!record?.ownerUserId) {
+    params.log?.warn?.(
+      `[${params.accountId}] [DingTalk][CardStop] security rejection: missing owner binding outTrackId=${outTrackId}`,
+    );
+    return { handled: true };
+  }
+  if (!clickerUserId || record.ownerUserId !== clickerUserId) {
+    params.log?.info?.(
+      `[${params.accountId}] [DingTalk][CardStop] rejected: clicker=${clickerUserId ?? "unknown"} owner=${record.ownerUserId}`,
+    );
+    return { handled: true };
   }
 
   const result = await stopCardRun({

--- a/src/targeting/group-members-store.ts
+++ b/src/targeting/group-members-store.ts
@@ -6,8 +6,12 @@ const GROUP_MEMBERS_NAMESPACE = "members.group-roster";
 
 function groupMembersFilePath(storePath: string, groupId: string): string {
   const dir = path.join(path.dirname(storePath), "dingtalk-members");
-  const safeId = groupId.replace(/\+/g, "-").replace(/\//g, "_");
-  return path.join(dir, `${safeId}.json`);
+  const safeId = groupId
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/\.\.+/g, "_");
+  return path.join(dir, `${safeId || "_"}.json`);
 }
 
 function readLegacyRoster(storePath: string, groupId: string): Record<string, string> | null {


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `src/targeting/group-members-store.ts:L7`

`groupMembersFilePath()` derives a filename from `groupId` using only `+` and `/` replacements. Other dangerous characters (e.g. `..`, `\\`, control chars) are not normalized. On some platforms (notably Windows path semantics), crafted `groupId` values could escape the intended directory or create unexpected files.

## Solution

Harden filename sanitization with a strict allowlist (e.g. `[A-Za-z0-9._-]`), reject path separators for all platforms, and optionally encode IDs (base64url/hex) before using them in filesystem paths.

## Changes

- `src/targeting/group-members-store.ts` (modified)
- `src/card/card-action-handler.ts` (modified)