### PR TITLE
Handle detailed DingTalk chatRecord payloads

### DIFF
--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -141,6 +141,8 @@ function stringifyChatRecordContentValue(value: unknown): string | undefined {
         ? trimString((content as Record<string, unknown>).text as string | undefined)
         : undefined;
 
+  // Preserve DingTalk's observed chatRecord text priority: explicit text first,
+  // then nested content text, then the legacy message fallback.
   return (
     trimString(record.text as string | undefined) ||
     contentText ||

--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -1,5 +1,10 @@
-import type { AtMention, DingTalkInboundMessage, MessageContent, QuotedInfo, SendMessageOptions } from "./types";
-
+import type {
+  AtMention,
+  DingTalkInboundMessage,
+  MessageContent,
+  QuotedInfo,
+  SendMessageOptions,
+} from "./types";
 
 interface DingTalkDocMeta {
   spaceId: string;
@@ -94,7 +99,8 @@ function extractRichTextQuoteParts(
   return {
     summary,
     pictureDownloadCode,
-    pictureDownloadCodes: uniquePictureDownloadCodes.length > 0 ? uniquePictureDownloadCodes : undefined,
+    pictureDownloadCodes:
+      uniquePictureDownloadCodes.length > 0 ? uniquePictureDownloadCodes : undefined,
   };
 }
 
@@ -115,7 +121,82 @@ function trimString(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function buildQuotedMessageTypePlaceholder(messageType: string | undefined, fileName?: string): string | undefined {
+function stringifyChatRecordContentValue(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return trimString(value);
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    trimString(record.text as string | undefined) ||
+    trimString(record.content as string | undefined) ||
+    trimString(record.message as string | undefined) ||
+    trimString((record.content as Record<string, unknown> | undefined)?.text as string | undefined)
+  );
+}
+
+function formatChatRecordEntries(rawRecord: unknown): string[] {
+  let entries = rawRecord;
+  if (typeof rawRecord === "string") {
+    const trimmed = rawRecord.trim();
+    if (!trimmed || trimmed === "[]") {
+      return [];
+    }
+    try {
+      entries = JSON.parse(trimmed);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return trimString(String(entry ?? ""));
+      }
+      const record = entry as Record<string, unknown>;
+      const sender =
+        trimString(record.senderName as string | undefined) ||
+        trimString(record.senderNick as string | undefined) ||
+        trimString(record.sender as string | undefined) ||
+        trimString(record.senderId as string | undefined) ||
+        "某人";
+      const body = stringifyChatRecordContentValue(
+        record.content ?? record.text ?? record.message ?? record.body,
+      );
+      return body ? `${sender}: ${body}` : undefined;
+    })
+    .filter((line): line is string => Boolean(line))
+    .slice(0, 30);
+}
+
+function formatChatRecordPreview(
+  content: Record<string, unknown> | undefined,
+  options: { titlePrefix?: boolean } = {},
+): string | undefined {
+  const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
+  const title = typeof content?.title === "string" ? content.title.trim() : "";
+  const rawRecord = content?.chatRecord ?? content?.records ?? content?.messages;
+  const recordLines = formatChatRecordEntries(rawRecord);
+  const parts: string[] = [];
+  if (summary && summary !== "[]") {
+    const label = options.titlePrefix ? (title ? `[${title}] ` : "[聊天记录] ") : "[聊天记录摘要] ";
+    parts.push(`${label}${summary}`);
+  }
+  if (recordLines.length > 0) {
+    parts.push(`[聊天记录内容]\n${recordLines.join("\n")}`);
+  }
+  return parts.join("\n\n") || undefined;
+}
+
+function buildQuotedMessageTypePlaceholder(
+  messageType: string | undefined,
+  fileName?: string,
+): string | undefined {
   switch (messageType) {
     case "text":
       return undefined;
@@ -147,8 +228,7 @@ function buildLegacyQuoteMessagePreview(message: DingTalkInboundMessage["quoteMe
   const previewMessageType = trimString(message?.msgtype);
   return {
     previewText:
-      trimString(message?.text?.content) ||
-      buildQuotedMessageTypePlaceholder(previewMessageType),
+      trimString(message?.text?.content) || buildQuotedMessageTypePlaceholder(previewMessageType),
     previewMessageType,
     previewSenderId: trimString(message?.senderId),
   };
@@ -202,7 +282,10 @@ function buildRepliedMessagePreview(params: {
     return {
       isQuotedFile: true,
       fileCreatedAt: repliedMsg.createdAt,
-      previewText: buildQuotedMessageTypePlaceholder(repliedMsgType, hasFileName ? fileName : undefined),
+      previewText: buildQuotedMessageTypePlaceholder(
+        repliedMsgType,
+        hasFileName ? fileName : undefined,
+      ),
       previewMessageType: repliedMsgType,
       ...(hasFileName ? { previewFileName: fileName } : {}),
       previewSenderId: trimString(repliedMsg.senderId),
@@ -235,11 +318,11 @@ function buildRepliedMessagePreview(params: {
   }
 
   if (repliedMsgType === "chatRecord") {
-    const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
-    const title = typeof content?.title === "string" ? content.title.trim() : "";
-    const chatRecordLabel = title ? `[${title}] ` : "[聊天记录] ";
     return {
-      previewText: summary ? `${chatRecordLabel}${summary}` : buildQuotedMessageTypePlaceholder("chatRecord"),
+      previewText:
+        formatChatRecordPreview(content as Record<string, unknown> | undefined, {
+          titlePrefix: true,
+        }) || buildQuotedMessageTypePlaceholder("chatRecord"),
       previewMessageType: "chatRecord",
       previewSenderId: trimString(repliedMsg.senderId),
     };
@@ -517,7 +600,10 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
       mediaPath: pictureDownloadCode,
       mediaPaths: uniquePictureDownloadCodes.length > 0 ? uniquePictureDownloadCodes : undefined,
       mediaType: pictureDownloadCode ? "image" : undefined,
-      mediaTypes: uniquePictureDownloadCodes.length > 0 ? uniquePictureDownloadCodes.map(() => "image") : undefined,
+      mediaTypes:
+        uniquePictureDownloadCodes.length > 0
+          ? uniquePictureDownloadCodes.map(() => "image")
+          : undefined,
       messageType: "richText",
       quoted: quoted ?? undefined,
       atMentions,
@@ -605,7 +691,8 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
   if (msgtype === "chatRecord") {
     const content = data.content as Record<string, unknown> | undefined;
     const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
-    const rawRecord = content?.chatRecord;
+    const rawRecord = content?.chatRecord ?? content?.records ?? content?.messages;
+    const chatRecordText = formatChatRecordPreview(content);
     if (
       summary === "[]" ||
       (typeof rawRecord === "string" && rawRecord.trim() === "[]") ||
@@ -619,9 +706,9 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
         atUserDingtalkIds,
       };
     }
-    if (summary) {
+    if (chatRecordText) {
       return {
-        text: `[聊天记录摘要] ${summary}`,
+        text: chatRecordText,
         messageType: "chatRecord",
         quoted: quoted ?? undefined,
         atMentions,

--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -11,6 +11,8 @@ interface DingTalkDocMeta {
   fileId: string;
 }
 
+const UNKNOWN_PERSON_LABEL = "某人";
+
 function parseBizCustomActionUrl(url: string | undefined): DingTalkDocMeta | null {
   if (!url || typeof url !== "string") {
     return null;
@@ -81,7 +83,7 @@ function extractRichTextQuoteParts(
           ? part.atName
           : typeof textValue === "string"
             ? textValue
-            : "某人";
+            : UNKNOWN_PERSON_LABEL;
       textParts.push(`@${atName}`);
       continue;
     }
@@ -121,6 +123,8 @@ function trimString(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+const MAX_CHAT_RECORD_ENTRIES = 30;
+
 function stringifyChatRecordContentValue(value: unknown): string | undefined {
   if (typeof value === "string") {
     return trimString(value);
@@ -129,11 +133,18 @@ function stringifyChatRecordContentValue(value: unknown): string | undefined {
     return undefined;
   }
   const record = value as Record<string, unknown>;
+  const content = record.content;
+  const contentText =
+    typeof content === "string"
+      ? trimString(content)
+      : content && typeof content === "object"
+        ? trimString((content as Record<string, unknown>).text as string | undefined)
+        : undefined;
+
   return (
     trimString(record.text as string | undefined) ||
-    trimString(record.content as string | undefined) ||
-    trimString(record.message as string | undefined) ||
-    trimString((record.content as Record<string, unknown> | undefined)?.text as string | undefined)
+    contentText ||
+    trimString(record.message as string | undefined)
   );
 }
 
@@ -168,19 +179,19 @@ function formatChatRecordEntries(rawRecord: unknown): string[] {
         trimString(record.senderNick as string | undefined) ||
         trimString(record.sender as string | undefined) ||
         trimString(record.senderId as string | undefined) ||
-        "某人";
+        UNKNOWN_PERSON_LABEL;
       const body = stringifyChatRecordContentValue(
         record.content ?? record.text ?? record.message ?? record.body,
       );
       return body ? `${sender}: ${body}` : undefined;
     })
     .filter((line): line is string => Boolean(line))
-    .slice(0, 30);
+    .slice(0, MAX_CHAT_RECORD_ENTRIES);
 }
 
 function formatChatRecordPreview(
   content: Record<string, unknown> | undefined,
-  options: { titlePrefix?: boolean } = {},
+  options: { useTitleAsLabel?: boolean } = {},
 ): string | undefined {
   const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
   const title = typeof content?.title === "string" ? content.title.trim() : "";
@@ -188,7 +199,11 @@ function formatChatRecordPreview(
   const recordLines = formatChatRecordEntries(rawRecord);
   const parts: string[] = [];
   if (summary && summary !== "[]") {
-    const label = options.titlePrefix ? (title ? `[${title}] ` : "[聊天记录] ") : "[聊天记录摘要] ";
+    const label = options.useTitleAsLabel
+      ? title
+        ? `[${title}] `
+        : "[聊天记录] "
+      : "[聊天记录摘要] ";
     parts.push(`${label}${summary}`);
   }
   if (recordLines.length > 0) {
@@ -325,7 +340,7 @@ function buildRepliedMessagePreview(params: {
     return {
       previewText:
         formatChatRecordPreview(content as Record<string, unknown> | undefined, {
-          titlePrefix: true,
+          useTitleAsLabel: true,
         }) || buildQuotedMessageTypePlaceholder("chatRecord"),
       previewMessageType: "chatRecord",
       previewSenderId: trimString(repliedMsg.senderId),

--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -137,6 +137,10 @@ function stringifyChatRecordContentValue(value: unknown): string | undefined {
   );
 }
 
+function getChatRecordEntriesSource(content: Record<string, unknown> | undefined): unknown {
+  return content?.chatRecord ?? content?.records ?? content?.messages;
+}
+
 function formatChatRecordEntries(rawRecord: unknown): string[] {
   let entries = rawRecord;
   if (typeof rawRecord === "string") {
@@ -156,7 +160,7 @@ function formatChatRecordEntries(rawRecord: unknown): string[] {
   return entries
     .map((entry) => {
       if (!entry || typeof entry !== "object") {
-        return trimString(String(entry ?? ""));
+        return undefined;
       }
       const record = entry as Record<string, unknown>;
       const sender =
@@ -180,7 +184,7 @@ function formatChatRecordPreview(
 ): string | undefined {
   const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
   const title = typeof content?.title === "string" ? content.title.trim() : "";
-  const rawRecord = content?.chatRecord ?? content?.records ?? content?.messages;
+  const rawRecord = getChatRecordEntriesSource(content);
   const recordLines = formatChatRecordEntries(rawRecord);
   const parts: string[] = [];
   if (summary && summary !== "[]") {
@@ -691,7 +695,7 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
   if (msgtype === "chatRecord") {
     const content = data.content as Record<string, unknown> | undefined;
     const summary = typeof content?.summary === "string" ? content.summary.trim() : "";
-    const rawRecord = content?.chatRecord ?? content?.records ?? content?.messages;
+    const rawRecord = getChatRecordEntriesSource(content);
     const chatRecordText = formatChatRecordPreview(content);
     if (
       summary === "[]" ||

--- a/tests/unit/message-utils.test.ts
+++ b/tests/unit/message-utils.test.ts
@@ -671,4 +671,69 @@ describe('message-utils', () => {
         expect(content.quoted?.previewText).toBe('[Quoted chatRecord]');
         expect(content.quoted?.previewMessageType).toBe('chatRecord');
     });
+
+    it('chatRecord reply — expands detailed forwarded records when DingTalk includes them', () => {
+        const message = {
+            msgId: 'test',
+            createAt: 0,
+            conversationType: '1',
+            conversationId: 'cid',
+            senderId: 'sid',
+            chatbotUserId: 'bot',
+            sessionWebhook: 'https://example.com',
+            msgtype: 'text',
+            text: {
+                content: '学下这个内容',
+                isReplyMsg: true,
+                repliedMsg: {
+                    msgType: 'chatRecord',
+                    msgId: 'quoted_chat_4',
+                    content: {
+                        title: '溯煜与祝欣莹的聊天记录',
+                        summary: '祝欣莹:[消息]\n溯煜:这个就是',
+                        chatRecord: [
+                            { senderName: '祝欣莹', content: '原始正文' },
+                            { senderNick: '溯煜', content: { text: '这个就是' } },
+                        ],
+                    },
+                },
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.previewText).toContain('[溯煜与祝欣莹的聊天记录]');
+        expect(content.quoted?.previewText).toContain('[聊天记录内容]');
+        expect(content.quoted?.previewText).toContain('祝欣莹: 原始正文');
+        expect(content.quoted?.previewText).toContain('溯煜: 这个就是');
+        expect(content.quoted?.previewMessageType).toBe('chatRecord');
+    });
+
+    it('top-level chatRecord — expands records aliases instead of only summary', () => {
+        const message = {
+            msgId: 'test',
+            createAt: 0,
+            conversationType: '1',
+            conversationId: 'cid',
+            senderId: 'sid',
+            chatbotUserId: 'bot',
+            sessionWebhook: 'https://example.com',
+            msgtype: 'chatRecord',
+            content: {
+                summary: '祝欣莹:[消息]\n溯煜:[分享]',
+                records: [
+                    { senderName: '祝欣莹', content: '第一条' },
+                    { senderName: '溯煜', message: '第二条' },
+                ],
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.messageType).toBe('chatRecord');
+        expect(content.text).toContain('[聊天记录摘要] 祝欣莹:[消息]');
+        expect(content.text).toContain('[聊天记录内容]');
+        expect(content.text).toContain('祝欣莹: 第一条');
+        expect(content.text).toContain('溯煜: 第二条');
+    });
 });

--- a/tests/unit/message-utils.test.ts
+++ b/tests/unit/message-utils.test.ts
@@ -736,4 +736,30 @@ describe('message-utils', () => {
         expect(content.text).toContain('祝欣莹: 第一条');
         expect(content.text).toContain('溯煜: 第二条');
     });
+
+    it('top-level chatRecord — expands messages aliases', () => {
+        const message = {
+            msgId: 'test',
+            createAt: 0,
+            conversationType: '1',
+            conversationId: 'cid',
+            senderId: 'sid',
+            chatbotUserId: 'bot',
+            sessionWebhook: 'https://example.com',
+            msgtype: 'chatRecord',
+            content: {
+                summary: '溯煜:[图片]',
+                messages: [
+                    { senderName: '溯煜', content: '图片里的原始描述' },
+                ],
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.messageType).toBe('chatRecord');
+        expect(content.text).toContain('[聊天记录摘要] 溯煜:[图片]');
+        expect(content.text).toContain('[聊天记录内容]');
+        expect(content.text).toContain('溯煜: 图片里的原始描述');
+    });
 });

--- a/tests/unit/message-utils.test.ts
+++ b/tests/unit/message-utils.test.ts
@@ -672,6 +672,43 @@ describe('message-utils', () => {
         expect(content.quoted?.previewMessageType).toBe('chatRecord');
     });
 
+    it('chatRecord reply — logged DingTalk summary-only payload has no detailed records to expand', () => {
+        const message = {
+            msgId: 'msgv+gE8CSZUZWAKbxk3KrUYA==',
+            createAt: 1776067733725,
+            conversationType: '2',
+            conversationId: 'cid4AkDhNKBaSK+cq6zt4dDEA==',
+            senderId: 'sender',
+            chatbotUserId: 'bot',
+            sessionWebhook: 'https://example.com',
+            originalMsgId: 'msgrAGRxGTFIE0Jr5rrzqj1sQ==',
+            msgtype: 'text',
+            text: {
+                isReplyMsg: true,
+                content: ' 重新学习一下',
+                repliedMsg: {
+                    createdAt: 1776065111071,
+                    senderId: 'sender',
+                    msgType: 'chatRecord',
+                    msgId: 'msgrAGRxGTFIE0Jr5rrzqj1sQ==',
+                    content: {
+                        summary: '祝欣莹:[消息]\n溯煜:[分享]\n溯煜:[图片]\n溯煜:这个就是',
+                        title: '溯煜与祝欣莹的聊天记录',
+                    },
+                },
+            },
+        } as any;
+
+        const content = extractMessageContent(message);
+
+        expect(content.text).toBe('重新学习一下');
+        expect(content.quoted?.previewText).toBe(
+            '[溯煜与祝欣莹的聊天记录] 祝欣莹:[消息]\n溯煜:[分享]\n溯煜:[图片]\n溯煜:这个就是',
+        );
+        expect(content.quoted?.previewText).not.toContain('[聊天记录内容]');
+        expect(content.quoted?.previewMessageType).toBe('chatRecord');
+    });
+
     it('chatRecord reply — expands detailed forwarded records when DingTalk includes them', () => {
         const message = {
             msgId: 'test',


### PR DESCRIPTION
## Summary
- expand DingTalk `chatRecord` payloads when forwarded record details are present on replied messages
- support `chatRecord`, `records`, and `messages` aliases for top-level chat record content
- keep the existing summary/empty-record fallback behavior when DingTalk only provides placeholders

## Tests
- `pnpm test tests/unit/message-utils.test.ts`
- `pnpm type-check`
- `pnpm test`
- `pnpm exec oxfmt --check src/message-utils.ts`

Note: `pnpm lint` currently reports existing warnings in unrelated files but 0 errors.
