### PR TITLE
feat: add DingTalk RPC and SecretInput compatibility

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,22 @@
 import { defineChannelPluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { readStringParam } from "openclaw/plugin-sdk/param-readers";
+import { getAccessToken } from "./src/auth";
 import { dingtalkPlugin } from "./src/channel";
-import { getConfig } from "./src/config";
-import { appendToDoc, createDoc, DocCreateAppendError, listDocs, searchDocs } from "./src/docs-service";
+import {
+  getConfig,
+  isConfigured,
+  listDingTalkAccountIds,
+  resolveDingTalkAccount,
+} from "./src/config";
+import {
+  appendToDoc,
+  createDoc,
+  DocCreateAppendError,
+  listDocs,
+  searchDocs,
+} from "./src/docs-service";
 import { setDingTalkRuntime } from "./src/runtime";
+import { sendMessage } from "./src/send-service";
 
 type GatewayMethodContext = Pick<
   Parameters<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>[0],
@@ -11,7 +24,7 @@ type GatewayMethodContext = Pick<
 >;
 
 function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
-  api.registerGatewayMethod("dingtalk.docs.create", async ({ respond, params }: GatewayMethodContext) => {
+  const createHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const spaceId = readStringParam(params, "spaceId", { required: true });
     const title = readStringParam(params, "title", { required: true });
@@ -40,34 +53,189 @@ function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
       }
       throw error;
     }
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.append", async ({ respond, params }: GatewayMethodContext) => {
+  const appendHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const docId = readStringParam(params, "docId", { required: true });
     const content = readStringParam(params, "content", { required: true, allowEmpty: false });
     const config = getConfig(api.config, accountId ?? undefined);
     const result = await appendToDoc(config, docId, content, api.logger);
     return respond(true, result);
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.search", async ({ respond, params }: GatewayMethodContext) => {
+  const searchHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const keyword = readStringParam(params, "keyword", { required: true });
     const spaceId = readStringParam(params, "spaceId");
     const config = getConfig(api.config, accountId ?? undefined);
     const docs = await searchDocs(config, keyword, spaceId, api.logger);
     return respond(true, { docs });
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.list", async ({ respond, params }: GatewayMethodContext) => {
+  const listHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const spaceId = readStringParam(params, "spaceId", { required: true });
     const parentId = readStringParam(params, "parentId");
     const config = getConfig(api.config, accountId ?? undefined);
     const docs = await listDocs(config, spaceId, parentId, api.logger);
     return respond(true, { docs });
+  };
+
+  api.registerGatewayMethod("dingtalk.docs.create", createHandler);
+  api.registerGatewayMethod("dingtalk.docs.append", appendHandler);
+  api.registerGatewayMethod("dingtalk.docs.search", searchHandler);
+  api.registerGatewayMethod("dingtalk.docs.list", listHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.create", createHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.append", appendHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.search", searchHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.list", listHandler);
+}
+
+function getContentParam(params: Record<string, unknown>): string | undefined {
+  return (
+    readStringParam(params, "content", { allowEmpty: true }) ??
+    readStringParam(params, "message", { allowEmpty: true })
+  );
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+async function sendGatewayMessage(params: {
+  api: OpenClawPluginApi;
+  respond: GatewayMethodContext["respond"];
+  accountId?: string;
+  target: string;
+  content: string;
+  useAICard?: unknown;
+}) {
+  const config = getConfig(params.api.config, params.accountId);
+  if (!isConfigured(params.api.config, params.accountId)) {
+    return params.respond(false, { error: "DingTalk not configured" });
+  }
+  const result = await sendMessage(config, params.target, params.content, {
+    log: params.api.logger,
+    accountId: params.accountId,
+    conversationId: params.target,
+    forceMarkdown: params.useAICard === false,
   });
+  return params.respond(
+    result.ok,
+    result.ok
+      ? {
+          ok: true,
+          target: params.target,
+          messageId:
+            result.messageId ??
+            result.tracking?.processQueryKey ??
+            result.tracking?.cardInstanceId ??
+            null,
+          tracking: result.tracking ?? null,
+        }
+      : { error: result.error || "send failed" },
+  );
+}
+
+function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPluginApi): void {
+  api.registerGatewayMethod(
+    "dingtalk-connector.sendToUser",
+    async ({ respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const userId = readStringParam(params, "userId", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target: `user:${userId}`,
+        content,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.sendToGroup",
+    async ({ respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const openConversationId = readStringParam(params, "openConversationId", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target: `group:${openConversationId}`,
+        content,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.send",
+    async ({ respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const target = readStringParam(params, "target", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target,
+        content,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.status",
+    async ({ respond }: GatewayMethodContext) => {
+      const accountIds = listDingTalkAccountIds(api.config);
+      const accounts = accountIds.length > 0 ? accountIds : ["default"];
+      return respond(true, {
+        channel: "dingtalk",
+        accounts: accounts.map((accountId) => {
+          const account = resolveDingTalkAccount(api.config, accountId);
+          return {
+            accountId,
+            configured: account.configured,
+            enabled: account.enabled !== false,
+            name: account.name ?? null,
+            clientId: account.clientId || null,
+          };
+        }),
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.probe",
+    async ({ respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const config = getConfig(api.config, accountId ?? undefined);
+      if (!isConfigured(api.config, accountId ?? undefined)) {
+        return respond(false, { error: "DingTalk not configured" });
+      }
+      try {
+        await getAccessToken(config, api.logger);
+        return respond(true, { ok: true, clientId: config.clientId });
+      } catch (error: unknown) {
+        return respond(false, { error: getErrorMessage(error, "probe failed") });
+      }
+    },
+  );
 }
 
 export { dingtalkPlugin } from "./src/channel";
@@ -81,5 +249,6 @@ export default defineChannelPluginEntry({
   setRuntime: setDingTalkRuntime,
   registerFull(api) {
     registerDingTalkDocsGatewayMethods(api);
+    registerDingTalkConnectorCompatibilityGatewayMethods(api);
   },
 });

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -36,8 +36,20 @@
             "description": "DingTalk App Key (Client ID) used to authenticate API and Stream connections."
           },
           "clientSecret": {
-            "type": "string",
-            "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens."
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source", "provider", "id"],
+                "properties": {
+                  "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                  "provider": { "type": "string", "minLength": 1 },
+                  "id": { "type": "string", "minLength": 1 }
+                }
+              }
+            ],
+            "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. Supports SecretInput references such as env/file/exec."
           },
           "dmPolicy": {
             "type": "string",
@@ -282,8 +294,20 @@
                   "description": "DingTalk App Key (Client ID) used to authenticate API and Stream connections."
                 },
                 "clientSecret": {
-                  "type": "string",
-                  "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens."
+                  "anyOf": [
+                    { "type": "string" },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["source", "provider", "id"],
+                      "properties": {
+                        "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                        "provider": { "type": "string", "minLength": 1 },
+                        "id": { "type": "string", "minLength": 1 }
+                      }
+                    }
+                  ],
+                  "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. Supports SecretInput references such as env/file/exec."
                 },
                 "dmPolicy": {
                   "type": "string",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -16,14 +16,15 @@ const accessTokenCache = new Map<string, TokenCache>();
  * Refreshes token one minute before expiry to avoid near-expiry failures.
  */
 export async function getAccessToken(config: DingTalkConfig, log?: Logger): Promise<string> {
-  const runtimeConfig = resolveRuntimeConfig(config);
-  const cacheKey = runtimeConfig.clientId;
+  const cacheKey = config.clientId;
   const now = Date.now();
   const cached = accessTokenCache.get(cacheKey);
 
   if (cached && cached.expiry > now + 60000) {
     return cached.accessToken;
   }
+
+  const runtimeConfig = resolveRuntimeConfig(config);
 
   const token = await retryWithBackoff(
     async () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import { resolveRuntimeConfig } from "./config";
 import axios from "./http-client";
 import type { DingTalkConfig, Logger, TokenInfo } from "./types";
 import { retryWithBackoff } from "./utils";
@@ -15,7 +16,8 @@ const accessTokenCache = new Map<string, TokenCache>();
  * Refreshes token one minute before expiry to avoid near-expiry failures.
  */
 export async function getAccessToken(config: DingTalkConfig, log?: Logger): Promise<string> {
-  const cacheKey = config.clientId;
+  const runtimeConfig = resolveRuntimeConfig(config);
+  const cacheKey = runtimeConfig.clientId;
   const now = Date.now();
   const cached = accessTokenCache.get(cacheKey);
 
@@ -28,8 +30,8 @@ export async function getAccessToken(config: DingTalkConfig, log?: Logger): Prom
       const response = await axios.post<TokenInfo>(
         "https://api.dingtalk.com/v1.0/oauth2/accessToken",
         {
-          appKey: config.clientId,
-          appSecret: config.clientSecret,
+          appKey: runtimeConfig.clientId,
+          appSecret: runtimeConfig.clientSecret,
         },
       );
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -7,7 +7,6 @@ import { readStringParam } from "openclaw/plugin-sdk/param-readers";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { getAccessToken } from "./auth";
 import { analyzeCardCallback } from "./card-callback-service";
-import { handleCardAction } from "./card/card-action-handler";
 import {
   createAICard,
   streamAICard,
@@ -15,10 +14,12 @@ import {
   finalizeActiveCardsForAccount,
   recoverPendingCardsForAccount,
 } from "./card-service";
+import { handleCardAction } from "./card/card-action-handler";
 import {
   getConfig,
   isConfigured,
   mergeAccountWithDefaults,
+  resolveRuntimeConfig,
   resolveGroupConfig,
   resolveRelativePath,
   resolveRobotCode,
@@ -38,6 +39,7 @@ import { prepareMediaInput, resolveOutboundMediaType } from "./media-utils";
 import { dingtalkSetupAdapter, dingtalkSetupWizard } from "./onboarding.js";
 import { resolveOriginalPeerId, preloadPeerIdsFromSessions } from "./peer-id-registry";
 import { getDingTalkRuntime } from "./runtime";
+import { hasConfiguredSecretInput } from "./secret-input";
 import {
   sendMessage,
   sendProactiveMedia,
@@ -206,7 +208,7 @@ function describeDingTalkMessageTool(cfg: OpenClawConfig): {
   schema: null;
 } {
   const config = getConfig(cfg);
-  const configured = Boolean(config.clientId && config.clientSecret);
+  const configured = Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret));
   if (!configured && !(config.accounts && Object.keys(config.accounts).length > 0)) {
     return { actions: [], capabilities: [], schema: null };
   }
@@ -367,7 +369,9 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       const id = accountId || "default";
       const account = config.accounts?.[id];
       const resolvedConfig = account ? mergeAccountWithDefaults(config, account) : config;
-      const configured = Boolean(resolvedConfig.clientId && resolvedConfig.clientSecret);
+      const configured = Boolean(
+        resolvedConfig.clientId && hasConfiguredSecretInput(resolvedConfig.clientSecret),
+      );
       return {
         accountId: id,
         config: resolvedConfig,
@@ -378,7 +382,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
     },
     defaultAccountId: (): string => "default",
     isConfigured: (account: ResolvedAccount): boolean =>
-      Boolean(account.config?.clientId && account.config?.clientSecret),
+      Boolean(account.config?.clientId && hasConfiguredSecretInput(account.config?.clientSecret)),
     describeAccount: (account: ResolvedAccount) => ({
       accountId: account.accountId,
       name: account.config?.name || "DingTalk",
@@ -477,7 +481,9 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
         };
       } catch (err: any) {
         if (err?.response?.data !== undefined) {
-          effectiveLog?.error?.(formatDingTalkErrorPayloadLog("outbound.sendText", err.response.data));
+          effectiveLog?.error?.(
+            formatDingTalkErrorPayloadLog("outbound.sendText", err.response.data),
+          );
         }
         throw new Error(
           typeof err?.response?.data === "string"
@@ -531,7 +537,11 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       let preparedMedia;
       try {
         try {
-          preparedMedia = await prepareMediaInput(rawMediaPath, effectiveLog, config.mediaUrlAllowlist);
+          preparedMedia = await prepareMediaInput(
+            rawMediaPath,
+            effectiveLog,
+            config.mediaUrlAllowlist,
+          );
         } catch (err: any) {
           if (err?.response?.data !== undefined) {
             effectiveLog?.error?.(
@@ -601,7 +611,9 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
         );
       } catch (err: any) {
         if (err?.response?.data !== undefined) {
-          effectiveLog?.error?.(formatDingTalkErrorPayloadLog("outbound.sendMedia", err.response.data));
+          effectiveLog?.error?.(
+            formatDingTalkErrorPayloadLog("outbound.sendMedia", err.response.data),
+          );
         }
         throw new Error(
           typeof err?.response?.data === "string"
@@ -617,7 +629,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
   gateway: {
     startAccount: async (ctx: GatewayStartContext): Promise<GatewayStopResult> => {
       const { account, cfg, abortSignal } = ctx;
-      const config = account.config;
+      const config = resolveRuntimeConfig(account.config);
       if (!config.clientId || !config.clientSecret) {
         throw new Error("DingTalk clientId and clientSecret are required");
       }
@@ -859,7 +871,12 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
               config,
               log: pluginLog,
             });
-            if (!actionResult.handled && analysis.actionId && analysis.actionId !== "feedback_up" && analysis.actionId !== "feedback_down") {
+            if (
+              !actionResult.handled &&
+              analysis.actionId &&
+              analysis.actionId !== "feedback_up" &&
+              analysis.actionId !== "feedback_down"
+            ) {
               pluginLog?.debug?.(
                 `[${account.accountId}] [DingTalk][CardCallback] Unhandled actionId=${analysis.actionId}`,
               );
@@ -968,7 +985,9 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
               lastStartAt: getCurrentTimestamp(),
               lastError: null,
             });
-            pluginLog?.info?.(`[${account.accountId}] DingTalk Stream client connected successfully`);
+            pluginLog?.info?.(
+              `[${account.accountId}] DingTalk Stream client connected successfully`,
+            );
             await nativeStopPromise;
           }
         } catch (err: any) {

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { DEFAULT_MESSAGE_CONTEXT_TTL_DAYS } from "./message-context-store";
+import { buildSecretInputSchema } from "./secret-input";
 
 const AckReactionSchema = z.union([
   z.literal(""),
@@ -29,7 +30,7 @@ const DingTalkAccountConfigShape = {
   clientId: z.string().optional(),
 
   /** DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. */
-  clientSecret: z.string().optional(),
+  clientSecret: buildSecretInputSchema().optional(),
 
   /** Direct-message access policy: open, pairing, or allowlist. */
   dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional().default("open"),
@@ -120,7 +121,13 @@ const DingTalkAccountConfigShape = {
       /** Show the proactive-send permission hint when the runtime detects missing DingTalk proactive permission. */
       enabled: z.boolean().optional().default(true),
       /** Minimum cooldown in hours before the same proactive permission hint can be shown again. */
-      cooldownHours: z.number().int().min(1).max(24 * 30).optional().default(24),
+      cooldownHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(24 * 30)
+        .optional()
+        .default(24),
     })
     .optional()
     .default({ enabled: true, cooldownHours: 24 }),
@@ -138,7 +145,12 @@ const DingTalkAccountConfigShape = {
   cardStreamInterval: z.number().int().min(200).optional().default(1000),
 
   /** Cooldown window in milliseconds after AI card trigger errors. Replies fall back to non-card delivery during this period. */
-  aicardDegradeMs: z.number().int().min(60_000).optional().default(30 * 60 * 1000),
+  aicardDegradeMs: z
+    .number()
+    .int()
+    .min(60_000)
+    .optional()
+    .default(30 * 60 * 1000),
 
   /** Enable the local feedback-learning loop for notes, reflections, and command-assisted learning. */
   learningEnabled: z.boolean().optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,11 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+  resolveDingTalkSecretConfig,
+} from "./secret-input";
 import type { DingTalkChannelConfig, DingTalkConfig } from "./types";
 
 const WINDOWS_ROOT_DIRECTORIES = new Set([
@@ -12,6 +17,7 @@ const WINDOWS_ROOT_DIRECTORIES = new Set([
   "Documents and Settings",
 ]);
 const DEFAULT_LEARNING_NOTE_TTL_MS = 6 * 60 * 60 * 1000;
+export type RuntimeDingTalkConfig = Omit<DingTalkConfig, "clientSecret"> & { clientSecret: string };
 
 function normalizeLearningConfig(
   config: DingTalkConfig,
@@ -19,12 +25,14 @@ function normalizeLearningConfig(
 ): DingTalkConfig {
   return {
     ...config,
-    learningEnabled: options.applyDefaults ? config.learningEnabled ?? false : config.learningEnabled,
+    learningEnabled: options.applyDefaults
+      ? (config.learningEnabled ?? false)
+      : config.learningEnabled,
     learningAutoApply: options.applyDefaults
-      ? config.learningAutoApply ?? false
+      ? (config.learningAutoApply ?? false)
       : config.learningAutoApply,
     learningNoteTtlMs: options.applyDefaults
-      ? config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS
+      ? (config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS)
       : config.learningNoteTtlMs,
     cardStreamingMode: options.applyDefaults
       ? (config.cardStreamingMode ?? (config.cardRealTimeStream === true ? "all" : "off"))
@@ -65,8 +73,10 @@ export function mergeAccountWithDefaults(
   channelCfg: DingTalkConfig,
   accountCfg: DingTalkConfig,
 ): DingTalkConfig {
-  const { accounts: _accounts, ...defaultCandidate } =
-    channelCfg as DingTalkConfig & { accounts?: unknown; verboseRealtimeStream?: unknown };
+  const { accounts: _accounts, ...defaultCandidate } = channelCfg as DingTalkConfig & {
+    accounts?: unknown;
+    verboseRealtimeStream?: unknown;
+  };
   const defaults = stripRemovedLegacyFields(defaultCandidate as DingTalkConfig);
   const normalizedAccountCfg = stripRemovedLegacyFields(
     normalizeLearningConfig(accountCfg, { applyDefaults: false }),
@@ -114,7 +124,11 @@ export function getConfig(cfg: OpenClawConfig, accountId?: string): DingTalkConf
 
 export function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {
   const config = getConfig(cfg, accountId);
-  return Boolean(config.clientId && config.clientSecret);
+  return Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret));
+}
+
+export function resolveRuntimeConfig(config: DingTalkConfig): RuntimeDingTalkConfig {
+  return resolveDingTalkSecretConfig(config) as RuntimeDingTalkConfig;
 }
 
 /**
@@ -197,7 +211,10 @@ function hasOwn(obj: unknown, key: string): boolean {
   return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function resolveAgentIdentityEmoji(cfg: OpenClawConfig, agentId?: string | null): string | undefined {
+function resolveAgentIdentityEmoji(
+  cfg: OpenClawConfig,
+  agentId?: string | null,
+): string | undefined {
   const targetAgentId = String(agentId || "").trim();
   if (!targetAgentId) {
     return undefined;
@@ -276,7 +293,6 @@ export function stripTargetPrefix(target: string): { targetId: string; isExplici
 // ============ Onboarding Helper Functions ============
 
 const DEFAULT_ACCOUNT_ID = "default";
-
 
 /**
  * List all DingTalk account IDs from config
@@ -363,21 +379,20 @@ export function resolveDingTalkAccount(
     return {
       ...config,
       accountId: id,
-      configured: Boolean(config.clientId && config.clientSecret),
+      configured: Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret)),
+      clientSecret: normalizeSecretInputString(config.clientSecret) || "",
     };
   }
 
   const accountConfig = dingtalk?.accounts?.[id];
   if (accountConfig) {
-    const merged = mergeAccountWithDefaults(
-      dingtalk as DingTalkConfig,
-      accountConfig,
-    );
+    const merged = mergeAccountWithDefaults(dingtalk as DingTalkConfig, accountConfig);
     const publicMerged = stripRemovedLegacyFields(merged);
     return {
       ...publicMerged,
       accountId: id,
-      configured: Boolean(merged.clientId && merged.clientSecret),
+      configured: Boolean(merged.clientId && hasConfiguredSecretInput(merged.clientSecret)),
+      clientSecret: normalizeSecretInputString(merged.clientSecret) || "",
     };
   }
 

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -6,14 +6,15 @@ import type {
   WizardPrompter,
 } from "openclaw/plugin-sdk/setup";
 import { DEFAULT_ACCOUNT_ID, formatDocsLink, normalizeAccountId } from "openclaw/plugin-sdk/setup";
-import { DEFAULT_MESSAGE_CONTEXT_TTL_DAYS } from "./message-context-store.js";
-import type { DingTalkConfig, DingTalkChannelConfig } from "./types.js";
 import { listDingTalkAccountIds, resolveDingTalkAccount } from "./config.js";
+import { DEFAULT_MESSAGE_CONTEXT_TTL_DAYS } from "./message-context-store.js";
+import { hasConfiguredSecretInput, normalizeSecretInputString } from "./secret-input.js";
+import type { DingTalkConfig, DingTalkChannelConfig } from "./types.js";
 
 const channel = "dingtalk" as const;
 
 function isConfigured(account: DingTalkConfig): boolean {
-  return Boolean(account.clientId && account.clientSecret);
+  return Boolean(account.clientId && hasConfiguredSecretInput(account.clientSecret));
 }
 
 function parseList(value: string): string[] {
@@ -225,7 +226,7 @@ async function configureDingTalkAccount(params: {
   const clientSecret = await prompter.text({
     message: "Client Secret (AppSecret)",
     placeholder: "xxx-xxx-xxx-xxx",
-    initialValue: resolved.clientSecret ?? undefined,
+    initialValue: normalizeSecretInputString(resolved.clientSecret),
     validate: (value: string) => (String(value ?? "").trim() ? undefined : "Required"),
   });
 
@@ -283,7 +284,8 @@ async function configureDingTalkAccount(params: {
     initialValue: (resolved.mediaUrlAllowlist || []).join(", ") || undefined,
   });
   const mediaUrlAllowlistParsed = parseList(String(mediaUrlAllowlistEntry ?? ""));
-  const mediaUrlAllowlist = mediaUrlAllowlistParsed.length > 0 ? mediaUrlAllowlistParsed : undefined;
+  const mediaUrlAllowlist =
+    mediaUrlAllowlistParsed.length > 0 ? mediaUrlAllowlistParsed : undefined;
 
   const groupPolicyValue = await prompter.select({
     message: "Group message policy",
@@ -473,8 +475,7 @@ export const dingtalkSetupWizard: ChannelSetupWizard = {
     resolveStatusLines: ({ configured }) => [
       `DingTalk: ${configured ? "configured" : "needs setup"}`,
     ],
-    resolveSelectionHint: ({ configured }) =>
-      configured ? "configured" : "钉钉企业机器人",
+    resolveSelectionHint: ({ configured }) => (configured ? "configured" : "钉钉企业机器人"),
     resolveQuickstartScore: ({ configured }) => (configured ? 1 : 4),
   },
   resolveAccountIdForConfigure: async ({

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -1,0 +1,104 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { z } from "zod";
+
+export type SecretInputRef = {
+  source: "env" | "file" | "exec";
+  provider: string;
+  id: string;
+};
+
+export type SecretInput = string | SecretInputRef;
+
+export function buildSecretInputSchema() {
+  return z.union([
+    z.string(),
+    z.object({
+      source: z.enum(["env", "file", "exec"]),
+      provider: z.string().min(1),
+      id: z.string().min(1),
+    }),
+  ]);
+}
+
+export function isSecretInputRef(value: unknown): value is SecretInputRef {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const ref = value as SecretInputRef;
+  return (
+    (ref.source === "env" || ref.source === "file" || ref.source === "exec") &&
+    typeof ref.provider === "string" &&
+    ref.provider.trim().length > 0 &&
+    typeof ref.id === "string" &&
+    ref.id.trim().length > 0
+  );
+}
+
+export function hasConfiguredSecretInput(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (!isSecretInputRef(value)) {
+    return false;
+  }
+  if (value.source === "env") {
+    return Boolean(process.env[value.id]?.trim());
+  }
+  return true;
+}
+
+export function normalizeSecretInputString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!isSecretInputRef(value)) {
+    return undefined;
+  }
+  return `<${value.source}:${value.provider}:${value.id}>`;
+}
+
+export function resolveSecretInputString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!isSecretInputRef(value)) {
+    return undefined;
+  }
+  if (value.source === "env") {
+    return process.env[value.id]?.trim() || undefined;
+  }
+  if (value.source === "file") {
+    try {
+      const filePath = value.id.startsWith("~/")
+        ? path.resolve(os.homedir(), value.id.slice(2))
+        : path.resolve(value.id);
+      return readFileSync(filePath, "utf8").trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    return (
+      execFileSync(value.provider, [value.id], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim() || undefined
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveDingTalkSecretConfig<T extends { clientSecret?: unknown }>(
+  config: T,
+): T & { clientSecret?: string } {
+  return {
+    ...config,
+    clientSecret: resolveSecretInputString(config.clientSecret),
+  };
+}

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -12,6 +12,8 @@ export type SecretInputRef = {
 
 export type SecretInput = string | SecretInputRef;
 
+export const SECRET_INPUT_EXEC_TIMEOUT_MS = 5000;
+
 export function buildSecretInputSchema() {
   return z.union([
     z.string(),
@@ -87,6 +89,7 @@ export function resolveSecretInputString(value: unknown): string | undefined {
       execFileSync(value.provider, [value.id], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
+        timeout: SECRET_INPUT_EXEC_TIMEOUT_MS,
       }).trim() || undefined
     );
   } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,15 +10,13 @@
  */
 
 import type {
-  ChannelPlugin as SDKChannelPlugin,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/core";
-import type {
   ChannelAccountSnapshot as SDKChannelAccountSnapshot,
   ChannelGatewayContext as SDKChannelGatewayContext,
   ChannelLogSink as SDKChannelLogSink,
 } from "openclaw/plugin-sdk/channel-runtime";
+import type { ChannelPlugin as SDKChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import type { SecretInput } from "./secret-input";
 
 export type AckReactionMode = "off" | "emoji" | "kaomoji";
 // Accept arbitrary strings for backward compatibility; the recommended
@@ -32,7 +30,7 @@ export type ContextVisibilityMode = "all" | "allowlist" | "allowlist_quote";
  */
 export interface DingTalkConfig extends OpenClawConfig {
   clientId: string;
-  clientSecret: string;
+  clientSecret: SecretInput;
   name?: string;
   enabled?: boolean;
   dmPolicy?: "open" | "pairing" | "allowlist";
@@ -50,7 +48,10 @@ export interface DingTalkConfig extends OpenClawConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   // Connection robustness configuration
   maxConnectionAttempts?: number;
@@ -102,7 +103,7 @@ export interface DingTalkConfig extends OpenClawConfig {
 export interface DingTalkChannelConfig {
   enabled?: boolean;
   clientId: string;
-  clientSecret: string;
+  clientSecret: SecretInput;
   name?: string;
   dmPolicy?: "open" | "pairing" | "allowlist";
   groupPolicy?: "open" | "allowlist" | "disabled";
@@ -119,7 +120,10 @@ export interface DingTalkChannelConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   maxConnectionAttempts?: number;
   initialReconnectDelay?: number;
@@ -297,7 +301,12 @@ export interface DingTalkInboundMessage {
   sessionWebhook: string;
 }
 
-export type QuotedRefKey = "msgId" | "processQueryKey" | "messageId" | "outTrackId" | "cardInstanceId";
+export type QuotedRefKey =
+  | "msgId"
+  | "processQueryKey"
+  | "messageId"
+  | "outTrackId"
+  | "cardInstanceId";
 
 export type AttachmentTextSource = "text" | "html" | "pdf" | "docx";
 
@@ -635,7 +644,9 @@ export interface DingTalkOutboundHandler {
   deliveryMode: "direct" | "queued" | "batch";
   resolveTarget: (params: ResolveTargetParams) => TargetResolutionResult;
   sendText: (params: SendTextParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
-  sendMedia?: (params: SendMediaParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
+  sendMedia?: (
+    params: SendMediaParams,
+  ) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
 }
 
 /**
@@ -730,4 +741,3 @@ export interface ConnectionAttemptResult {
   error?: Error;
   nextDelay?: number;
 }
-

--- a/tests/unit/auth-secret-input-cache.test.ts
+++ b/tests/unit/auth-secret-input-cache.test.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockedAxiosPost = vi.mocked(axios.post);
+
+async function loadAuthModule() {
+  vi.resetModules();
+  return import("../../src/auth");
+}
+
+describe("auth.getAccessToken SecretInput cache path", () => {
+  beforeEach(() => {
+    mockedAxiosPost.mockReset();
+    vi.doUnmock("../../src/config");
+  });
+
+  it("does not resolve runtime secret config on cache hit", async () => {
+    const resolveRuntimeConfig = vi.fn((config) => config);
+    vi.doMock("../../src/config", async () => {
+      const actual = await vi.importActual<typeof import("../../src/config")>("../../src/config");
+      return { ...actual, resolveRuntimeConfig };
+    });
+    const { getAccessToken } = await loadAuthModule();
+    mockedAxiosPost.mockResolvedValue({
+      data: { accessToken: "token_cached", expireIn: 7200 },
+    } as any);
+
+    const config = {
+      clientId: "ding_secret_ref",
+      clientSecret: { source: "exec", provider: "helper", id: "client-secret" },
+    } as any;
+    const token1 = await getAccessToken(config);
+    const token2 = await getAccessToken(config);
+
+    expect(token1).toBe("token_cached");
+    expect(token2).toBe("token_cached");
+    expect(resolveRuntimeConfig).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/runtime-peer-index.test.ts
+++ b/tests/unit/runtime-peer-index.test.ts
@@ -5,6 +5,8 @@ const shared = vi.hoisted(() => ({
     appendToDocMock: vi.fn(),
     searchDocsMock: vi.fn(),
     listDocsMock: vi.fn(),
+    sendMessageMock: vi.fn(),
+    getAccessTokenMock: vi.fn(),
     defineChannelPluginEntryMock: vi.fn(
         (entry: {
             id: string;
@@ -109,6 +111,14 @@ vi.mock("../../src/docs-service", () => ({
     DocCreateAppendError: shared.DocCreateAppendErrorMock,
 }));
 
+vi.mock("../../src/send-service", () => ({
+    sendMessage: shared.sendMessageMock,
+}));
+
+vi.mock("../../src/auth", () => ({
+    getAccessToken: shared.getAccessTokenMock,
+}));
+
 describe("runtime + peer registry + index plugin", () => {
     beforeEach(async () => {
         vi.resetModules();
@@ -116,12 +126,16 @@ describe("runtime + peer registry + index plugin", () => {
         shared.appendToDocMock.mockReset();
         shared.searchDocsMock.mockReset();
         shared.listDocsMock.mockReset();
+        shared.sendMessageMock.mockReset();
+        shared.getAccessTokenMock.mockReset();
         shared.defineChannelPluginEntryMock.mockClear();
         shared.readStringParamMock.mockClear();
         shared.createDocMock.mockResolvedValue({ docId: "doc_1", title: "测试文档", docType: "alidoc" });
         shared.appendToDocMock.mockResolvedValue({ success: true });
         shared.searchDocsMock.mockResolvedValue([{ docId: "doc_2", title: "周报", docType: "alidoc" }]);
         shared.listDocsMock.mockResolvedValue([{ docId: "doc_3", title: "知识库", docType: "folder" }]);
+        shared.sendMessageMock.mockResolvedValue({ ok: true, messageId: "msg_1" });
+        shared.getAccessTokenMock.mockResolvedValue("token_abc");
         const peer = await import("../../src/peer-id-registry");
         peer.clearPeerIdRegistry();
     });
@@ -149,7 +163,7 @@ describe("runtime + peer registry + index plugin", () => {
         expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("cidabc+123");
     });
 
-    it("index plugin defines a channel entry and only registers docs methods in full mode", async () => {
+    it("index plugin defines a channel entry and only registers gateway methods in full mode", async () => {
         const runtimeModule = await import("../../src/runtime");
         const runtimeSpy = vi.spyOn(runtimeModule, "setDingTalkRuntime");
 
@@ -171,11 +185,20 @@ describe("runtime + peer registry + index plugin", () => {
         expect(shared.defineChannelPluginEntryMock).toHaveBeenCalledTimes(1);
         expect(runtimeSpy).toHaveBeenCalledWith(runtime);
         expect(registerChannel).toHaveBeenCalledTimes(1);
-        expect(registerGatewayMethod).toHaveBeenCalledTimes(4);
+        expect(registerGatewayMethod).toHaveBeenCalledTimes(13);
         expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.create", expect.any(Function));
         expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.append", expect.any(Function));
         expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.search", expect.any(Function));
         expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.list", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.docs.create", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.docs.append", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.docs.search", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.docs.list", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.sendToUser", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.sendToGroup", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.send", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.status", expect.any(Function));
+        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk-connector.probe", expect.any(Function));
     });
 
     it("skips docs gateway registration outside full registration mode", async () => {
@@ -226,6 +249,49 @@ describe("runtime + peer registry + index plugin", () => {
         expect(respondSearch).toHaveBeenCalledWith(true, {
             docs: [{ docId: "doc_2", title: "周报", docType: "alidoc" }],
         });
+    });
+
+    it("registered connector compatibility gateway methods send to explicit user and group targets", async () => {
+        const plugin = (await import("../../index")).default;
+        const registerGatewayMethod = vi.fn();
+
+        await plugin.register({
+            runtime: {},
+            registrationMode: "full",
+            registerChannel: vi.fn(),
+            registerGatewayMethod,
+            config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        } as any);
+
+        const sendToUserHandler = registerGatewayMethod.mock.calls.find((call: any[]) => call[0] === "dingtalk-connector.sendToUser")?.[1];
+        const sendToGroupHandler = registerGatewayMethod.mock.calls.find((call: any[]) => call[0] === "dingtalk-connector.sendToGroup")?.[1];
+
+        const respondUser = vi.fn();
+        await sendToUserHandler?.({
+            respond: respondUser,
+            params: { userId: "staff_1", content: "hello" },
+        });
+        expect(shared.sendMessageMock).toHaveBeenCalledWith(
+            expect.objectContaining({ clientId: "id", clientSecret: "sec" }),
+            "user:staff_1",
+            "hello",
+            expect.objectContaining({ conversationId: "user:staff_1" }),
+        );
+        expect(respondUser).toHaveBeenCalledWith(true, expect.objectContaining({ messageId: "msg_1" }));
+
+        const respondGroup = vi.fn();
+        await sendToGroupHandler?.({
+            respond: respondGroup,
+            params: { openConversationId: "cid_1", message: "hi group", useAICard: false },
+        });
+        expect(shared.sendMessageMock).toHaveBeenLastCalledWith(
+            expect.objectContaining({ clientId: "id", clientSecret: "sec" }),
+            "group:cid_1",
+            "hi group",
+            expect.objectContaining({ forceMarkdown: true }),
+        );
+        expect(respondGroup).toHaveBeenCalledWith(true, expect.objectContaining({ target: "group:cid_1" }));
     });
 
     it("returns partial-success metadata when initial doc append fails after creation", async () => {

--- a/tests/unit/secret-input-exec.test.ts
+++ b/tests/unit/secret-input-exec.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+describe("SecretInput exec support", () => {
+  it("bounds exec secret helper calls with a timeout", async () => {
+    execFileSyncMock.mockReturnValue("secret-from-helper\n");
+    const { SECRET_INPUT_EXEC_TIMEOUT_MS, resolveSecretInputString } =
+      await import("../../src/secret-input");
+
+    const secret = resolveSecretInputString({
+      source: "exec",
+      provider: "secret-helper",
+      id: "dingtalk/client-secret",
+    });
+
+    expect(secret).toBe("secret-from-helper");
+    expect(execFileSyncMock).toHaveBeenCalledWith("secret-helper", ["dingtalk/client-secret"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: SECRET_INPUT_EXEC_TIMEOUT_MS,
+    });
+  });
+});

--- a/tests/unit/secret-input.test.ts
+++ b/tests/unit/secret-input.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DingTalkConfigSchema } from "../../src/config-schema";
+import { isConfigured } from "../../src/config";
+
+describe("SecretInput support", () => {
+    afterEach(() => {
+        delete process.env.DINGTALK_TEST_SECRET;
+    });
+
+    it("accepts SecretInput references in the DingTalk config schema", () => {
+        const parsed = DingTalkConfigSchema.parse({
+            clientId: "id",
+            clientSecret: { source: "env", provider: "env", id: "DINGTALK_TEST_SECRET" },
+            accounts: {
+                main: {
+                    clientId: "account-id",
+                    clientSecret: {
+                        source: "file",
+                        provider: "local",
+                        id: "~/.config/dingtalk-secret",
+                    },
+                },
+            },
+        }) as { clientSecret?: unknown; accounts: Record<string, { clientSecret?: unknown }> };
+
+        expect(parsed.clientSecret).toEqual({
+            source: "env",
+            provider: "env",
+            id: "DINGTALK_TEST_SECRET",
+        });
+        expect(parsed.accounts.main?.clientSecret).toEqual({
+            source: "file",
+            provider: "local",
+            id: "~/.config/dingtalk-secret",
+        });
+    });
+
+    it("treats env SecretInput as configured only when the env value exists", () => {
+        process.env.DINGTALK_TEST_SECRET = "sec-from-env";
+
+        expect(isConfigured({
+            channels: {
+                dingtalk: {
+                    clientId: "id",
+                    clientSecret: { source: "env", provider: "env", id: "DINGTALK_TEST_SECRET" },
+                },
+            },
+        } as any)).toBe(true);
+        expect(isConfigured({
+            channels: {
+                dingtalk: {
+                    clientId: "id",
+                    clientSecret: { source: "env", provider: "env", id: "DINGTALK_MISSING_SECRET" },
+                },
+            },
+        } as any)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

This PR adds two narrowly scoped compatibility improvements, based on a comparison with `DingTalk-Real-AI/dingtalk-openclaw-connector` main:

- add `dingtalk-connector.*` Gateway RPC compatibility entrypoints for proactive send, status, probe, and the existing docs create/append/search/list methods
- allow `channels.dingtalk.clientSecret` and account-level `clientSecret` to use SecretInput-style references (`env` / `file` / `exec`) instead of only plaintext strings

## Why this shape

The reference connector exposes direct Gateway RPC methods such as `dingtalk-connector.sendToUser`, `dingtalk-connector.sendToGroup`, and `dingtalk-connector.send`. Those are useful for external scripts, MCP tools, and other agents that call Gateway methods directly. This plugin already has stronger runtime delivery paths through channel actions/outbound, so this PR implements the RPC layer as a thin compatibility wrapper over the existing `sendMessage` flow rather than copying the reference connector's runtime.

The reference connector also accepts SecretInput-style `clientSecret` objects. This PR keeps plaintext strings working, adds schema/manifest support for the object form, and resolves the secret only at runtime before DingTalk auth/Stream startup.

Intentionally not included:

- no DEAP documentation or workflow migration
- no GitHub automation workflow migration
- no `docs.read` migration, because the reference implementation does not clearly provide full document-body reading and would be a separate product decision
- no replacement of the existing soimy runtime architecture

## Validation

- `pnpm exec oxfmt --check index.ts src/config-schema.ts src/config.ts src/auth.ts src/channel.ts src/onboarding.ts src/types.ts src/secret-input.ts`
- `pnpm type-check`
- `pnpm test tests/unit/runtime-peer-index.test.ts tests/unit/secret-input.test.ts`
- `pnpm test`
- `pnpm lint` (passes with existing warnings, 0 errors)
