### PR TITLE
feat: add DingTalk connector Gateway RPC compatibility

### DIFF
--- a/docs/user/reference/gateway-rpc.md
+++ b/docs/user/reference/gateway-rpc.md
@@ -1,21 +1,21 @@
-# Gateway RPC compatibility
+# Gateway RPC 兼容层
 
-This plugin exposes DingTalk Gateway RPC methods in two namespaces:
+本插件现在提供两组 DingTalk Gateway RPC 命名空间：
 
-- `dingtalk.*` is the canonical OpenClaw DingTalk plugin namespace.
-- `dingtalk-connector.*` is a compatibility namespace for existing connector-style callers.
+- `dingtalk.*`：本仓库的 canonical OpenClaw DingTalk 插件命名空间。
+- `dingtalk-connector.*`：仅面向已有 connector 风格调用方的兼容命名空间。
 
-The compatibility namespace is a thin adapter over this repository's existing DingTalk implementation. It does not vendor, depend on, or promise feature parity with any separate DingTalk connector project. New callers should prefer the canonical `dingtalk.*` methods when they do not need compatibility with an existing `dingtalk-connector.*` integration.
+`dingtalk-connector.*` 是本仓库现有 DingTalk 能力之上的薄适配层。它不 vendored、不依赖、也不承诺兼容任何独立的 DingTalk connector 项目。新调用方如果没有历史兼容需求，应优先使用 `dingtalk.*`。
 
-## Compatibility boundary
+## 兼容边界
 
-The `dingtalk-connector.*` methods keep the smallest stable surface needed by Gateway callers:
+`dingtalk-connector.*` 只保留 Gateway 调用方需要的最小稳定表面：
 
-- `dingtalk-connector.sendToUser` maps `userId` to `user:<userId>` and accepts `content` or `message`.
-- `dingtalk-connector.sendToGroup` maps `openConversationId` to `group:<openConversationId>` and accepts `content` or `message`.
-- `dingtalk-connector.send` accepts the canonical `target` string directly.
-- `dingtalk-connector.status` reports configured DingTalk accounts.
-- `dingtalk-connector.probe` validates account credentials by requesting an access token.
-- `dingtalk-connector.docs.*` aliases share the same handlers as `dingtalk.docs.*`.
+- `dingtalk-connector.sendToUser`：把 `userId` 映射为 `user:<userId>`，内容参数接受 `content` 或 `message`。
+- `dingtalk-connector.sendToGroup`：把 `openConversationId` 映射为 `group:<openConversationId>`，内容参数接受 `content` 或 `message`。
+- `dingtalk-connector.send`：直接接受 canonical `target` 字符串；当前只接受 `user:*` 或 `group:*`，避免在 RPC 边界透传无法识别的目标格式。
+- `dingtalk-connector.status`：返回已配置账号的配置状态；`clientId` 只返回脱敏尾号，不暴露完整凭证标识。
+- `dingtalk-connector.probe`：通过请求 access token 验证账号凭证；成功响应同样只返回脱敏后的 `clientId`。
+- `dingtalk-connector.docs.*`：与 `dingtalk.docs.*` 共享同一组 handler，只是兼容别名。
 
-The compatibility methods intentionally reuse the canonical auth, send, docs, usage-tracking, and outbound-context persistence paths. If a future compatibility request requires behavior that differs from `dingtalk.*`, document that difference here before expanding the adapter.
+这些兼容方法复用 canonical auth、send、docs、usage-tracking 和 outbound-context persistence 路径。后续如果某个兼容请求需要与 `dingtalk.*` 不同的行为，必须先在这里说明差异，再扩展适配层。

--- a/docs/user/reference/gateway-rpc.md
+++ b/docs/user/reference/gateway-rpc.md
@@ -1,0 +1,21 @@
+# Gateway RPC compatibility
+
+This plugin exposes DingTalk Gateway RPC methods in two namespaces:
+
+- `dingtalk.*` is the canonical OpenClaw DingTalk plugin namespace.
+- `dingtalk-connector.*` is a compatibility namespace for existing connector-style callers.
+
+The compatibility namespace is a thin adapter over this repository's existing DingTalk implementation. It does not vendor, depend on, or promise feature parity with any separate DingTalk connector project. New callers should prefer the canonical `dingtalk.*` methods when they do not need compatibility with an existing `dingtalk-connector.*` integration.
+
+## Compatibility boundary
+
+The `dingtalk-connector.*` methods keep the smallest stable surface needed by Gateway callers:
+
+- `dingtalk-connector.sendToUser` maps `userId` to `user:<userId>` and accepts `content` or `message`.
+- `dingtalk-connector.sendToGroup` maps `openConversationId` to `group:<openConversationId>` and accepts `content` or `message`.
+- `dingtalk-connector.send` accepts the canonical `target` string directly.
+- `dingtalk-connector.status` reports configured DingTalk accounts.
+- `dingtalk-connector.probe` validates account credentials by requesting an access token.
+- `dingtalk-connector.docs.*` aliases share the same handlers as `dingtalk.docs.*`.
+
+The compatibility methods intentionally reuse the canonical auth, send, docs, usage-tracking, and outbound-context persistence paths. If a future compatibility request requires behavior that differs from `dingtalk.*`, document that difference here before expanding the adapter.

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,16 @@ type GatewayMethodContext = Pick<
   "context" | "params" | "respond"
 >;
 
+/**
+ * Register the canonical OpenClaw DingTalk docs RPC namespace.
+ *
+ * The `dingtalk-connector.docs.*` names below are compatibility aliases for
+ * existing connector-style Gateway callers that already use the
+ * `dingtalk-connector` prefix. They intentionally share the same handlers as
+ * `dingtalk.docs.*`; this plugin does not vendor or mirror a separate
+ * third-party connector implementation. New OpenClaw callers should prefer the
+ * canonical `dingtalk.docs.*` namespace.
+ */
 function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
   const createHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
@@ -134,6 +144,16 @@ async function sendGatewayMessage(params: {
   );
 }
 
+/**
+ * Register compatibility Gateway RPCs for connector-style DingTalk callers.
+ *
+ * Compatibility target: callers that address DingTalk through the historical
+ * `dingtalk-connector.*` Gateway namespace. The maintenance boundary is only
+ * this thin parameter/response adapter; canonical plugin behavior, auth, docs,
+ * sending, and persistence remain implemented by this repository's existing
+ * `dingtalk.*` services. Do not add connector-only behavior here unless it is
+ * also documented as part of this compatibility surface.
+ */
 function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPluginApi): void {
   api.registerGatewayMethod(
     "dingtalk-connector.sendToUser",

--- a/index.ts
+++ b/index.ts
@@ -133,11 +133,7 @@ async function sendGatewayMessage(params: {
       ? {
           ok: true,
           target: params.target,
-          messageId:
-            result.messageId ??
-            result.tracking?.processQueryKey ??
-            result.tracking?.cardInstanceId ??
-            null,
+          messageId: result.messageId ?? null,
           tracking: result.tracking ?? null,
         }
       : { error: result.error || "send failed" },

--- a/index.ts
+++ b/index.ts
@@ -1,18 +1,26 @@
 import { defineChannelPluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { readStringParam } from "openclaw/plugin-sdk/param-readers";
+import { getAccessToken } from "./src/auth";
 import { dingtalkPlugin } from "./src/channel";
-import { getConfig } from "./src/config";
-import { appendToDoc, createDoc, DocCreateAppendError, listDocs, searchDocs } from "./src/docs-service";
+import { getConfig, listDingTalkAccountIds, resolveDingTalkAccount } from "./src/config";
+import {
+  appendToDoc,
+  createDoc,
+  DocCreateAppendError,
+  listDocs,
+  searchDocs,
+} from "./src/docs-service";
 import { accumulateUsage } from "./src/run-usage-store";
 import { setDingTalkRuntime } from "./src/runtime";
+import { sendMessage } from "./src/send-service";
 
 type GatewayMethodContext = Pick<
   Parameters<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>[0],
-  "params" | "respond"
+  "context" | "params" | "respond"
 >;
 
 function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
-  api.registerGatewayMethod("dingtalk.docs.create", async ({ respond, params }: GatewayMethodContext) => {
+  const createHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const spaceId = readStringParam(params, "spaceId", { required: true });
     const title = readStringParam(params, "title", { required: true });
@@ -41,34 +49,192 @@ function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
       }
       throw error;
     }
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.append", async ({ respond, params }: GatewayMethodContext) => {
+  const appendHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const docId = readStringParam(params, "docId", { required: true });
     const content = readStringParam(params, "content", { required: true, allowEmpty: false });
     const config = getConfig(api.config, accountId ?? undefined);
     const result = await appendToDoc(config, docId, content, api.logger);
     return respond(true, result);
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.search", async ({ respond, params }: GatewayMethodContext) => {
+  const searchHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const keyword = readStringParam(params, "keyword", { required: true });
     const spaceId = readStringParam(params, "spaceId");
     const config = getConfig(api.config, accountId ?? undefined);
     const docs = await searchDocs(config, keyword, spaceId, api.logger);
     return respond(true, { docs });
-  });
+  };
 
-  api.registerGatewayMethod("dingtalk.docs.list", async ({ respond, params }: GatewayMethodContext) => {
+  const listHandler = async ({ respond, params }: GatewayMethodContext) => {
     const accountId = readStringParam(params, "accountId");
     const spaceId = readStringParam(params, "spaceId", { required: true });
     const parentId = readStringParam(params, "parentId");
     const config = getConfig(api.config, accountId ?? undefined);
     const docs = await listDocs(config, spaceId, parentId, api.logger);
     return respond(true, { docs });
+  };
+
+  api.registerGatewayMethod("dingtalk.docs.create", createHandler);
+  api.registerGatewayMethod("dingtalk.docs.append", appendHandler);
+  api.registerGatewayMethod("dingtalk.docs.search", searchHandler);
+  api.registerGatewayMethod("dingtalk.docs.list", listHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.create", createHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.append", appendHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.search", searchHandler);
+  api.registerGatewayMethod("dingtalk-connector.docs.list", listHandler);
+}
+
+function getContentParam(params: Record<string, unknown>): string | undefined {
+  return readStringParam(params, "content") ?? readStringParam(params, "message");
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+async function sendGatewayMessage(params: {
+  api: OpenClawPluginApi;
+  respond: GatewayMethodContext["respond"];
+  accountId?: string;
+  target: string;
+  content: string;
+  storePath?: string;
+  useAICard?: unknown;
+}) {
+  const config = getConfig(params.api.config, params.accountId);
+  const accountId = params.accountId ?? "default";
+  if (!config.clientId || !config.clientSecret) {
+    return params.respond(false, { error: "DingTalk not configured" });
+  }
+  const result = await sendMessage(config, params.target, params.content, {
+    log: params.api.logger,
+    accountId,
+    conversationId: params.target,
+    storePath: params.storePath,
+    forceMarkdown: params.useAICard === false,
   });
+  return params.respond(
+    result.ok,
+    result.ok
+      ? {
+          ok: true,
+          target: params.target,
+          messageId:
+            result.messageId ??
+            result.tracking?.processQueryKey ??
+            result.tracking?.cardInstanceId ??
+            null,
+          tracking: result.tracking ?? null,
+        }
+      : { error: result.error || "send failed" },
+  );
+}
+
+function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPluginApi): void {
+  api.registerGatewayMethod(
+    "dingtalk-connector.sendToUser",
+    async ({ context, respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const userId = readStringParam(params, "userId", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target: `user:${userId}`,
+        content,
+        storePath: context?.cronStorePath,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.sendToGroup",
+    async ({ context, respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const openConversationId = readStringParam(params, "openConversationId", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target: `group:${openConversationId}`,
+        content,
+        storePath: context?.cronStorePath,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.send",
+    async ({ context, respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const target = readStringParam(params, "target", { required: true });
+      const content = getContentParam(params);
+      if (!content) {
+        return respond(false, { error: "content or message is required" });
+      }
+      return sendGatewayMessage({
+        api,
+        respond,
+        accountId: accountId ?? undefined,
+        target,
+        content,
+        storePath: context?.cronStorePath,
+        useAICard: params.useAICard,
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.status",
+    async ({ respond }: GatewayMethodContext) => {
+      const accountIds = listDingTalkAccountIds(api.config);
+      const accounts = accountIds.length > 0 ? accountIds : ["default"];
+      return respond(true, {
+        channel: "dingtalk",
+        accounts: accounts.map((accountId) => {
+          const account = resolveDingTalkAccount(api.config, accountId);
+          return {
+            accountId,
+            configured: account.configured,
+            enabled: account.enabled !== false,
+            name: account.name ?? null,
+            clientId: account.clientId || null,
+          };
+        }),
+      });
+    },
+  );
+
+  api.registerGatewayMethod(
+    "dingtalk-connector.probe",
+    async ({ respond, params }: GatewayMethodContext) => {
+      const accountId = readStringParam(params, "accountId");
+      const config = getConfig(api.config, accountId ?? undefined);
+      if (!config.clientId || !config.clientSecret) {
+        return respond(false, { error: "DingTalk not configured" });
+      }
+      try {
+        await getAccessToken(config, api.logger);
+        return respond(true, { ok: true, clientId: config.clientId });
+      } catch (error: unknown) {
+        return respond(false, { error: getErrorMessage(error, "probe failed") });
+      }
+    },
+  );
 }
 
 export { dingtalkPlugin } from "./src/channel";
@@ -82,11 +248,24 @@ export default defineChannelPluginEntry({
   setRuntime: setDingTalkRuntime,
   registerFull(api) {
     registerDingTalkDocsGatewayMethods(api);
+    registerDingTalkConnectorCompatibilityGatewayMethods(api);
 
-    api.on("llm_output", (event: { runId: string; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; total?: number } }) => {
-      if (event.usage) {
-        accumulateUsage(event.runId, event.usage);
-      }
-    });
+    api.on(
+      "llm_output",
+      (event: {
+        runId: string;
+        usage?: {
+          input?: number;
+          output?: number;
+          cacheRead?: number;
+          cacheWrite?: number;
+          total?: number;
+        };
+      }) => {
+        if (event.usage) {
+          accumulateUsage(event.runId, event.usage);
+        }
+      },
+    );
   },
 });

--- a/index.ts
+++ b/index.ts
@@ -106,6 +106,17 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
 
+function maskClientId(clientId: string | undefined): string | null {
+  if (!clientId) {
+    return null;
+  }
+  return clientId.length <= 4 ? "****" : `****${clientId.slice(-4)}`;
+}
+
+function isConnectorSendTarget(target: string): boolean {
+  return /^(user|group):\S+$/.test(target);
+}
+
 async function sendGatewayMessage(params: {
   api: OpenClawPluginApi;
   respond: GatewayMethodContext["respond"];
@@ -120,13 +131,20 @@ async function sendGatewayMessage(params: {
   if (!config.clientId || !config.clientSecret) {
     return params.respond(false, { error: "DingTalk not configured" });
   }
-  const result = await sendMessage(config, params.target, params.content, {
-    log: params.api.logger,
-    accountId,
-    conversationId: params.target,
-    storePath: params.storePath,
-    forceMarkdown: params.useAICard === false,
-  });
+  let result: Awaited<ReturnType<typeof sendMessage>>;
+  try {
+    result = await sendMessage(config, params.target, params.content, {
+      log: params.api.logger,
+      accountId,
+      conversationId: params.target,
+      storePath: params.storePath,
+      forceMarkdown: params.useAICard === false,
+    });
+  } catch (error: unknown) {
+    const message = getErrorMessage(error, "send failed");
+    params.api.logger?.warn?.(`[DingTalk][GatewayRPC] send failed: ${message}`);
+    return params.respond(false, { error: message });
+  }
   return params.respond(
     result.ok,
     result.ok
@@ -202,6 +220,9 @@ function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPlugi
       if (!content) {
         return respond(false, { error: "content or message is required" });
       }
+      if (!isConnectorSendTarget(target)) {
+        return respond(false, { error: "target must start with user: or group:" });
+      }
       return sendGatewayMessage({
         api,
         respond,
@@ -228,7 +249,7 @@ function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPlugi
             configured: account.configured,
             enabled: account.enabled !== false,
             name: account.name ?? null,
-            clientId: account.clientId || null,
+            clientId: maskClientId(account.clientId),
           };
         }),
       });
@@ -245,9 +266,11 @@ function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPlugi
       }
       try {
         await getAccessToken(config, api.logger);
-        return respond(true, { ok: true, clientId: config.clientId });
+        return respond(true, { ok: true, clientId: maskClientId(config.clientId) });
       } catch (error: unknown) {
-        return respond(false, { error: getErrorMessage(error, "probe failed") });
+        const message = getErrorMessage(error, "probe failed");
+        api.logger?.warn?.(`[DingTalk][GatewayRPC] probe failed: ${message}`);
+        return respond(false, { error: message });
       }
     },
   );

--- a/tests/unit/runtime-peer-index.test.ts
+++ b/tests/unit/runtime-peer-index.test.ts
@@ -1,267 +1,489 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const shared = vi.hoisted(() => ({
-    createDocMock: vi.fn(),
-    appendToDocMock: vi.fn(),
-    searchDocsMock: vi.fn(),
-    listDocsMock: vi.fn(),
-    defineChannelPluginEntryMock: vi.fn(
-        (entry: {
-            id: string;
-            name: string;
-            description: string;
-            plugin: unknown;
-            setRuntime?: (runtime: unknown) => void;
-            registerFull?: (api: unknown) => void;
-        }) => ({
-            id: entry.id,
-            name: entry.name,
-            description: entry.description,
-            register(api: {
-                runtime: unknown;
-                registerChannel: (registration: { plugin: unknown }) => void;
-                registrationMode?: string;
-                on?: (...args: unknown[]) => void;
-            }) {
-                entry.setRuntime?.(api.runtime);
-                api.registerChannel({ plugin: entry.plugin });
-                if (api.registrationMode === "full") {
-                    entry.registerFull?.(api);
-                }
-            },
-        }),
-    ),
-    readStringParamMock: vi.fn(
-        (
-            params: Record<string, unknown>,
-            key: string,
-            opts?: { required?: boolean; allowEmpty?: boolean; trim?: boolean },
-        ) => {
-            const value = params?.[key];
-            if (typeof value !== "string") {
-                if (opts?.required) {
-                    throw new Error(`${key} is required`);
-                }
-                return undefined;
-            }
-            const normalized = opts?.trim === false ? value : value.trim();
-            if (!opts?.allowEmpty && opts?.required && normalized.length === 0) {
-                throw new Error(`${key} is required`);
-            }
-            if (!opts?.allowEmpty && normalized.length === 0) {
-                return undefined;
-            }
-            return normalized;
-        },
-    ),
-    DocCreateAppendErrorMock: class extends Error {
-        doc: unknown;
-
-        constructor(doc: unknown) {
-            super("initial content append failed after document creation");
-            this.name = "DocCreateAppendError";
-            this.doc = doc;
+  createDocMock: vi.fn(),
+  appendToDocMock: vi.fn(),
+  searchDocsMock: vi.fn(),
+  listDocsMock: vi.fn(),
+  sendMessageMock: vi.fn(),
+  getAccessTokenMock: vi.fn(),
+  defineChannelPluginEntryMock: vi.fn(
+    (entry: {
+      id: string;
+      name: string;
+      description: string;
+      plugin: unknown;
+      setRuntime?: (runtime: unknown) => void;
+      registerFull?: (api: unknown) => void;
+    }) => ({
+      id: entry.id,
+      name: entry.name,
+      description: entry.description,
+      register(api: {
+        runtime: unknown;
+        registerChannel: (registration: { plugin: unknown }) => void;
+        registrationMode?: string;
+        on?: (...args: unknown[]) => void;
+      }) {
+        entry.setRuntime?.(api.runtime);
+        api.registerChannel({ plugin: entry.plugin });
+        if (api.registrationMode === "full") {
+          entry.registerFull?.(api);
         }
+      },
+    }),
+  ),
+  readStringParamMock: vi.fn(
+    (
+      params: Record<string, unknown>,
+      key: string,
+      opts?: { required?: boolean; allowEmpty?: boolean; trim?: boolean },
+    ) => {
+      const value = params?.[key];
+      if (typeof value !== "string") {
+        if (opts?.required) {
+          throw new Error(`${key} is required`);
+        }
+        return undefined;
+      }
+      const normalized = opts?.trim === false ? value : value.trim();
+      if (!opts?.allowEmpty && opts?.required && normalized.length === 0) {
+        throw new Error(`${key} is required`);
+      }
+      if (!opts?.allowEmpty && normalized.length === 0) {
+        return undefined;
+      }
+      return normalized;
     },
+  ),
+  DocCreateAppendErrorMock: class extends Error {
+    doc: unknown;
+
+    constructor(doc: unknown) {
+      super("initial content append failed after document creation");
+      this.name = "DocCreateAppendError";
+      this.doc = doc;
+    }
+  },
 }));
 
 vi.mock("openclaw/plugin-sdk/core", () => ({
-    defineChannelPluginEntry: shared.defineChannelPluginEntryMock,
-    emptyPluginConfigSchema: vi.fn(() => ({ schema: {} })),
+  defineChannelPluginEntry: shared.defineChannelPluginEntryMock,
+  emptyPluginConfigSchema: vi.fn(() => ({ schema: {} })),
 }));
 
 vi.mock("openclaw/plugin-sdk/param-readers", () => ({
-    readStringParam: shared.readStringParamMock,
+  readStringParam: shared.readStringParamMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
-    createPluginRuntimeStore: vi.fn((errorMessage: string) => {
-        let runtime: unknown;
-        return {
-            setRuntime(next: unknown) {
-                runtime = next;
-            },
-            getRuntime() {
-                if (!runtime) {
-                    throw new Error(errorMessage);
-                }
-                return runtime;
-            },
-        };
-    }),
+  createPluginRuntimeStore: vi.fn((errorMessage: string) => {
+    let runtime: unknown;
+    return {
+      setRuntime(next: unknown) {
+        runtime = next;
+      },
+      getRuntime() {
+        if (!runtime) {
+          throw new Error(errorMessage);
+        }
+        return runtime;
+      },
+    };
+  }),
 }));
 
 vi.mock("openclaw/plugin-sdk/tool-send", () => ({
-    extractToolSend: vi.fn((args: Record<string, unknown>) => {
-        const to = typeof args.to === "string" ? args.to.trim() : "";
-        return to ? { to } : null;
-    }),
+  extractToolSend: vi.fn((args: Record<string, unknown>) => {
+    const to = typeof args.to === "string" ? args.to.trim() : "";
+    return to ? { to } : null;
+  }),
 }));
 
 vi.mock("../../src/channel", () => ({
-    dingtalkPlugin: { id: "dingtalk", meta: { label: "DingTalk" } },
+  dingtalkPlugin: { id: "dingtalk", meta: { label: "DingTalk" } },
 }));
 
 vi.mock("../../src/docs-service", () => ({
-    createDoc: shared.createDocMock,
-    appendToDoc: shared.appendToDocMock,
-    searchDocs: shared.searchDocsMock,
-    listDocs: shared.listDocsMock,
-    DocCreateAppendError: shared.DocCreateAppendErrorMock,
+  createDoc: shared.createDocMock,
+  appendToDoc: shared.appendToDocMock,
+  searchDocs: shared.searchDocsMock,
+  listDocs: shared.listDocsMock,
+  DocCreateAppendError: shared.DocCreateAppendErrorMock,
+}));
+
+vi.mock("../../src/send-service", () => ({
+  sendMessage: shared.sendMessageMock,
+}));
+
+vi.mock("../../src/auth", () => ({
+  getAccessToken: shared.getAccessTokenMock,
 }));
 
 describe("runtime + peer registry + index plugin", () => {
-    beforeEach(async () => {
-        vi.resetModules();
-        shared.createDocMock.mockReset();
-        shared.appendToDocMock.mockReset();
-        shared.searchDocsMock.mockReset();
-        shared.listDocsMock.mockReset();
-        shared.defineChannelPluginEntryMock.mockClear();
-        shared.readStringParamMock.mockClear();
-        shared.createDocMock.mockResolvedValue({ docId: "doc_1", title: "测试文档", docType: "alidoc" });
-        shared.appendToDocMock.mockResolvedValue({ success: true });
-        shared.searchDocsMock.mockResolvedValue([{ docId: "doc_2", title: "周报", docType: "alidoc" }]);
-        shared.listDocsMock.mockResolvedValue([{ docId: "doc_3", title: "知识库", docType: "folder" }]);
-        const peer = await import("../../src/peer-id-registry");
-        peer.clearPeerIdRegistry();
+  beforeEach(async () => {
+    vi.resetModules();
+    shared.createDocMock.mockReset();
+    shared.appendToDocMock.mockReset();
+    shared.searchDocsMock.mockReset();
+    shared.listDocsMock.mockReset();
+    shared.sendMessageMock.mockReset();
+    shared.getAccessTokenMock.mockReset();
+    shared.defineChannelPluginEntryMock.mockClear();
+    shared.readStringParamMock.mockClear();
+    shared.createDocMock.mockResolvedValue({
+      docId: "doc_1",
+      title: "测试文档",
+      docType: "alidoc",
+    });
+    shared.appendToDocMock.mockResolvedValue({ success: true });
+    shared.searchDocsMock.mockResolvedValue([{ docId: "doc_2", title: "周报", docType: "alidoc" }]);
+    shared.listDocsMock.mockResolvedValue([{ docId: "doc_3", title: "知识库", docType: "folder" }]);
+    shared.sendMessageMock.mockResolvedValue({ ok: true, messageId: "msg_1" });
+    shared.getAccessTokenMock.mockResolvedValue("token_abc");
+    const peer = await import("../../src/peer-id-registry");
+    peer.clearPeerIdRegistry();
+  });
+
+  it("runtime getter throws before initialization and returns assigned runtime later", async () => {
+    const runtime = await import("../../src/runtime");
+
+    expect(() => runtime.getDingTalkRuntime()).toThrow("DingTalk runtime not initialized");
+
+    const rt = { channel: {} } as any;
+    runtime.setDingTalkRuntime(rt);
+
+    expect(runtime.getDingTalkRuntime()).toBe(rt);
+  });
+
+  it("peer id registry preserves original case by lowercased key", async () => {
+    const peer = await import("../../src/peer-id-registry");
+
+    peer.registerPeerId("CidAbC+123");
+
+    expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("CidAbC+123");
+    expect(peer.resolveOriginalPeerId("unknown")).toBe("unknown");
+
+    peer.clearPeerIdRegistry();
+    expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("cidabc+123");
+  });
+
+  it("index plugin defines a channel entry and only registers gateway methods in full mode", async () => {
+    const runtimeModule = await import("../../src/runtime");
+    const runtimeSpy = vi.spyOn(runtimeModule, "setDingTalkRuntime");
+
+    const plugin = (await import("../../index")).default;
+
+    const registerChannel = vi.fn();
+    const registerGatewayMethod = vi.fn();
+    const runtime = { id: "runtime1" } as any;
+
+    await plugin.register({
+      runtime,
+      registrationMode: "full",
+      registerChannel,
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
+
+    expect(shared.defineChannelPluginEntryMock).toHaveBeenCalledTimes(1);
+    expect(runtimeSpy).toHaveBeenCalledWith(runtime);
+    expect(registerChannel).toHaveBeenCalledTimes(1);
+    expect(registerGatewayMethod).toHaveBeenCalledTimes(13);
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk.docs.create",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk.docs.append",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk.docs.search",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.list", expect.any(Function));
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.docs.create",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.docs.append",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.docs.search",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.docs.list",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.sendToUser",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.sendToGroup",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.send",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.status",
+      expect.any(Function),
+    );
+    expect(registerGatewayMethod).toHaveBeenCalledWith(
+      "dingtalk-connector.probe",
+      expect.any(Function),
+    );
+  });
+
+  it("skips docs gateway registration outside full registration mode", async () => {
+    const plugin = (await import("../../index")).default;
+    const registerGatewayMethod = vi.fn();
+
+    await plugin.register({
+      runtime: {},
+      registrationMode: "setup",
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
+
+    expect(registerGatewayMethod).not.toHaveBeenCalled();
+  });
+
+  it("registered docs gateway methods validate params and respond with docs payload", async () => {
+    const plugin = (await import("../../index")).default;
+    const registerGatewayMethod = vi.fn();
+
+    await plugin.register({
+      runtime: {},
+      registrationMode: "full",
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
+
+    const createHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk.docs.create",
+    )?.[1];
+    const searchHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk.docs.search",
+    )?.[1];
+
+    const respondCreate = vi.fn();
+    await createHandler?.({
+      respond: respondCreate,
+      params: { spaceId: "space_1", title: "测试文档", content: "第一段" },
+    });
+    expect(shared.readStringParamMock).toHaveBeenCalled();
+    expect(respondCreate).toHaveBeenCalledWith(true, {
+      docId: "doc_1",
+      title: "测试文档",
+      docType: "alidoc",
     });
 
-    it("runtime getter throws before initialization and returns assigned runtime later", async () => {
-        const runtime = await import("../../src/runtime");
+    const respondSearch = vi.fn();
+    await searchHandler?.({
+      respond: respondSearch,
+      params: { keyword: "周报" },
+    });
+    expect(respondSearch).toHaveBeenCalledWith(true, {
+      docs: [{ docId: "doc_2", title: "周报", docType: "alidoc" }],
+    });
+  });
 
-        expect(() => runtime.getDingTalkRuntime()).toThrow("DingTalk runtime not initialized");
+  it("registered connector compatibility gateway methods send to explicit user and group targets", async () => {
+    const plugin = (await import("../../index")).default;
+    const registerGatewayMethod = vi.fn();
+    const context = { cronStorePath: "/tmp/openclaw-cron-store.json" };
 
-        const rt = { channel: {} } as any;
-        runtime.setDingTalkRuntime(rt);
+    await plugin.register({
+      runtime: {},
+      registrationMode: "full",
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
 
-        expect(runtime.getDingTalkRuntime()).toBe(rt);
+    const sendToUserHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk-connector.sendToUser",
+    )?.[1];
+    const sendToGroupHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk-connector.sendToGroup",
+    )?.[1];
+
+    const respondUser = vi.fn();
+    await sendToUserHandler?.({
+      context,
+      respond: respondUser,
+      params: { userId: "staff_1", content: "hello" },
+    });
+    expect(shared.sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: "id", clientSecret: "sec" }),
+      "user:staff_1",
+      "hello",
+      expect.objectContaining({
+        accountId: "default",
+        conversationId: "user:staff_1",
+        storePath: "/tmp/openclaw-cron-store.json",
+      }),
+    );
+    expect(respondUser).toHaveBeenCalledWith(true, expect.objectContaining({ messageId: "msg_1" }));
+
+    const respondGroup = vi.fn();
+    await sendToGroupHandler?.({
+      context,
+      respond: respondGroup,
+      params: { openConversationId: "cid_1", message: "hi group", useAICard: false },
+    });
+    expect(shared.sendMessageMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ clientId: "id", clientSecret: "sec" }),
+      "group:cid_1",
+      "hi group",
+      expect.objectContaining({ forceMarkdown: true }),
+    );
+    expect(respondGroup).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ target: "group:cid_1" }),
+    );
+  });
+
+  it("registered connector send/status/probe methods handle fallback content and account status", async () => {
+    const plugin = (await import("../../index")).default;
+    const registerGatewayMethod = vi.fn();
+
+    await plugin.register({
+      runtime: {},
+      registrationMode: "full",
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: {
+        channels: {
+          dingtalk: {
+            clientId: "default-id",
+            clientSecret: "default-sec",
+            accounts: {
+              team: { clientId: "team-id", clientSecret: "team-sec", name: "Team" },
+            },
+          },
+        },
+      },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
+
+    const sendHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk-connector.send",
+    )?.[1];
+    const statusHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk-connector.status",
+    )?.[1];
+    const probeHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk-connector.probe",
+    )?.[1];
+
+    const respondSend = vi.fn();
+    await sendHandler?.({
+      context: { cronStorePath: "/tmp/rpc-store.json" },
+      respond: respondSend,
+      params: {
+        accountId: "team",
+        target: "user:staff_2",
+        content: "",
+        message: "fallback message",
+      },
+    });
+    expect(shared.sendMessageMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ clientId: "team-id", clientSecret: "team-sec" }),
+      "user:staff_2",
+      "fallback message",
+      expect.objectContaining({
+        accountId: "team",
+        conversationId: "user:staff_2",
+        storePath: "/tmp/rpc-store.json",
+      }),
+    );
+    expect(respondSend).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ target: "user:staff_2" }),
+    );
+
+    const respondStatus = vi.fn();
+    await statusHandler?.({ respond: respondStatus, params: {} });
+    expect(respondStatus).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        channel: "dingtalk",
+        accounts: expect.arrayContaining([
+          expect.objectContaining({
+            accountId: "default",
+            configured: true,
+            clientId: "default-id",
+          }),
+          expect.objectContaining({ accountId: "team", configured: true, clientId: "team-id" }),
+        ]),
+      }),
+    );
+
+    const respondProbe = vi.fn();
+    await probeHandler?.({ respond: respondProbe, params: { accountId: "team" } });
+    expect(shared.getAccessTokenMock).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: "team-id", clientSecret: "team-sec" }),
+      expect.any(Object),
+    );
+    expect(respondProbe).toHaveBeenCalledWith(true, { ok: true, clientId: "team-id" });
+  });
+
+  it("returns partial-success metadata when initial doc append fails after creation", async () => {
+    const plugin = (await import("../../index")).default;
+    const registerGatewayMethod = vi.fn();
+
+    await plugin.register({
+      runtime: {},
+      registrationMode: "full",
+      registerChannel: vi.fn(),
+      registerGatewayMethod,
+      on: vi.fn(),
+      config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } as any);
+
+    const createHandler = registerGatewayMethod.mock.calls.find(
+      (call: any[]) => call[0] === "dingtalk.docs.create",
+    )?.[1];
+    const respondCreate = vi.fn();
+    shared.createDocMock.mockRejectedValueOnce(
+      new shared.DocCreateAppendErrorMock({
+        docId: "doc_partial",
+        title: "测试文档",
+        docType: "alidoc",
+      }),
+    );
+
+    await createHandler?.({
+      respond: respondCreate,
+      params: { spaceId: "space_1", title: "测试文档", content: "第一段" },
     });
 
-    it("peer id registry preserves original case by lowercased key", async () => {
-        const peer = await import("../../src/peer-id-registry");
-
-        peer.registerPeerId("CidAbC+123");
-
-        expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("CidAbC+123");
-        expect(peer.resolveOriginalPeerId("unknown")).toBe("unknown");
-
-        peer.clearPeerIdRegistry();
-        expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("cidabc+123");
+    expect(respondCreate).toHaveBeenCalledWith(true, {
+      partialSuccess: true,
+      initContentAppended: false,
+      docId: "doc_partial",
+      doc: { docId: "doc_partial", title: "测试文档", docType: "alidoc" },
+      appendError: "initial content append failed after document creation",
     });
-
-    it("index plugin defines a channel entry and only registers docs methods in full mode", async () => {
-        const runtimeModule = await import("../../src/runtime");
-        const runtimeSpy = vi.spyOn(runtimeModule, "setDingTalkRuntime");
-
-        const plugin = (await import("../../index")).default;
-
-        const registerChannel = vi.fn();
-        const registerGatewayMethod = vi.fn();
-        const runtime = { id: "runtime1" } as any;
-
-        await plugin.register({
-            runtime,
-            registrationMode: "full",
-            registerChannel,
-            registerGatewayMethod,
-            on: vi.fn(),
-            config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
-            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        } as any);
-
-        expect(shared.defineChannelPluginEntryMock).toHaveBeenCalledTimes(1);
-        expect(runtimeSpy).toHaveBeenCalledWith(runtime);
-        expect(registerChannel).toHaveBeenCalledTimes(1);
-        expect(registerGatewayMethod).toHaveBeenCalledTimes(4);
-        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.create", expect.any(Function));
-        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.append", expect.any(Function));
-        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.search", expect.any(Function));
-        expect(registerGatewayMethod).toHaveBeenCalledWith("dingtalk.docs.list", expect.any(Function));
-    });
-
-    it("skips docs gateway registration outside full registration mode", async () => {
-        const plugin = (await import("../../index")).default;
-        const registerGatewayMethod = vi.fn();
-
-        await plugin.register({
-            runtime: {},
-            registrationMode: "setup",
-            registerChannel: vi.fn(),
-            registerGatewayMethod,
-            config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
-            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        } as any);
-
-        expect(registerGatewayMethod).not.toHaveBeenCalled();
-    });
-
-    it("registered docs gateway methods validate params and respond with docs payload", async () => {
-        const plugin = (await import("../../index")).default;
-        const registerGatewayMethod = vi.fn();
-
-        await plugin.register({
-            runtime: {},
-            registrationMode: "full",
-            registerChannel: vi.fn(),
-            registerGatewayMethod,
-            on: vi.fn(),
-            config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
-            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        } as any);
-
-        const createHandler = registerGatewayMethod.mock.calls.find((call: any[]) => call[0] === "dingtalk.docs.create")?.[1];
-        const searchHandler = registerGatewayMethod.mock.calls.find((call: any[]) => call[0] === "dingtalk.docs.search")?.[1];
-
-        const respondCreate = vi.fn();
-        await createHandler?.({
-            respond: respondCreate,
-            params: { spaceId: "space_1", title: "测试文档", content: "第一段" },
-        });
-        expect(shared.readStringParamMock).toHaveBeenCalled();
-        expect(respondCreate).toHaveBeenCalledWith(true, { docId: "doc_1", title: "测试文档", docType: "alidoc" });
-
-        const respondSearch = vi.fn();
-        await searchHandler?.({
-            respond: respondSearch,
-            params: { keyword: "周报" },
-        });
-        expect(respondSearch).toHaveBeenCalledWith(true, {
-            docs: [{ docId: "doc_2", title: "周报", docType: "alidoc" }],
-        });
-    });
-
-    it("returns partial-success metadata when initial doc append fails after creation", async () => {
-        const plugin = (await import("../../index")).default;
-        const registerGatewayMethod = vi.fn();
-
-        await plugin.register({
-            runtime: {},
-            registrationMode: "full",
-            registerChannel: vi.fn(),
-            registerGatewayMethod,
-            on: vi.fn(),
-            config: { channels: { dingtalk: { clientId: "id", clientSecret: "sec" } } },
-            logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        } as any);
-
-        const createHandler = registerGatewayMethod.mock.calls.find((call: any[]) => call[0] === "dingtalk.docs.create")?.[1];
-        const respondCreate = vi.fn();
-        shared.createDocMock.mockRejectedValueOnce(
-            new shared.DocCreateAppendErrorMock({ docId: "doc_partial", title: "测试文档", docType: "alidoc" }),
-        );
-
-        await createHandler?.({
-            respond: respondCreate,
-            params: { spaceId: "space_1", title: "测试文档", content: "第一段" },
-        });
-
-        expect(respondCreate).toHaveBeenCalledWith(true, {
-            partialSuccess: true,
-            initContentAppended: false,
-            docId: "doc_partial",
-            doc: { docId: "doc_partial", title: "测试文档", docType: "alidoc" },
-            appendError: "initial content append failed after document creation",
-        });
-    });
+  });
 });

--- a/tests/unit/runtime-peer-index.test.ts
+++ b/tests/unit/runtime-peer-index.test.ts
@@ -395,6 +395,11 @@ describe("runtime + peer registry + index plugin", () => {
       (call: any[]) => call[0] === "dingtalk-connector.probe",
     )?.[1];
 
+    shared.sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      tracking: { processQueryKey: "process_1", cardInstanceId: "card_1" },
+    });
+
     const respondSend = vi.fn();
     await sendHandler?.({
       context: { cronStorePath: "/tmp/rpc-store.json" },
@@ -418,7 +423,11 @@ describe("runtime + peer registry + index plugin", () => {
     );
     expect(respondSend).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ target: "user:staff_2" }),
+      expect.objectContaining({
+        target: "user:staff_2",
+        messageId: null,
+        tracking: { processQueryKey: "process_1", cardInstanceId: "card_1" },
+      }),
     );
 
     const respondStatus = vi.fn();

--- a/tests/unit/runtime-peer-index.test.ts
+++ b/tests/unit/runtime-peer-index.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 const shared = vi.hoisted(() => ({
   createDocMock: vi.fn(),
   appendToDocMock: vi.fn(),
@@ -58,7 +57,6 @@ const shared = vi.hoisted(() => ({
   ),
   DocCreateAppendErrorMock: class extends Error {
     doc: unknown;
-
     constructor(doc: unknown) {
       super("initial content append failed after document creation");
       this.name = "DocCreateAppendError";
@@ -66,16 +64,13 @@ const shared = vi.hoisted(() => ({
     }
   },
 }));
-
 vi.mock("openclaw/plugin-sdk/core", () => ({
   defineChannelPluginEntry: shared.defineChannelPluginEntryMock,
   emptyPluginConfigSchema: vi.fn(() => ({ schema: {} })),
 }));
-
 vi.mock("openclaw/plugin-sdk/param-readers", () => ({
   readStringParam: shared.readStringParamMock,
 }));
-
 vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
   createPluginRuntimeStore: vi.fn((errorMessage: string) => {
     let runtime: unknown;
@@ -92,18 +87,15 @@ vi.mock("openclaw/plugin-sdk/runtime-store", () => ({
     };
   }),
 }));
-
 vi.mock("openclaw/plugin-sdk/tool-send", () => ({
   extractToolSend: vi.fn((args: Record<string, unknown>) => {
     const to = typeof args.to === "string" ? args.to.trim() : "";
     return to ? { to } : null;
   }),
 }));
-
 vi.mock("../../src/channel", () => ({
   dingtalkPlugin: { id: "dingtalk", meta: { label: "DingTalk" } },
 }));
-
 vi.mock("../../src/docs-service", () => ({
   createDoc: shared.createDocMock,
   appendToDoc: shared.appendToDocMock,
@@ -111,15 +103,12 @@ vi.mock("../../src/docs-service", () => ({
   listDocs: shared.listDocsMock,
   DocCreateAppendError: shared.DocCreateAppendErrorMock,
 }));
-
 vi.mock("../../src/send-service", () => ({
   sendMessage: shared.sendMessageMock,
 }));
-
 vi.mock("../../src/auth", () => ({
   getAccessToken: shared.getAccessTokenMock,
 }));
-
 describe("runtime + peer registry + index plugin", () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -144,26 +133,19 @@ describe("runtime + peer registry + index plugin", () => {
     const peer = await import("../../src/peer-id-registry");
     peer.clearPeerIdRegistry();
   });
-
   it("runtime getter throws before initialization and returns assigned runtime later", async () => {
     const runtime = await import("../../src/runtime");
-
     expect(() => runtime.getDingTalkRuntime()).toThrow("DingTalk runtime not initialized");
-
     const rt = { channel: {} } as any;
     runtime.setDingTalkRuntime(rt);
-
     expect(runtime.getDingTalkRuntime()).toBe(rt);
   });
 
   it("peer id registry preserves original case by lowercased key", async () => {
     const peer = await import("../../src/peer-id-registry");
-
     peer.registerPeerId("CidAbC+123");
-
     expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("CidAbC+123");
     expect(peer.resolveOriginalPeerId("unknown")).toBe("unknown");
-
     peer.clearPeerIdRegistry();
     expect(peer.resolveOriginalPeerId("cidabc+123")).toBe("cidabc+123");
   });
@@ -171,13 +153,10 @@ describe("runtime + peer registry + index plugin", () => {
   it("index plugin defines a channel entry and only registers gateway methods in full mode", async () => {
     const runtimeModule = await import("../../src/runtime");
     const runtimeSpy = vi.spyOn(runtimeModule, "setDingTalkRuntime");
-
     const plugin = (await import("../../index")).default;
-
     const registerChannel = vi.fn();
     const registerGatewayMethod = vi.fn();
     const runtime = { id: "runtime1" } as any;
-
     await plugin.register({
       runtime,
       registrationMode: "full",
@@ -364,6 +343,7 @@ describe("runtime + peer registry + index plugin", () => {
   it("registered connector send/status/probe methods handle fallback content and account status", async () => {
     const plugin = (await import("../../index")).default;
     const registerGatewayMethod = vi.fn();
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
     await plugin.register({
       runtime: {},
@@ -382,7 +362,7 @@ describe("runtime + peer registry + index plugin", () => {
           },
         },
       },
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logger,
     } as any);
 
     const sendHandler = registerGatewayMethod.mock.calls.find(
@@ -430,6 +410,24 @@ describe("runtime + peer registry + index plugin", () => {
       }),
     );
 
+    shared.sendMessageMock.mockRejectedValueOnce(new Error("send exploded"));
+    const respondSendError = vi.fn();
+    await sendHandler?.({
+      respond: respondSendError,
+      params: { target: "user:staff_3", content: "hi" },
+    });
+    expect(respondSendError).toHaveBeenCalledWith(false, { error: "send exploded" });
+    expect(logger.warn).toHaveBeenCalledWith("[DingTalk][GatewayRPC] send failed: send exploded");
+
+    const respondInvalidTarget = vi.fn();
+    await sendHandler?.({
+      respond: respondInvalidTarget,
+      params: { target: "staff_3", content: "hi" },
+    });
+    expect(respondInvalidTarget).toHaveBeenCalledWith(false, {
+      error: "target must start with user: or group:",
+    });
+
     const respondStatus = vi.fn();
     await statusHandler?.({ respond: respondStatus, params: {} });
     expect(respondStatus).toHaveBeenCalledWith(
@@ -440,9 +438,9 @@ describe("runtime + peer registry + index plugin", () => {
           expect.objectContaining({
             accountId: "default",
             configured: true,
-            clientId: "default-id",
+            clientId: "****t-id",
           }),
-          expect.objectContaining({ accountId: "team", configured: true, clientId: "team-id" }),
+          expect.objectContaining({ accountId: "team", configured: true, clientId: "****m-id" }),
         ]),
       }),
     );
@@ -453,7 +451,7 @@ describe("runtime + peer registry + index plugin", () => {
       expect.objectContaining({ clientId: "team-id", clientSecret: "team-sec" }),
       expect.any(Object),
     );
-    expect(respondProbe).toHaveBeenCalledWith(true, { ok: true, clientId: "team-id" });
+    expect(respondProbe).toHaveBeenCalledWith(true, { ok: true, clientId: "****m-id" });
   });
 
   it("returns partial-success metadata when initial doc append fails after creation", async () => {


### PR DESCRIPTION
## 背景

这个 PR 从已关闭的组合 PR #526 中拆出，只保留 DingTalk Gateway RPC 兼容层，避免把 SecretInput 支持和 RPC 兼容两个独立主题混在一起审查。

当前仓库的 canonical DingTalk Gateway RPC 命名空间是 `dingtalk.*`。`dingtalk-connector.*` 不是新的独立 connector 实现，也不表示本插件 vendored、依赖或承诺兼容另一个 DingTalk connector 项目；它只是为了已有 OpenClaw Gateway 调用方中使用过的 connector 风格方法名提供薄适配。

## 目标

- 保持 `dingtalk.*` 作为本插件的 canonical OpenClaw DingTalk Gateway RPC 命名空间。
- 为已有 connector 风格调用方提供最小兼容表面：`sendToUser`、`sendToGroup`、`send`、`status`、`probe` 和 `docs.*` alias。
- 明确兼容边界：兼容层复用本仓库已有 auth、send、docs、usage tracking 和 outbound context persistence 路径，不扩展一套独立 DingTalk connector API。
- 在 RPC 边界收紧不明确行为，避免把内部 tracking key 当作 `messageId`，避免暴露完整 `clientId`，并让 send/probe 失败可诊断。

## 实现

- 新增 `dingtalk-connector.*` Gateway RPC 注册，底层复用现有 DingTalk send/docs/auth 服务。
- `dingtalk-connector.send` 只接受 `user:*` 或 `group:*` target，避免透传无法识别的目标格式。
- `messageId` 严格来自 `sendMessage` 的真实 `messageId`；`processQueryKey` / `cardInstanceId` 只保留在独立 `tracking` 字段。
- `status` / `probe` 返回脱敏后的 `clientId`，不再暴露完整凭证标识。
- `sendMessage` 抛错和 `probe` 失败会通过 Gateway RPC 返回结构化错误，并写入 logger warn，方便排查。
- `docs/user/reference/gateway-rpc.md` 用中文说明 canonical namespace、兼容 namespace、各方法语义和维护边界。

## 实现 TODO

- 暂无。后续如果需要增加与 `dingtalk.*` 不同的 compatibility 行为，应先更新 `docs/user/reference/gateway-rpc.md` 说明差异，再扩展适配层。

## 验证 TODO

本地已验证：

- `pnpm exec oxfmt --check index.ts tests/unit/runtime-peer-index.test.ts docs/user/reference/gateway-rpc.md`
- `pnpm test tests/unit/runtime-peer-index.test.ts`
- `pnpm type-check`
- `git diff --check`

远端 CI：等待 GitHub `test` check 对最新 head 重新跑完。
