### PR TITLE
feat: support SecretInput for DingTalk clientSecret

### DIFF
--- a/docs/user/features/multi-agent-bindings.md
+++ b/docs/user/features/multi-agent-bindings.md
@@ -37,8 +37,22 @@
   "channels": {
     "dingtalk": {
       "accounts": {
-        "bot_1": { "clientId": "..." },
-        "bot_2": { "clientId": "..." }
+        "bot_1": {
+          "clientId": "ding-bot-1",
+          "clientSecret": {
+            "source": "env",
+            "provider": "env",
+            "id": "DINGTALK_BOT_1_SECRET"
+          }
+        },
+        "bot_2": {
+          "clientId": "ding-bot-2",
+          "clientSecret": {
+            "source": "env",
+            "provider": "env",
+            "id": "DINGTALK_BOT_2_SECRET"
+          }
+        }
       }
     }
   }

--- a/docs/user/getting-started/configure.md
+++ b/docs/user/getting-started/configure.md
@@ -49,6 +49,61 @@ openclaw configure --section channels
 }
 ```
 
+如果不想把 `Client Secret` 直接写入配置文件，可以把 `clientSecret` 写成 SecretInput 引用。插件仍然兼容普通字符串；引用只在运行时需要真实密钥时解析。
+
+环境变量示例：
+
+```json5
+{
+  "channels": {
+    "dingtalk": {
+      "clientId": "dingxxxxxx",
+      "clientSecret": {
+        "source": "env",
+        "provider": "env",
+        "id": "DINGTALK_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+本地文件示例：
+
+```json5
+{
+  "channels": {
+    "dingtalk": {
+      "clientId": "dingxxxxxx",
+      "clientSecret": {
+        "source": "file",
+        "provider": "local",
+        "id": "~/.config/openclaw/dingtalk-client-secret"
+      }
+    }
+  }
+}
+```
+
+外部 helper 示例：
+
+```json5
+{
+  "channels": {
+    "dingtalk": {
+      "clientId": "dingxxxxxx",
+      "clientSecret": {
+        "source": "exec",
+        "provider": "secret-helper",
+        "id": "dingtalk/client-secret"
+      }
+    }
+  }
+}
+```
+
+`exec` 会执行 `provider` 指定的二进制，并把 `id` 作为唯一参数传入；`file` 会读取 `id` 指定的本地路径。二者都应只用于受信任的本机配置。修改 SecretInput 指向的文件或 helper 输出后，建议重启 gateway，让 Stream 连接使用新的凭据。
+
 卡片模式示例：
 
 ```json5

--- a/docs/user/getting-started/permissions.md
+++ b/docs/user/getting-started/permissions.md
@@ -60,7 +60,7 @@ message=auth level of org is not enough
 从开发者后台获取：
 
 - `Client ID`（与开放平台 AppKey 一致；插件将其同时用作钉钉 API 请求中的 `robotCode`）
-- `Client Secret`
+- `Client Secret`（可直接写入配置，也可在配置中用 SecretInput 引用环境变量、文件或外部 helper）
 
 ## 6. 配置联动
 

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -8,7 +8,7 @@
 | --- | --- | --- | --- |
 | `enabled` | boolean | `true` | 是否启用插件 |
 | `clientId` | string | 必填 | 钉钉 AppKey；同时作为钉钉 API 请求中的 `robotCode` |
-| `clientSecret` | string | 必填 | 钉钉 AppSecret |
+| `clientSecret` | string \| SecretInput | 必填 | 钉钉 AppSecret；可直接填写字符串，也可引用环境变量、文件或外部 helper |
 | `dmPolicy` | string | `open` | 私聊策略 |
 | `groupPolicy` | string | `open` | 群聊策略 |
 | `allowFrom` | string[] | `[]` | 私聊白名单 |
@@ -41,6 +41,61 @@
 ## 关于 `clientId` 与钉钉 `robotCode`
 
 钉钉开放接口的请求体里仍会携带 `robotCode` 字段。本插件不提供单独的 `robotCode`、`corpId` 或钉钉应用 `agentId` 配置项：`clientId` 会作为机器人代码用于相关 API 调用。
+
+## 关于 `clientSecret` 与 SecretInput
+
+`clientSecret` 可以继续使用普通字符串：
+
+```json5
+{
+  "clientId": "dingxxxxxx",
+  "clientSecret": "your-app-secret"
+}
+```
+
+也可以使用 SecretInput 引用：
+
+```json5
+{
+  "clientId": "dingxxxxxx",
+  "clientSecret": {
+    "source": "env",
+    "provider": "env",
+    "id": "DINGTALK_CLIENT_SECRET"
+  }
+}
+```
+
+SecretInput 对象字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `source` | 密钥来源：`env`、`file` 或 `exec` |
+| `provider` | 来源提供者。`env` 通常写 `env`；`file` 可写 `local`；`exec` 写要执行的二进制或命令路径 |
+| `id` | 密钥标识。`env` 为环境变量名；`file` 为本地文件路径；`exec` 为传给 helper 的唯一参数 |
+
+语法限制：
+
+- `provider` 不能为空，最长 `1024` 字符，不能包含 `:` 或 `>`
+- `id` 不能为空，最长 `1024` 字符，不能包含 `>`
+- `file` 的 `id` 支持 `~` 与相对路径解析
+- `exec` 会读取 helper 的 stdout，并去掉首尾空白；helper 超时时间为 `5s`
+
+解析时机：
+
+- 获取 DingTalk access token 时，如果 token 缓存未命中，会解析 `clientSecret`
+- 启动 Stream 连接时，会为每个账号解析一次运行时凭据
+- 状态展示、配置向导展示等路径只显示规范化引用，不会读取文件或执行 helper
+- `env` 引用会在配置态检查时确认环境变量是否存在；`file` / `exec` 为避免副作用，只在运行时解析
+
+安全边界：
+
+- `file` 会读取配置中指定的本地路径
+- `exec` 会执行配置中指定的二进制，并把 `id` 作为唯一参数传入
+- `execFile` 不经过 shell 插值，但仍然会执行选中的程序
+- 仅在受信任的插件配置环境中使用 `file` / `exec`
+
+如果 SecretInput 解析失败，插件会在发起 DingTalk API 请求前抛出本地错误，并在日志中带上 `source` / `provider` / `id` / 失败原因，方便定位配置问题。
 
 ## 关于 `displayNameResolution`
 

--- a/docs/user/troubleshooting/connection.en.md
+++ b/docs/user/troubleshooting/connection.en.md
@@ -60,6 +60,8 @@ For a multi-account setup:
 pwsh -File scripts/dingtalk-connection-check.ps1 -Config ~/.openclaw/openclaw.json -AccountId main
 ```
 
+If `clientSecret` is configured as a SecretInput reference, the connection check scripts do not read secret files or execute helper commands on behalf of the plugin. Resolve the real secret in your current shell and pass it explicitly with `--client-id` / `--client-secret` or `-ClientId` / `-ClientSecret`. The plugin runtime still resolves SecretInput values from the configured source.
+
 ## Credential Resolution Rules
 
 Both scripts follow the same order:

--- a/docs/user/troubleshooting/connection.md
+++ b/docs/user/troubleshooting/connection.md
@@ -16,6 +16,8 @@ Windows PowerShell：
 pwsh -File scripts/dingtalk-connection-check.ps1 -Config ~/.openclaw/openclaw.json
 ```
 
+如果配置中的 `clientSecret` 使用 SecretInput 引用，连接检查脚本不会代替插件读取文件或执行 helper。排查连接时请先在当前 shell 中解析出真实 secret，再用 `--client-id` / `--client-secret` 或 `-ClientId` / `-ClientSecret` 显式传入；插件运行时仍会按配置中的 SecretInput 规则自行解析。
+
 ## 关键后台检查项
 
 - 应用是企业内部应用

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -44,8 +44,18 @@
                 "required": ["source", "provider", "id"],
                 "properties": {
                   "source": { "type": "string", "enum": ["env", "file", "exec"] },
-                  "provider": { "type": "string", "minLength": 1, "maxLength": 1024 },
-                  "id": { "type": "string", "minLength": 1, "maxLength": 1024 }
+                  "provider": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1024,
+                    "pattern": "^[^:>]+$"
+                  },
+                  "id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1024,
+                    "pattern": "^[^>]+$"
+                  }
                 }
               }
             ],
@@ -340,8 +350,18 @@
                       "required": ["source", "provider", "id"],
                       "properties": {
                         "source": { "type": "string", "enum": ["env", "file", "exec"] },
-                        "provider": { "type": "string", "minLength": 1, "maxLength": 1024 },
-                        "id": { "type": "string", "minLength": 1, "maxLength": 1024 }
+                        "provider": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 1024,
+                          "pattern": "^[^:>]+$"
+                        },
+                        "id": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 1024,
+                          "pattern": "^[^>]+$"
+                        }
                       }
                     }
                   ],

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -36,8 +36,20 @@
             "description": "DingTalk App Key (Client ID) used to authenticate API and Stream connections."
           },
           "clientSecret": {
-            "type": "string",
-            "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens."
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["source", "provider", "id"],
+                "properties": {
+                  "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                  "provider": { "type": "string", "minLength": 1, "maxLength": 1024 },
+                  "id": { "type": "string", "minLength": 1, "maxLength": 1024 }
+                }
+              }
+            ],
+            "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. Supports SecretInput references such as env/file/exec. Security boundary: file reads the configured local path, and exec runs the configured provider binary with id as its only argument; use file/exec only with trusted plugin configuration."
           },
           "dmPolicy": {
             "type": "string",
@@ -257,7 +269,14 @@
             "type": "object",
             "description": "Status line visibility toggles for the AI card footer.",
             "additionalProperties": false,
-            "default": { "model": true, "effort": true, "agent": true, "taskTime": false, "tokens": false, "dapiUsage": false },
+            "default": {
+              "model": true,
+              "effort": true,
+              "agent": true,
+              "taskTime": false,
+              "tokens": false,
+              "dapiUsage": false
+            },
             "properties": {
               "model": {
                 "type": "boolean",
@@ -320,8 +339,20 @@
                   "description": "DingTalk App Key (Client ID) used to authenticate API and Stream connections."
                 },
                 "clientSecret": {
-                  "type": "string",
-                  "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens."
+                  "anyOf": [
+                    { "type": "string" },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["source", "provider", "id"],
+                      "properties": {
+                        "source": { "type": "string", "enum": ["env", "file", "exec"] },
+                        "provider": { "type": "string", "minLength": 1, "maxLength": 1024 },
+                        "id": { "type": "string", "minLength": 1, "maxLength": 1024 }
+                      }
+                    }
+                  ],
+                  "description": "DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. Supports SecretInput references such as env/file/exec. Security boundary: file reads the configured local path, and exec runs the configured provider binary with id as its only argument; use file/exec only with trusted plugin configuration."
                 },
                 "dmPolicy": {
                   "type": "string",
@@ -541,7 +572,14 @@
                   "type": "object",
                   "description": "Status line visibility toggles for the AI card footer.",
                   "additionalProperties": false,
-                  "default": { "model": true, "effort": true, "agent": true, "taskTime": false, "tokens": false, "dapiUsage": false },
+                  "default": {
+                    "model": true,
+                    "effort": true,
+                    "agent": true,
+                    "taskTime": false,
+                    "tokens": false,
+                    "dapiUsage": false
+                  },
                   "properties": {
                     "model": {
                       "type": "boolean",
@@ -607,7 +645,7 @@
         },
         "clientSecret": {
           "label": "DingTalk Client Secret",
-          "help": "App Secret used to obtain DingTalk access tokens.",
+          "help": "App Secret used to obtain DingTalk access tokens. SecretInput file/exec references are for trusted plugin configuration because file reads a local path and exec runs the configured provider binary.",
           "sensitive": true
         },
         "dmPolicy": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -269,14 +269,7 @@
             "type": "object",
             "description": "Status line visibility toggles for the AI card footer.",
             "additionalProperties": false,
-            "default": {
-              "model": true,
-              "effort": true,
-              "agent": true,
-              "taskTime": false,
-              "tokens": false,
-              "dapiUsage": false
-            },
+            "default": { "model": true, "effort": true, "agent": true, "taskTime": false, "tokens": false, "dapiUsage": false },
             "properties": {
               "model": {
                 "type": "boolean",
@@ -572,14 +565,7 @@
                   "type": "object",
                   "description": "Status line visibility toggles for the AI card footer.",
                   "additionalProperties": false,
-                  "default": {
-                    "model": true,
-                    "effort": true,
-                    "agent": true,
-                    "taskTime": false,
-                    "tokens": false,
-                    "dapiUsage": false
-                  },
+                  "default": { "model": true, "effort": true, "agent": true, "taskTime": false, "tokens": false, "dapiUsage": false },
                   "properties": {
                     "model": {
                       "type": "boolean",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import { resolveRuntimeConfig } from "./config";
 import axios from "./http-client";
 import type { DingTalkConfig, Logger, TokenInfo } from "./types";
 import { retryWithBackoff } from "./utils";
@@ -23,13 +24,15 @@ export async function getAccessToken(config: DingTalkConfig, log?: Logger): Prom
     return cached.accessToken;
   }
 
+  const runtimeConfig = await resolveRuntimeConfig(config, log);
+
   const token = await retryWithBackoff(
     async () => {
       const response = await axios.post<TokenInfo>(
         "https://api.dingtalk.com/v1.0/oauth2/accessToken",
         {
-          appKey: config.clientId,
-          appSecret: config.clientSecret,
+          appKey: runtimeConfig.clientId,
+          appSecret: runtimeConfig.clientSecret,
         },
       );
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,10 +5,11 @@ import {
   CHANNEL_INFLIGHT_NAMESPACE_POLICY,
   createDingTalkGateway,
 } from "./gateway/channel-gateway";
-import { dingtalkSetupAdapter, dingtalkSetupWizard } from "./onboarding.js";
 import { createDingTalkMessageActions } from "./messaging/channel-actions";
 import { createDingTalkOutbound } from "./messaging/channel-outbound";
+import { dingtalkSetupAdapter, dingtalkSetupWizard } from "./onboarding.js";
 import { createDingTalkStatus } from "./platform/channel-status";
+import { hasConfiguredSecretInput } from "./secret-input";
 import {
   listDingTalkDirectoryGroups,
   listDingTalkDirectoryUsers,
@@ -54,7 +55,9 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       const id = accountId || "default";
       const account = config.accounts?.[id];
       const resolvedConfig = account ? mergeAccountWithDefaults(config, account) : config;
-      const configured = Boolean(resolvedConfig.clientId && resolvedConfig.clientSecret);
+      const configured = Boolean(
+        resolvedConfig.clientId && hasConfiguredSecretInput(resolvedConfig.clientSecret),
+      );
       return {
         accountId: id,
         config: resolvedConfig,
@@ -65,7 +68,7 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
     },
     defaultAccountId: (): string => "default",
     isConfigured: (account: ResolvedAccount): boolean =>
-      Boolean(account.config?.clientId && account.config?.clientSecret),
+      Boolean(account.config?.clientId && hasConfiguredSecretInput(account.config?.clientSecret)),
     describeAccount: (account: ResolvedAccount) => ({
       accountId: account.accountId,
       name: account.config?.name || "DingTalk",
@@ -128,9 +131,4 @@ export { getAccessToken } from "./auth";
 export { createAICard, finishAICard, streamAICard } from "./card-service";
 export { detectMediaTypeFromExtension } from "./media-utils";
 export { getLogger } from "./logger-context";
-export {
-  sendBySession,
-  sendMessage,
-  sendProactiveMedia,
-  uploadMedia,
-} from "./send-service";
+export { sendBySession, sendMessage, sendProactiveMedia, uploadMedia } from "./send-service";

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -5,9 +5,9 @@ import {
   CHANNEL_INFLIGHT_NAMESPACE_POLICY,
   createDingTalkGateway,
 } from "./gateway/channel-gateway";
+import { dingtalkSetupAdapter, dingtalkSetupWizard } from "./onboarding.js";
 import { createDingTalkMessageActions } from "./messaging/channel-actions";
 import { createDingTalkOutbound } from "./messaging/channel-outbound";
-import { dingtalkSetupAdapter, dingtalkSetupWizard } from "./onboarding.js";
 import { createDingTalkStatus } from "./platform/channel-status";
 import { hasConfiguredSecretInput } from "./secret-input";
 import {
@@ -131,4 +131,9 @@ export { getAccessToken } from "./auth";
 export { createAICard, finishAICard, streamAICard } from "./card-service";
 export { detectMediaTypeFromExtension } from "./media-utils";
 export { getLogger } from "./logger-context";
-export { sendBySession, sendMessage, sendProactiveMedia, uploadMedia } from "./send-service";
+export {
+  sendBySession,
+  sendMessage,
+  sendProactiveMedia,
+  uploadMedia,
+} from "./send-service";

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { DEFAULT_MESSAGE_CONTEXT_TTL_DAYS } from "./message-context-store";
+import { buildSecretInputSchema } from "./secret-input";
 
 const AckReactionSchema = z.union([
   z.literal(""),
@@ -29,7 +30,7 @@ const DingTalkAccountConfigShape = {
   clientId: z.string().optional(),
 
   /** DingTalk App Secret (Client Secret) used to obtain DingTalk access tokens. */
-  clientSecret: z.string().optional(),
+  clientSecret: buildSecretInputSchema().optional(),
 
   /** Direct-message access policy: open, pairing, or allowlist. */
   dmPolicy: z.enum(["open", "pairing", "allowlist"]).optional().default("open"),
@@ -120,7 +121,13 @@ const DingTalkAccountConfigShape = {
       /** Show the proactive-send permission hint when the runtime detects missing DingTalk proactive permission. */
       enabled: z.boolean().optional().default(true),
       /** Minimum cooldown in hours before the same proactive permission hint can be shown again. */
-      cooldownHours: z.number().int().min(1).max(24 * 30).optional().default(24),
+      cooldownHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(24 * 30)
+        .optional()
+        .default(24),
     })
     .optional()
     .default({ enabled: true, cooldownHours: 24 }),
@@ -138,7 +145,12 @@ const DingTalkAccountConfigShape = {
   cardStreamInterval: z.number().int().min(200).optional().default(1000),
 
   /** Cooldown window in milliseconds after AI card trigger errors. Replies fall back to non-card delivery during this period. */
-  aicardDegradeMs: z.number().int().min(60_000).optional().default(30 * 60 * 1000),
+  aicardDegradeMs: z
+    .number()
+    .int()
+    .min(60_000)
+    .optional()
+    .default(30 * 60 * 1000),
 
   /** Enable the local feedback-learning loop for notes, reflections, and command-assisted learning. */
   learningEnabled: z.boolean().optional(),
@@ -174,7 +186,14 @@ const DingTalkAccountConfigShape = {
       dapiUsage: z.boolean().optional().default(false),
     })
     .optional()
-    .default({ model: true, effort: true, agent: true, taskTime: false, tokens: false, dapiUsage: false }),
+    .default({
+      model: true,
+      effort: true,
+      agent: true,
+      taskTime: false,
+      tokens: false,
+      dapiUsage: false,
+    }),
 } as const;
 
 const DingTalkAccountConfigSchema = z.object(DingTalkAccountConfigShape);

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -121,13 +121,7 @@ const DingTalkAccountConfigShape = {
       /** Show the proactive-send permission hint when the runtime detects missing DingTalk proactive permission. */
       enabled: z.boolean().optional().default(true),
       /** Minimum cooldown in hours before the same proactive permission hint can be shown again. */
-      cooldownHours: z
-        .number()
-        .int()
-        .min(1)
-        .max(24 * 30)
-        .optional()
-        .default(24),
+      cooldownHours: z.number().int().min(1).max(24 * 30).optional().default(24),
     })
     .optional()
     .default({ enabled: true, cooldownHours: 24 }),
@@ -145,12 +139,7 @@ const DingTalkAccountConfigShape = {
   cardStreamInterval: z.number().int().min(200).optional().default(1000),
 
   /** Cooldown window in milliseconds after AI card trigger errors. Replies fall back to non-card delivery during this period. */
-  aicardDegradeMs: z
-    .number()
-    .int()
-    .min(60_000)
-    .optional()
-    .default(30 * 60 * 1000),
+  aicardDegradeMs: z.number().int().min(60_000).optional().default(30 * 60 * 1000),
 
   /** Enable the local feedback-learning loop for notes, reflections, and command-assisted learning. */
   learningEnabled: z.boolean().optional(),
@@ -186,14 +175,7 @@ const DingTalkAccountConfigShape = {
       dapiUsage: z.boolean().optional().default(false),
     })
     .optional()
-    .default({
-      model: true,
-      effort: true,
-      agent: true,
-      taskTime: false,
-      tokens: false,
-      dapiUsage: false,
-    }),
+    .default({ model: true, effort: true, agent: true, taskTime: false, tokens: false, dapiUsage: false }),
 } as const;
 
 const DingTalkAccountConfigSchema = z.object(DingTalkAccountConfigShape);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,17 +1,14 @@
-import * as os from "node:os";
-import * as path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import {
+  formatSecretInputResolutionFailure,
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+  resolveDingTalkSecretConfig,
+} from "./secret-input";
 import type { DingTalkChannelConfig, DingTalkConfig } from "./types";
-
-const WINDOWS_ROOT_DIRECTORIES = new Set([
-  "Users",
-  "Program Files",
-  "Program Files (x86)",
-  "ProgramData",
-  "Windows",
-  "Documents and Settings",
-]);
+export { resolveRelativePath, resolveUserPath } from "./path-utils";
 const DEFAULT_LEARNING_NOTE_TTL_MS = 6 * 60 * 60 * 1000;
+export type RuntimeDingTalkConfig = Omit<DingTalkConfig, "clientSecret"> & { clientSecret: string };
 
 function normalizeLearningConfig(
   config: DingTalkConfig,
@@ -19,12 +16,14 @@ function normalizeLearningConfig(
 ): DingTalkConfig {
   return {
     ...config,
-    learningEnabled: options.applyDefaults ? config.learningEnabled ?? false : config.learningEnabled,
+    learningEnabled: options.applyDefaults
+      ? (config.learningEnabled ?? false)
+      : config.learningEnabled,
     learningAutoApply: options.applyDefaults
-      ? config.learningAutoApply ?? false
+      ? (config.learningAutoApply ?? false)
       : config.learningAutoApply,
     learningNoteTtlMs: options.applyDefaults
-      ? config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS
+      ? (config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS)
       : config.learningNoteTtlMs,
     cardStreamingMode: options.applyDefaults
       ? (config.cardStreamingMode ?? (config.cardRealTimeStream === true ? "all" : "off"))
@@ -65,8 +64,10 @@ export function mergeAccountWithDefaults(
   channelCfg: DingTalkConfig,
   accountCfg: DingTalkConfig,
 ): DingTalkConfig {
-  const { accounts: _accounts, ...defaultCandidate } =
-    channelCfg as DingTalkConfig & { accounts?: unknown; verboseRealtimeStream?: unknown };
+  const { accounts: _accounts, ...defaultCandidate } = channelCfg as DingTalkConfig & {
+    accounts?: unknown;
+    verboseRealtimeStream?: unknown;
+  };
   const defaults = stripRemovedLegacyFields(defaultCandidate as DingTalkConfig);
   const normalizedAccountCfg = stripRemovedLegacyFields(
     normalizeLearningConfig(accountCfg, { applyDefaults: false }),
@@ -114,64 +115,25 @@ export function getConfig(cfg: OpenClawConfig, accountId?: string): DingTalkConf
 
 export function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {
   const config = getConfig(cfg, accountId);
-  return Boolean(config.clientId && config.clientSecret);
+  return Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret));
 }
 
-/**
- * Resolve relative paths against a base directory, with intelligent platform-specific handling.
- *
- * Supports:
- * - ~ and ~/ expansion to home directory
- * - Absolute paths (Unix: /path, Windows: \path or C:\path)
- * - Relative paths resolved against cwd
- * - Windows absolute paths without drive letters (e.g., Users\name\.openclaw\file.txt)
- * - Mixed path separators (/ and \)
- *
- * @param input - The path string to resolve
- * @returns The resolved absolute path
- */
-export function resolveRelativePath(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return trimmed;
+export async function resolveRuntimeConfig(
+  config: DingTalkConfig,
+  log?: { warn?: (message: string, data?: unknown) => void },
+): Promise<RuntimeDingTalkConfig> {
+  const resolved = await resolveDingTalkSecretConfig(config, log);
+  if (!resolved.clientId || !resolved.clientSecret) {
+    const secretFailure = resolved.clientSecretResolutionFailure
+      ? `: clientSecret resolution failed for ${formatSecretInputResolutionFailure(resolved.clientSecretResolutionFailure)}`
+      : "";
+    throw new Error(`DingTalk clientId and resolved clientSecret are required${secretFailure}`);
   }
-
-  const segments = (value: string): string[] => value.split(/[\\/]+/).filter(Boolean);
-  const pathSegments = segments(trimmed);
-  const firstSegment = pathSegments[0];
-
-  // Expand bare "~" and "~/" or "~\\" prefixes into the user home directory.
-  if (trimmed === "~") {
-    return path.resolve(os.homedir());
-  }
-  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
-    return path.resolve(os.homedir(), ...segments(trimmed.slice(2)));
-  }
-
-  if (process.platform === "win32") {
-    // On Windows, OpenClaw may drop the leading "\" from root-based paths like
-    // "Users\name\.openclaw\workspace\file.xlsx". Only recover paths that start
-    // with well-known root directories to avoid misclassifying ordinary relative paths.
-    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) {
-      return path.win32.normalize(trimmed);
-    }
-    if (firstSegment && /^[a-zA-Z]:$/.test(firstSegment)) {
-      return path.win32.resolve(`${firstSegment}\\`, ...pathSegments.slice(1));
-    }
-    if (firstSegment && WINDOWS_ROOT_DIRECTORIES.has(firstSegment)) {
-      return path.win32.resolve("\\", ...pathSegments);
-    }
-  }
-  // Treat both "/" and "\\" as absolute root prefixes for cross-platform input.
-  if (/^[\\/]/.test(trimmed)) {
-    return path.resolve(path.sep, ...pathSegments);
-  }
-
-  // Resolve relative path against cwd; supports mixed separators and "..\\..".
-  return path.resolve(process.cwd(), ...pathSegments);
+  return {
+    ...resolved,
+    clientSecret: resolved.clientSecret,
+  };
 }
-
-export const resolveUserPath = resolveRelativePath;
 
 /**
  * Resolve the robot code used by DingTalk APIs.
@@ -197,7 +159,10 @@ function hasOwn(obj: unknown, key: string): boolean {
   return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function resolveAgentIdentityEmoji(cfg: OpenClawConfig, agentId?: string | null): string | undefined {
+function resolveAgentIdentityEmoji(
+  cfg: OpenClawConfig,
+  agentId?: string | null,
+): string | undefined {
   const targetAgentId = String(agentId || "").trim();
   if (!targetAgentId) {
     return undefined;
@@ -276,7 +241,6 @@ export function stripTargetPrefix(target: string): { targetId: string; isExplici
 // ============ Onboarding Helper Functions ============
 
 const DEFAULT_ACCOUNT_ID = "default";
-
 
 /**
  * List all DingTalk account IDs from config
@@ -363,21 +327,20 @@ export function resolveDingTalkAccount(
     return {
       ...config,
       accountId: id,
-      configured: Boolean(config.clientId && config.clientSecret),
+      configured: Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret)),
+      clientSecret: normalizeSecretInputString(config.clientSecret) || "",
     };
   }
 
   const accountConfig = dingtalk?.accounts?.[id];
   if (accountConfig) {
-    const merged = mergeAccountWithDefaults(
-      dingtalk as DingTalkConfig,
-      accountConfig,
-    );
+    const merged = mergeAccountWithDefaults(dingtalk as DingTalkConfig, accountConfig);
     const publicMerged = stripRemovedLegacyFields(merged);
     return {
       ...publicMerged,
       accountId: id,
-      configured: Boolean(merged.clientId && merged.clientSecret),
+      configured: Boolean(merged.clientId && hasConfiguredSecretInput(merged.clientSecret)),
+      clientSecret: normalizeSecretInputString(merged.clientSecret) || "",
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import {
   formatSecretInputResolutionFailure,
   hasConfiguredSecretInput,
-  normalizeSecretInputString,
   resolveDingTalkSecretConfig,
 } from "./secret-input";
 import type { DingTalkChannelConfig, DingTalkConfig } from "./types";
@@ -16,14 +15,12 @@ function normalizeLearningConfig(
 ): DingTalkConfig {
   return {
     ...config,
-    learningEnabled: options.applyDefaults
-      ? (config.learningEnabled ?? false)
-      : config.learningEnabled,
+    learningEnabled: options.applyDefaults ? config.learningEnabled ?? false : config.learningEnabled,
     learningAutoApply: options.applyDefaults
-      ? (config.learningAutoApply ?? false)
+      ? config.learningAutoApply ?? false
       : config.learningAutoApply,
     learningNoteTtlMs: options.applyDefaults
-      ? (config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS)
+      ? config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS
       : config.learningNoteTtlMs,
     cardStreamingMode: options.applyDefaults
       ? (config.cardStreamingMode ?? (config.cardRealTimeStream === true ? "all" : "off"))
@@ -64,10 +61,8 @@ export function mergeAccountWithDefaults(
   channelCfg: DingTalkConfig,
   accountCfg: DingTalkConfig,
 ): DingTalkConfig {
-  const { accounts: _accounts, ...defaultCandidate } = channelCfg as DingTalkConfig & {
-    accounts?: unknown;
-    verboseRealtimeStream?: unknown;
-  };
+  const { accounts: _accounts, ...defaultCandidate } =
+    channelCfg as DingTalkConfig & { accounts?: unknown; verboseRealtimeStream?: unknown };
   const defaults = stripRemovedLegacyFields(defaultCandidate as DingTalkConfig);
   const normalizedAccountCfg = stripRemovedLegacyFields(
     normalizeLearningConfig(accountCfg, { applyDefaults: false }),
@@ -159,10 +154,7 @@ function hasOwn(obj: unknown, key: string): boolean {
   return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function resolveAgentIdentityEmoji(
-  cfg: OpenClawConfig,
-  agentId?: string | null,
-): string | undefined {
+function resolveAgentIdentityEmoji(cfg: OpenClawConfig, agentId?: string | null): string | undefined {
   const targetAgentId = String(agentId || "").trim();
   if (!targetAgentId) {
     return undefined;
@@ -241,6 +233,7 @@ export function stripTargetPrefix(target: string): { targetId: string; isExplici
 // ============ Onboarding Helper Functions ============
 
 const DEFAULT_ACCOUNT_ID = "default";
+
 
 /**
  * List all DingTalk account IDs from config
@@ -328,19 +321,20 @@ export function resolveDingTalkAccount(
       ...config,
       accountId: id,
       configured: Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret)),
-      clientSecret: normalizeSecretInputString(config.clientSecret) || "",
     };
   }
 
   const accountConfig = dingtalk?.accounts?.[id];
   if (accountConfig) {
-    const merged = mergeAccountWithDefaults(dingtalk as DingTalkConfig, accountConfig);
+    const merged = mergeAccountWithDefaults(
+      dingtalk as DingTalkConfig,
+      accountConfig,
+    );
     const publicMerged = stripRemovedLegacyFields(merged);
     return {
       ...publicMerged,
       accountId: id,
       configured: Boolean(merged.clientId && hasConfiguredSecretInput(merged.clientSecret)),
-      clientSecret: normalizeSecretInputString(merged.clientSecret) || "",
     };
   }
 

--- a/src/gateway/channel-gateway.ts
+++ b/src/gateway/channel-gateway.ts
@@ -1,7 +1,10 @@
 import { DWClient, TOPIC_CARD, TOPIC_ROBOT } from "dingtalk-stream";
 import { analyzeCardCallback } from "../card-callback-service";
-import { finalizeActiveCardsForAccount, recoverPendingCardsForAccount } from "../card-service";
 import { handleCardAction } from "../card/card-action-handler";
+import {
+  finalizeActiveCardsForAccount,
+  recoverPendingCardsForAccount,
+} from "../card-service";
 import { resolveRobotCode, resolveRuntimeConfig } from "../config";
 import { ConnectionManager } from "../connection-manager";
 import { isMessageProcessed, markMessageProcessed } from "../dedup";
@@ -170,6 +173,9 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
         debug: config.debug,
         baseLog: ctx.log,
       });
+      // Stream credentials are resolved once per account start. If a file/exec
+      // SecretInput rotates, restart the gateway/account so reconnects use the
+      // new secret.
       const runtimeConfig = await resolveRuntimeConfig(config, pluginLog);
       setCurrentLogger(pluginLog, account.accountId);
 
@@ -494,9 +500,7 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               lastStartAt: getCurrentTimestamp(),
               lastError: null,
             });
-            pluginLog?.info?.(
-              `[${account.accountId}] DingTalk Stream client connected successfully`,
-            );
+            pluginLog?.info?.(`[${account.accountId}] DingTalk Stream client connected successfully`);
             await nativeStopPromise;
           }
         } catch (err: any) {

--- a/src/gateway/channel-gateway.ts
+++ b/src/gateway/channel-gateway.ts
@@ -1,11 +1,8 @@
 import { DWClient, TOPIC_CARD, TOPIC_ROBOT } from "dingtalk-stream";
 import { analyzeCardCallback } from "../card-callback-service";
+import { finalizeActiveCardsForAccount, recoverPendingCardsForAccount } from "../card-service";
 import { handleCardAction } from "../card/card-action-handler";
-import {
-  finalizeActiveCardsForAccount,
-  recoverPendingCardsForAccount,
-} from "../card-service";
-import { resolveRobotCode } from "../config";
+import { resolveRobotCode, resolveRuntimeConfig } from "../config";
 import { ConnectionManager } from "../connection-manager";
 import { isMessageProcessed, markMessageProcessed } from "../dedup";
 import {
@@ -157,9 +154,6 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
     startAccount: async (ctx: GatewayStartContext): Promise<GatewayStopResult> => {
       const { account, cfg, abortSignal } = ctx;
       const config = account.config;
-      if (!config.clientId || !config.clientSecret) {
-        throw new Error("DingTalk clientId and clientSecret are required");
-      }
       let accountStorePath: string | undefined;
       try {
         const runtime = getDingTalkRuntime();
@@ -176,6 +170,7 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
         debug: config.debug,
         baseLog: ctx.log,
       });
+      const runtimeConfig = await resolveRuntimeConfig(config, pluginLog);
       setCurrentLogger(pluginLog, account.accountId);
 
       pluginLog?.info?.(`[${account.accountId}] Initializing DingTalk Stream client...`);
@@ -212,10 +207,10 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
 
       const createStreamClient: StreamClientFactory = () => {
         const client = new DWClient({
-          clientId: config.clientId,
-          clientSecret: config.clientSecret,
-          debug: config.debug || false,
-          keepAlive: config.keepAlive ?? !useConnectionManager,
+          clientId: runtimeConfig.clientId,
+          clientSecret: runtimeConfig.clientSecret,
+          debug: runtimeConfig.debug || false,
+          keepAlive: runtimeConfig.keepAlive ?? !useConnectionManager,
         });
         (client as any).sslopts = {
           ...(client as any).sslopts,
@@ -499,7 +494,9 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               lastStartAt: getCurrentTimestamp(),
               lastError: null,
             });
-            pluginLog?.info?.(`[${account.accountId}] DingTalk Stream client connected successfully`);
+            pluginLog?.info?.(
+              `[${account.accountId}] DingTalk Stream client connected successfully`,
+            );
             await nativeStopPromise;
           }
         } catch (err: any) {

--- a/src/messaging/channel-actions.ts
+++ b/src/messaging/channel-actions.ts
@@ -6,6 +6,7 @@ import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { getConfig, stripTargetPrefix } from "../config";
 import { getLogger } from "../logger-context";
 import { resolveOriginalPeerId } from "../peer-id-registry";
+import { hasConfiguredSecretInput } from "../secret-input";
 import { sendMedia, sendMessage } from "../send-service";
 import { parseBooleanLike } from "../utils";
 
@@ -50,7 +51,7 @@ function inferCardOwnerIdFromTarget(target: string): string | undefined {
 
 function describeDingTalkMessageTool(cfg: OpenClawConfig) {
   const config = getConfig(cfg);
-  const configured = Boolean(config.clientId && config.clientSecret);
+  const configured = Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret));
   if (!configured && !(config.accounts && Object.keys(config.accounts).length > 0)) {
     return { actions: [], capabilities: [], schema: null };
   }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -12,12 +12,17 @@ import {
   openUrlInBrowser,
   RegistrationError,
 } from "./device-registration.js";
+import {
+  hasConfiguredSecretInput,
+  normalizeSecretInputString,
+  parseSecretInputString,
+} from "./secret-input.js";
 import type { DingTalkConfig, DingTalkChannelConfig } from "./types.js";
 
 const channel = "dingtalk" as const;
 
 function isConfigured(account: DingTalkConfig): boolean {
-  return Boolean(account.clientId && account.clientSecret);
+  return Boolean(account.clientId && hasConfiguredSecretInput(account.clientSecret));
 }
 
 function applyAccountNameToChannelSection(params: {
@@ -354,7 +359,9 @@ function applyGenericSetupInput(params: {
       name: params.input.name,
       clientId: typeof params.input.token === "string" ? params.input.token.trim() : undefined,
       clientSecret:
-        typeof params.input.password === "string" ? params.input.password.trim() : undefined,
+        typeof params.input.password === "string"
+          ? parseSecretInputString(params.input.password)
+          : undefined,
     },
   });
 }
@@ -368,7 +375,9 @@ async function configureDingTalkAccount(params: {
   const resolved = resolveDingTalkAccount(cfg, accountId);
 
   // ── Credential acquisition: auto-register or manual ────────────────────
-  const hasExistingCredentials = Boolean(resolved.clientId && resolved.clientSecret);
+  const hasExistingCredentials = Boolean(
+    resolved.clientId && hasConfiguredSecretInput(resolved.clientSecret),
+  );
   const credentialMethod = await prompter.select({
     message: "How do you want to get DingTalk bot credentials?",
     options: [
@@ -441,7 +450,7 @@ async function configureDingTalkAccount(params: {
         await prompter.text({
           message: "Client Secret (AppSecret)",
           placeholder: "xxx-xxx-xxx-xxx",
-          initialValue: resolved.clientSecret ?? undefined,
+          initialValue: normalizeSecretInputString(resolved.clientSecret),
           validate: (value: string) => (String(value ?? "").trim() ? undefined : "Required"),
         }),
       ).trim();
@@ -461,7 +470,7 @@ async function configureDingTalkAccount(params: {
       await prompter.text({
         message: "Client Secret (AppSecret)",
         placeholder: "xxx-xxx-xxx-xxx",
-        initialValue: resolved.clientSecret ?? undefined,
+        initialValue: normalizeSecretInputString(resolved.clientSecret),
         validate: (value: string) => (String(value ?? "").trim() ? undefined : "Required"),
       }),
     ).trim();
@@ -523,7 +532,7 @@ async function configureDingTalkAccount(params: {
     accountId,
     input: {
       clientId: String(clientId).trim(),
-      clientSecret: String(clientSecret).trim(),
+      clientSecret: parseSecretInputString(clientSecret),
       dmPolicy: dmPolicyValue,
       groupPolicy: groupPolicyValue,
       messageType,

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,0 +1,49 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
+const WINDOWS_ROOT_DIRECTORIES = new Set([
+  "Users",
+  "Program Files",
+  "Program Files (x86)",
+  "ProgramData",
+  "Windows",
+  "Documents and Settings",
+]);
+
+export function resolveRelativePath(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const segments = (value: string): string[] => value.split(/[\\/]+/).filter(Boolean);
+  const pathSegments = segments(trimmed);
+  const firstSegment = pathSegments[0];
+
+  if (trimmed === "~") {
+    return path.resolve(os.homedir());
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.resolve(os.homedir(), ...segments(trimmed.slice(2)));
+  }
+
+  if (process.platform === "win32") {
+    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) {
+      return path.win32.normalize(trimmed);
+    }
+    if (firstSegment && /^[a-zA-Z]:$/.test(firstSegment)) {
+      return path.win32.resolve(`${firstSegment}\\`, ...pathSegments.slice(1));
+    }
+    if (firstSegment && WINDOWS_ROOT_DIRECTORIES.has(firstSegment)) {
+      return path.win32.resolve("\\", ...pathSegments);
+    }
+  }
+
+  if (/^[\\/]/.test(trimmed)) {
+    return path.resolve(path.sep, ...pathSegments);
+  }
+
+  return path.resolve(process.cwd(), ...pathSegments);
+}
+
+export const resolveUserPath = resolveRelativePath;

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -1,0 +1,213 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { z } from "zod";
+import { resolveRelativePath } from "./path-utils";
+
+export type SecretInputRef = {
+  source: "env" | "file" | "exec";
+  provider: string;
+  id: string;
+};
+
+export type SecretInput = string | SecretInputRef;
+
+export type SecretInputResolutionFailure = {
+  source: SecretInputRef["source"];
+  provider: string;
+  id: string;
+  reason: string;
+};
+
+export const SECRET_INPUT_EXEC_TIMEOUT_MS = 5000;
+
+type SecretInputLog = {
+  warn?: (message: string, data?: unknown) => void;
+};
+
+const execFileAsync = promisify(execFile);
+
+function buildSecretInputFailure(
+  value: SecretInputRef,
+  reason: string,
+): SecretInputResolutionFailure {
+  return {
+    source: value.source,
+    provider: value.provider,
+    id: value.id,
+    reason,
+  };
+}
+
+export function formatSecretInputResolutionFailure(failure: SecretInputResolutionFailure): string {
+  return `${failure.source}:${failure.provider}:${failure.id} - ${failure.reason}`;
+}
+
+export function buildSecretInputSchema() {
+  return z.union([
+    z.string(),
+    z.object({
+      source: z.enum(["env", "file", "exec"]),
+      provider: z.string().min(1).max(1024),
+      id: z.string().min(1).max(1024),
+    }),
+  ]);
+}
+
+export function isSecretInputRef(value: unknown): value is SecretInputRef {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const ref = value as SecretInputRef;
+  return (
+    (ref.source === "env" || ref.source === "file" || ref.source === "exec") &&
+    typeof ref.provider === "string" &&
+    ref.provider.trim().length > 0 &&
+    typeof ref.id === "string" &&
+    ref.id.trim().length > 0
+  );
+}
+
+export function hasConfiguredSecretInput(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (!isSecretInputRef(value)) {
+    return false;
+  }
+  if (value.source === "env") {
+    return Boolean(process.env[value.id]?.trim());
+  }
+  // file/exec references are considered configured when the reference shape is
+  // present. The actual filesystem/process lookup happens at runtime so status
+  // checks can stay side-effect free.
+  return true;
+}
+
+export function normalizeSecretInputString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (!isSecretInputRef(value)) {
+    return undefined;
+  }
+  return `<${value.source}:${value.provider}:${value.id}>`;
+}
+
+export function parseSecretInputString(value: unknown): SecretInput | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const match = trimmed.match(/^<(env|file|exec):([^:>]+):(.+)>$/);
+  if (!match) {
+    return trimmed;
+  }
+  return {
+    source: match[1] as SecretInputRef["source"],
+    provider: match[2],
+    id: match[3],
+  };
+}
+
+export async function resolveSecretInputString(
+  value: unknown,
+  log?: SecretInputLog,
+): Promise<string | undefined> {
+  return (await resolveSecretInputStringWithFailure(value, log)).value;
+}
+
+export async function resolveSecretInputStringWithFailure(
+  value: unknown,
+  log?: SecretInputLog,
+): Promise<{ value?: string; failure?: SecretInputResolutionFailure }> {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return { value: trimmed || undefined };
+  }
+  if (!isSecretInputRef(value)) {
+    return {};
+  }
+  if (value.source === "env") {
+    const envValue = process.env[value.id]?.trim();
+    if (envValue) {
+      return { value: envValue };
+    }
+    const failure = buildSecretInputFailure(value, "environment variable is not set or is empty");
+    log?.warn?.("[DingTalk][SecretInput] Failed to resolve env secret", {
+      provider: value.provider,
+      id: value.id,
+      error: failure.reason,
+    });
+    return { failure };
+  }
+  if (value.source === "file") {
+    try {
+      // Trust boundary: file SecretInput reads the configured local path. Use it
+      // only with trusted plugin configuration.
+      const filePath = resolveRelativePath(value.id);
+      const secret = (await readFile(filePath, "utf8")).trim();
+      if (secret) {
+        return { value: secret };
+      }
+      return { failure: buildSecretInputFailure(value, "file secret is empty") };
+    } catch (error) {
+      const failure = buildSecretInputFailure(
+        value,
+        error instanceof Error ? error.message : String(error),
+      );
+      log?.warn?.("[DingTalk][SecretInput] Failed to read file secret", {
+        provider: value.provider,
+        id: value.id,
+        error: failure.reason,
+      });
+      return { failure };
+    }
+  }
+  try {
+    // Trust boundary: exec SecretInput runs the configured provider binary with
+    // the secret id as its only argument. Use it only with trusted plugin
+    // configuration; execFile avoids shell interpolation but still executes the
+    // selected program.
+    const result = await execFileAsync(value.provider, [value.id], {
+      encoding: "utf8",
+      timeout: SECRET_INPUT_EXEC_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    const stdout = typeof result === "string" ? result : result.stdout;
+    const secret = String(stdout).trim();
+    if (secret) {
+      return { value: secret };
+    }
+    return { failure: buildSecretInputFailure(value, "exec secret output is empty") };
+  } catch (error) {
+    const failure = buildSecretInputFailure(
+      value,
+      error instanceof Error ? error.message : String(error),
+    );
+    log?.warn?.("[DingTalk][SecretInput] Failed to resolve exec secret", {
+      provider: value.provider,
+      id: value.id,
+      error: failure.reason,
+    });
+    return { failure };
+  }
+}
+
+export async function resolveDingTalkSecretConfig<T extends { clientSecret?: unknown }>(
+  config: T,
+  log?: SecretInputLog,
+): Promise<
+  T & { clientSecret?: string; clientSecretResolutionFailure?: SecretInputResolutionFailure }
+> {
+  const resolvedSecret = await resolveSecretInputStringWithFailure(config.clientSecret, log);
+  return {
+    ...config,
+    clientSecret: resolvedSecret.value,
+    clientSecretResolutionFailure: resolvedSecret.failure,
+  };
+}

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -103,7 +103,7 @@ export function parseSecretInputString(value: unknown): SecretInput | undefined 
   if (!trimmed) {
     return undefined;
   }
-  const match = trimmed.match(/^<(env|file|exec):([^:>]+):(.+)>$/);
+  const match = trimmed.match(/^<(env|file|exec):([^:>]+):([^>]+)>$/);
   if (!match) {
     return trimmed;
   }

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -26,6 +26,8 @@ type SecretInputLog = {
 };
 
 const execFileAsync = promisify(execFile);
+const SECRET_INPUT_PROVIDER_PATTERN = /^[^:>]+$/;
+const SECRET_INPUT_ID_PATTERN = /^[^>]+$/;
 
 function buildSecretInputFailure(
   value: SecretInputRef,
@@ -48,8 +50,8 @@ export function buildSecretInputSchema() {
     z.string(),
     z.object({
       source: z.enum(["env", "file", "exec"]),
-      provider: z.string().min(1).max(1024),
-      id: z.string().min(1).max(1024),
+      provider: z.string().min(1).max(1024).regex(SECRET_INPUT_PROVIDER_PATTERN),
+      id: z.string().min(1).max(1024).regex(SECRET_INPUT_ID_PATTERN),
     }),
   ]);
 }
@@ -63,8 +65,10 @@ export function isSecretInputRef(value: unknown): value is SecretInputRef {
     (ref.source === "env" || ref.source === "file" || ref.source === "exec") &&
     typeof ref.provider === "string" &&
     ref.provider.trim().length > 0 &&
+    SECRET_INPUT_PROVIDER_PATTERN.test(ref.provider) &&
     typeof ref.id === "string" &&
-    ref.id.trim().length > 0
+    ref.id.trim().length > 0 &&
+    SECRET_INPUT_ID_PATTERN.test(ref.id)
   );
 }
 
@@ -178,8 +182,7 @@ export async function resolveSecretInputStringWithFailure(
       timeout: SECRET_INPUT_EXEC_TIMEOUT_MS,
       windowsHide: true,
     });
-    const stdout = typeof result === "string" ? result : result.stdout;
-    const secret = String(stdout).trim();
+    const secret = String(result.stdout).trim();
     if (secret) {
       return { value: secret };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,14 @@
  */
 
 import type {
+  ChannelPlugin as SDKChannelPlugin,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/core";
+import type {
   ChannelAccountSnapshot as SDKChannelAccountSnapshot,
   ChannelGatewayContext as SDKChannelGatewayContext,
   ChannelLogSink as SDKChannelLogSink,
 } from "openclaw/plugin-sdk/channel-runtime";
-import type { ChannelPlugin as SDKChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
 import type { SecretInput } from "./secret-input";
 
@@ -48,10 +51,7 @@ export interface DingTalkConfig extends OpenClawConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<
-    string,
-    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
-  >;
+  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
   accounts?: Record<string, DingTalkConfig>;
   // Connection robustness configuration
   maxConnectionAttempts?: number;
@@ -129,10 +129,7 @@ export interface DingTalkChannelConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<
-    string,
-    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
-  >;
+  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
   accounts?: Record<string, DingTalkConfig>;
   maxConnectionAttempts?: number;
   initialReconnectDelay?: number;
@@ -310,12 +307,7 @@ export interface DingTalkInboundMessage {
   sessionWebhook: string;
 }
 
-export type QuotedRefKey =
-  | "msgId"
-  | "processQueryKey"
-  | "messageId"
-  | "outTrackId"
-  | "cardInstanceId";
+export type QuotedRefKey = "msgId" | "processQueryKey" | "messageId" | "outTrackId" | "cardInstanceId";
 
 export type AttachmentTextSource = "text" | "html" | "pdf" | "docx";
 
@@ -653,9 +645,7 @@ export interface DingTalkOutboundHandler {
   deliveryMode: "direct" | "queued" | "batch";
   resolveTarget: (params: ResolveTargetParams) => TargetResolutionResult;
   sendText: (params: SendTextParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
-  sendMedia?: (
-    params: SendMediaParams,
-  ) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
+  sendMedia?: (params: SendMediaParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,15 +10,13 @@
  */
 
 import type {
-  ChannelPlugin as SDKChannelPlugin,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/core";
-import type {
   ChannelAccountSnapshot as SDKChannelAccountSnapshot,
   ChannelGatewayContext as SDKChannelGatewayContext,
   ChannelLogSink as SDKChannelLogSink,
 } from "openclaw/plugin-sdk/channel-runtime";
+import type { ChannelPlugin as SDKChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import type { SecretInput } from "./secret-input";
 
 export type AckReactionMode = "off" | "emoji" | "kaomoji";
 // Accept arbitrary strings for backward compatibility; the recommended
@@ -32,7 +30,7 @@ export type ContextVisibilityMode = "all" | "allowlist" | "allowlist_quote";
  */
 export interface DingTalkConfig extends OpenClawConfig {
   clientId: string;
-  clientSecret: string;
+  clientSecret: SecretInput;
   name?: string;
   enabled?: boolean;
   dmPolicy?: "open" | "pairing" | "allowlist";
@@ -50,7 +48,10 @@ export interface DingTalkConfig extends OpenClawConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   // Connection robustness configuration
   maxConnectionAttempts?: number;
@@ -111,7 +112,7 @@ export interface DingTalkConfig extends OpenClawConfig {
 export interface DingTalkChannelConfig {
   enabled?: boolean;
   clientId: string;
-  clientSecret: string;
+  clientSecret: SecretInput;
   name?: string;
   dmPolicy?: "open" | "pairing" | "allowlist";
   groupPolicy?: "open" | "allowlist" | "disabled";
@@ -128,7 +129,10 @@ export interface DingTalkChannelConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   maxConnectionAttempts?: number;
   initialReconnectDelay?: number;
@@ -306,7 +310,12 @@ export interface DingTalkInboundMessage {
   sessionWebhook: string;
 }
 
-export type QuotedRefKey = "msgId" | "processQueryKey" | "messageId" | "outTrackId" | "cardInstanceId";
+export type QuotedRefKey =
+  | "msgId"
+  | "processQueryKey"
+  | "messageId"
+  | "outTrackId"
+  | "cardInstanceId";
 
 export type AttachmentTextSource = "text" | "html" | "pdf" | "docx";
 
@@ -644,7 +653,9 @@ export interface DingTalkOutboundHandler {
   deliveryMode: "direct" | "queued" | "batch";
   resolveTarget: (params: ResolveTargetParams) => TargetResolutionResult;
   sendText: (params: SendTextParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
-  sendMedia?: (params: SendMediaParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
+  sendMedia?: (
+    params: SendMediaParams,
+  ) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
 }
 
 /**

--- a/tests/integration/channel-gateway-module.test.ts
+++ b/tests/integration/channel-gateway-module.test.ts
@@ -1,97 +1,97 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const shared = vi.hoisted(() => ({
-  connectMock: vi.fn(),
-  waitForStopMock: vi.fn(),
-  stopMock: vi.fn(),
-  isConnectedMock: vi.fn(),
-  resolvePluginDebugLogMock: vi.fn(),
-  cleanupOrphanedTempFilesMock: vi.fn(),
-  closePluginDebugLogMock: vi.fn(),
+    connectMock: vi.fn(),
+    waitForStopMock: vi.fn(),
+    stopMock: vi.fn(),
+    isConnectedMock: vi.fn(),
+    resolvePluginDebugLogMock: vi.fn(),
+    cleanupOrphanedTempFilesMock: vi.fn(),
+    closePluginDebugLogMock: vi.fn(),
 }));
 
 vi.mock("dingtalk-stream", () => ({
-  TOPIC_CARD: "TOPIC_CARD",
-  TOPIC_ROBOT: "TOPIC_ROBOT",
-  DWClient: class {
-    config: Record<string, unknown>;
-    registerCallbackListener: (topic: string, cb: (res: unknown) => Promise<void>) => void;
-    socketCallBackResponse: (messageId: string, payload: unknown) => void;
-    connect: () => Promise<void>;
-    disconnect: () => void;
+    TOPIC_CARD: "TOPIC_CARD",
+    TOPIC_ROBOT: "TOPIC_ROBOT",
+    DWClient: class {
+        config: Record<string, unknown>;
+        registerCallbackListener: (topic: string, cb: (res: unknown) => Promise<void>) => void;
+        socketCallBackResponse: (messageId: string, payload: unknown) => void;
+        connect: () => Promise<void>;
+        disconnect: () => void;
 
-    constructor(config: Record<string, unknown>) {
-      this.config = config;
-      this.registerCallbackListener = vi.fn();
-      this.socketCallBackResponse = vi.fn();
-      this.connect = vi.fn();
-      this.disconnect = vi.fn();
-    }
-  },
+        constructor(config: Record<string, unknown>) {
+            this.config = config;
+            this.registerCallbackListener = vi.fn();
+            this.socketCallBackResponse = vi.fn();
+            this.connect = vi.fn();
+            this.disconnect = vi.fn();
+        }
+    },
 }));
 
 vi.mock("../../src/connection-manager", () => ({
-  ConnectionManager: class {
-    connect: () => Promise<void>;
-    waitForStop: () => Promise<void>;
-    stop: () => void;
-    isConnected: () => boolean;
+    ConnectionManager: class {
+        connect: () => Promise<void>;
+        waitForStop: () => Promise<void>;
+        stop: () => void;
+        isConnected: () => boolean;
 
-    constructor() {
-      this.connect = shared.connectMock;
-      this.waitForStop = shared.waitForStopMock;
-      this.stop = shared.stopMock;
-      this.isConnected = shared.isConnectedMock;
-    }
-  },
+        constructor() {
+            this.connect = shared.connectMock;
+            this.waitForStop = shared.waitForStopMock;
+            this.stop = shared.stopMock;
+            this.isConnected = shared.isConnectedMock;
+        }
+    },
 }));
 
 vi.mock("../../src/utils", async () => {
-  const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
-  return {
-    ...actual,
-    resolvePluginDebugLog: shared.resolvePluginDebugLogMock,
-    cleanupOrphanedTempFiles: shared.cleanupOrphanedTempFilesMock,
-    closePluginDebugLog: shared.closePluginDebugLogMock,
-  };
+    const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
+    return {
+        ...actual,
+        resolvePluginDebugLog: shared.resolvePluginDebugLogMock,
+        cleanupOrphanedTempFiles: shared.cleanupOrphanedTempFilesMock,
+        closePluginDebugLog: shared.closePluginDebugLogMock,
+    };
 });
 
 import {
-  CHANNEL_INFLIGHT_NAMESPACE_POLICY,
-  createDingTalkGateway,
+    CHANNEL_INFLIGHT_NAMESPACE_POLICY,
+    createDingTalkGateway,
 } from "../../src/gateway/channel-gateway";
 
 describe("createDingTalkGateway", () => {
-  beforeEach(() => {
-    shared.connectMock.mockReset().mockResolvedValue(undefined);
-    shared.waitForStopMock.mockReset().mockResolvedValue(undefined);
-    shared.stopMock.mockReset();
-    shared.isConnectedMock.mockReset().mockReturnValue(true);
-    shared.resolvePluginDebugLogMock.mockReset().mockImplementation(({ baseLog }: any) => baseLog);
-    shared.cleanupOrphanedTempFilesMock.mockReset();
-    shared.closePluginDebugLogMock.mockReset();
-  });
+    beforeEach(() => {
+        shared.connectMock.mockReset().mockResolvedValue(undefined);
+        shared.waitForStopMock.mockReset().mockResolvedValue(undefined);
+        shared.stopMock.mockReset();
+        shared.isConnectedMock.mockReset().mockReturnValue(true);
+        shared.resolvePluginDebugLogMock.mockReset().mockImplementation(({ baseLog }: any) => baseLog);
+        shared.cleanupOrphanedTempFilesMock.mockReset();
+        shared.closePluginDebugLogMock.mockReset();
+    });
 
-  it("exports the memory-only inflight namespace policy", () => {
-    expect(CHANNEL_INFLIGHT_NAMESPACE_POLICY).toBe("memory-only");
-  });
+    it("exports the memory-only inflight namespace policy", () => {
+        expect(CHANNEL_INFLIGHT_NAMESPACE_POLICY).toBe("memory-only");
+    });
 
-  it("fails fast when account credentials are missing", async () => {
-    const gateway = createDingTalkGateway();
+    it("fails fast when account credentials are missing", async () => {
+        const gateway = createDingTalkGateway();
 
-    await expect(
-      gateway.startAccount?.({
-        cfg: {},
-        account: { accountId: "main", config: { clientId: "id" } },
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-          debug: vi.fn(),
-        },
-        getStatus: () => ({}),
-        setStatus: vi.fn(),
-      } as any),
-    ).rejects.toThrow("DingTalk clientId and resolved clientSecret are required");
-  });
+        await expect(
+            gateway.startAccount?.({
+                cfg: {},
+                account: { accountId: "main", config: { clientId: "id" } },
+                log: {
+                    info: vi.fn(),
+                    warn: vi.fn(),
+                    error: vi.fn(),
+                    debug: vi.fn(),
+                },
+                getStatus: () => ({}),
+                setStatus: vi.fn(),
+            } as any),
+        ).rejects.toThrow("DingTalk clientId and resolved clientSecret are required");
+    });
 });

--- a/tests/integration/channel-gateway-module.test.ts
+++ b/tests/integration/channel-gateway-module.test.ts
@@ -1,97 +1,97 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const shared = vi.hoisted(() => ({
-    connectMock: vi.fn(),
-    waitForStopMock: vi.fn(),
-    stopMock: vi.fn(),
-    isConnectedMock: vi.fn(),
-    resolvePluginDebugLogMock: vi.fn(),
-    cleanupOrphanedTempFilesMock: vi.fn(),
-    closePluginDebugLogMock: vi.fn(),
+  connectMock: vi.fn(),
+  waitForStopMock: vi.fn(),
+  stopMock: vi.fn(),
+  isConnectedMock: vi.fn(),
+  resolvePluginDebugLogMock: vi.fn(),
+  cleanupOrphanedTempFilesMock: vi.fn(),
+  closePluginDebugLogMock: vi.fn(),
 }));
 
 vi.mock("dingtalk-stream", () => ({
-    TOPIC_CARD: "TOPIC_CARD",
-    TOPIC_ROBOT: "TOPIC_ROBOT",
-    DWClient: class {
-        config: Record<string, unknown>;
-        registerCallbackListener: (topic: string, cb: (res: unknown) => Promise<void>) => void;
-        socketCallBackResponse: (messageId: string, payload: unknown) => void;
-        connect: () => Promise<void>;
-        disconnect: () => void;
+  TOPIC_CARD: "TOPIC_CARD",
+  TOPIC_ROBOT: "TOPIC_ROBOT",
+  DWClient: class {
+    config: Record<string, unknown>;
+    registerCallbackListener: (topic: string, cb: (res: unknown) => Promise<void>) => void;
+    socketCallBackResponse: (messageId: string, payload: unknown) => void;
+    connect: () => Promise<void>;
+    disconnect: () => void;
 
-        constructor(config: Record<string, unknown>) {
-            this.config = config;
-            this.registerCallbackListener = vi.fn();
-            this.socketCallBackResponse = vi.fn();
-            this.connect = vi.fn();
-            this.disconnect = vi.fn();
-        }
-    },
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      this.registerCallbackListener = vi.fn();
+      this.socketCallBackResponse = vi.fn();
+      this.connect = vi.fn();
+      this.disconnect = vi.fn();
+    }
+  },
 }));
 
 vi.mock("../../src/connection-manager", () => ({
-    ConnectionManager: class {
-        connect: () => Promise<void>;
-        waitForStop: () => Promise<void>;
-        stop: () => void;
-        isConnected: () => boolean;
+  ConnectionManager: class {
+    connect: () => Promise<void>;
+    waitForStop: () => Promise<void>;
+    stop: () => void;
+    isConnected: () => boolean;
 
-        constructor() {
-            this.connect = shared.connectMock;
-            this.waitForStop = shared.waitForStopMock;
-            this.stop = shared.stopMock;
-            this.isConnected = shared.isConnectedMock;
-        }
-    },
+    constructor() {
+      this.connect = shared.connectMock;
+      this.waitForStop = shared.waitForStopMock;
+      this.stop = shared.stopMock;
+      this.isConnected = shared.isConnectedMock;
+    }
+  },
 }));
 
 vi.mock("../../src/utils", async () => {
-    const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
-    return {
-        ...actual,
-        resolvePluginDebugLog: shared.resolvePluginDebugLogMock,
-        cleanupOrphanedTempFiles: shared.cleanupOrphanedTempFilesMock,
-        closePluginDebugLog: shared.closePluginDebugLogMock,
-    };
+  const actual = await vi.importActual<typeof import("../../src/utils")>("../../src/utils");
+  return {
+    ...actual,
+    resolvePluginDebugLog: shared.resolvePluginDebugLogMock,
+    cleanupOrphanedTempFiles: shared.cleanupOrphanedTempFilesMock,
+    closePluginDebugLog: shared.closePluginDebugLogMock,
+  };
 });
 
 import {
-    CHANNEL_INFLIGHT_NAMESPACE_POLICY,
-    createDingTalkGateway,
+  CHANNEL_INFLIGHT_NAMESPACE_POLICY,
+  createDingTalkGateway,
 } from "../../src/gateway/channel-gateway";
 
 describe("createDingTalkGateway", () => {
-    beforeEach(() => {
-        shared.connectMock.mockReset().mockResolvedValue(undefined);
-        shared.waitForStopMock.mockReset().mockResolvedValue(undefined);
-        shared.stopMock.mockReset();
-        shared.isConnectedMock.mockReset().mockReturnValue(true);
-        shared.resolvePluginDebugLogMock.mockReset().mockImplementation(({ baseLog }: any) => baseLog);
-        shared.cleanupOrphanedTempFilesMock.mockReset();
-        shared.closePluginDebugLogMock.mockReset();
-    });
+  beforeEach(() => {
+    shared.connectMock.mockReset().mockResolvedValue(undefined);
+    shared.waitForStopMock.mockReset().mockResolvedValue(undefined);
+    shared.stopMock.mockReset();
+    shared.isConnectedMock.mockReset().mockReturnValue(true);
+    shared.resolvePluginDebugLogMock.mockReset().mockImplementation(({ baseLog }: any) => baseLog);
+    shared.cleanupOrphanedTempFilesMock.mockReset();
+    shared.closePluginDebugLogMock.mockReset();
+  });
 
-    it("exports the memory-only inflight namespace policy", () => {
-        expect(CHANNEL_INFLIGHT_NAMESPACE_POLICY).toBe("memory-only");
-    });
+  it("exports the memory-only inflight namespace policy", () => {
+    expect(CHANNEL_INFLIGHT_NAMESPACE_POLICY).toBe("memory-only");
+  });
 
-    it("fails fast when account credentials are missing", async () => {
-        const gateway = createDingTalkGateway();
+  it("fails fast when account credentials are missing", async () => {
+    const gateway = createDingTalkGateway();
 
-        await expect(
-            gateway.startAccount?.({
-                cfg: {},
-                account: { accountId: "main", config: { clientId: "id" } },
-                log: {
-                    info: vi.fn(),
-                    warn: vi.fn(),
-                    error: vi.fn(),
-                    debug: vi.fn(),
-                },
-                getStatus: () => ({}),
-                setStatus: vi.fn(),
-            } as any),
-        ).rejects.toThrow("DingTalk clientId and clientSecret are required");
-    });
+    await expect(
+      gateway.startAccount?.({
+        cfg: {},
+        account: { accountId: "main", config: { clientId: "id" } },
+        log: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+        getStatus: () => ({}),
+        setStatus: vi.fn(),
+      } as any),
+    ).rejects.toThrow("DingTalk clientId and resolved clientSecret are required");
+  });
 });

--- a/tests/unit/auth-secret-input-cache.test.ts
+++ b/tests/unit/auth-secret-input-cache.test.ts
@@ -1,0 +1,60 @@
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+const mockedAxiosPost = vi.mocked(axios.post);
+
+async function loadAuthModule() {
+  vi.resetModules();
+  return import("../../src/auth");
+}
+
+describe("auth.getAccessToken SecretInput cache path", () => {
+  beforeEach(() => {
+    mockedAxiosPost.mockReset();
+    vi.doUnmock("../../src/config");
+  });
+
+  it("does not resolve runtime secret config on cache hit", async () => {
+    const resolveRuntimeConfig = vi.fn((config) => config);
+    vi.doMock("../../src/config", async () => {
+      const actual = await vi.importActual<typeof import("../../src/config")>("../../src/config");
+      return { ...actual, resolveRuntimeConfig };
+    });
+    const { getAccessToken } = await loadAuthModule();
+    mockedAxiosPost.mockResolvedValue({
+      data: { accessToken: "token_cached", expireIn: 7200 },
+    } as any);
+
+    const config = {
+      clientId: "ding_secret_ref",
+      clientSecret: { source: "exec", provider: "helper", id: "client-secret" },
+    } as any;
+    const token1 = await getAccessToken(config);
+    const token2 = await getAccessToken(config);
+
+    expect(token1).toBe("token_cached");
+    expect(token2).toBe("token_cached");
+    expect(resolveRuntimeConfig).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails locally when SecretInput resolution produces no clientSecret", async () => {
+    const { getAccessToken } = await loadAuthModule();
+
+    await expect(
+      getAccessToken({
+        clientId: "ding_secret_ref_missing",
+        clientSecret: { source: "file", provider: "local", id: "/missing" },
+      } as any),
+    ).rejects.toThrow(
+      "DingTalk clientId and resolved clientSecret are required: clientSecret resolution failed for file:local:/missing",
+    );
+    expect(mockedAxiosPost).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/channel-actions-module.test.ts
+++ b/tests/unit/channel-actions-module.test.ts
@@ -66,6 +66,31 @@ describe("createDingTalkMessageActions", () => {
         });
     });
 
+    it("does not expose send actions when env SecretInput is missing", () => {
+        const actions = createDingTalkMessageActions();
+
+        expect(
+            actions.describeMessageTool?.({
+                cfg: {
+                    channels: {
+                        dingtalk: {
+                            clientId: "id",
+                            clientSecret: {
+                                source: "env",
+                                provider: "env",
+                                id: "DINGTALK_MISSING_SECRET",
+                            },
+                        },
+                    },
+                },
+            } as any),
+        ).toEqual({
+            actions: [],
+            capabilities: [],
+            schema: null,
+        });
+    });
+
     it("delegates media sends with audioAsVoice derived from action params", async () => {
         const actions = createDingTalkMessageActions();
 

--- a/tests/unit/onboarding.test.ts
+++ b/tests/unit/onboarding.test.ts
@@ -68,6 +68,27 @@ describe("dingtalk setup wizard", () => {
         expect(configured).toBe(false);
     });
 
+    it("status treats a missing env SecretInput as unconfigured", async () => {
+        delete process.env.DINGTALK_MISSING_SETUP_SECRET;
+
+        const configured = await dingtalkSetupWizard.status.resolveConfigured({
+            cfg: {
+                channels: {
+                    dingtalk: {
+                        clientId: "ding_client",
+                        clientSecret: {
+                            source: "env",
+                            provider: "env",
+                            id: "DINGTALK_MISSING_SETUP_SECRET",
+                        },
+                    },
+                },
+            } as any,
+        });
+
+        expect(configured).toBe(false);
+    });
+
     it("allows adding a named account during setup", async () => {
         const confirm = vi.fn();
         const select = vi.fn().mockResolvedValueOnce("new");
@@ -208,6 +229,49 @@ describe("dingtalk setup wizard", () => {
         const dingtalkConfig = cfg.channels?.dingtalk;
         expect(dingtalkConfig?.clientId).toBe("ding_client");
         expect(dingtalkConfig?.clientSecret).toBe("ding_secret");
+    });
+
+    it("preserves existing SecretInput when manual setup saves unchanged credentials", async () => {
+        process.env.DINGTALK_EXISTING_SECRET = "secret-from-env";
+        const note = vi.fn();
+        const text = vi.fn(async (options: { initialValue?: string }) => options.initialValue);
+        const confirm = vi.fn().mockResolvedValueOnce(false);
+        const select = vi
+            .fn()
+            .mockResolvedValueOnce("manual")
+            .mockResolvedValueOnce("open")
+            .mockResolvedValueOnce("open")
+            .mockResolvedValueOnce("markdown");
+
+        const result = await runSetupWizardConfigure({
+            cfg: {
+                channels: {
+                    dingtalk: {
+                        clientId: "ding_client",
+                        clientSecret: {
+                            source: "env",
+                            provider: "env",
+                            id: "DINGTALK_EXISTING_SECRET",
+                        },
+                    },
+                },
+            } as any,
+            prompter: { note, text, confirm, select } as unknown as WizardPrompter,
+        });
+
+        const dingtalkConfig = result.cfg.channels?.dingtalk;
+        expect(dingtalkConfig?.clientId).toBe("ding_client");
+        expect(dingtalkConfig?.clientSecret).toEqual({
+            source: "env",
+            provider: "env",
+            id: "DINGTALK_EXISTING_SECRET",
+        });
+        expect(text).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                initialValue: "<env:env:DINGTALK_EXISTING_SECRET>",
+            }),
+        );
     });
 
     it("configure with disabled groupPolicy skips groupAllowFrom prompt", async () => {

--- a/tests/unit/secret-input-exec.test.ts
+++ b/tests/unit/secret-input-exec.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: execFileMock,
+}));
+
+describe("SecretInput exec support", () => {
+  it("bounds async exec secret helper calls with a timeout", async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null, "secret-from-helper\n", "");
+    });
+    const { SECRET_INPUT_EXEC_TIMEOUT_MS, resolveSecretInputString } =
+      await import("../../src/secret-input");
+
+    const secret = await resolveSecretInputString({
+      source: "exec",
+      provider: "secret-helper",
+      id: "dingtalk/client-secret",
+    });
+
+    expect(secret).toBe("secret-from-helper");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "secret-helper",
+      ["dingtalk/client-secret"],
+      {
+        encoding: "utf8",
+        timeout: SECRET_INPUT_EXEC_TIMEOUT_MS,
+        windowsHide: true,
+      },
+      expect.any(Function),
+    );
+  });
+});

--- a/tests/unit/secret-input-exec.test.ts
+++ b/tests/unit/secret-input-exec.test.ts
@@ -5,7 +5,27 @@ const { execFileMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("node:child_process", () => ({
-  execFile: execFileMock,
+  execFile: Object.assign(execFileMock, {
+    [Symbol.for("nodejs.util.promisify.custom")]: (
+      command: string,
+      args: string[],
+      options: unknown,
+    ) =>
+      new Promise((resolve, reject) => {
+        execFileMock(
+          command,
+          args,
+          options,
+          (error: Error | null, stdout: string, stderr: string) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve({ stdout, stderr });
+          },
+        );
+      }),
+  }),
 }));
 
 describe("SecretInput exec support", () => {

--- a/tests/unit/secret-input.test.ts
+++ b/tests/unit/secret-input.test.ts
@@ -1,0 +1,136 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isConfigured } from "../../src/config";
+import { DingTalkConfigSchema } from "../../src/config-schema";
+import {
+  formatSecretInputResolutionFailure,
+  parseSecretInputString,
+  resolveSecretInputString,
+  resolveSecretInputStringWithFailure,
+} from "../../src/secret-input";
+
+describe("SecretInput support", () => {
+  let tempDir: string | undefined;
+
+  afterEach(async () => {
+    delete process.env.DINGTALK_TEST_SECRET;
+    if (tempDir) {
+      const dir = tempDir;
+      tempDir = undefined;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts SecretInput references in the DingTalk config schema", () => {
+    const parsed = DingTalkConfigSchema.parse({
+      clientId: "id",
+      clientSecret: { source: "env", provider: "env", id: "DINGTALK_TEST_SECRET" },
+      accounts: {
+        main: {
+          clientId: "account-id",
+          clientSecret: {
+            source: "file",
+            provider: "local",
+            id: "~/.config/dingtalk-secret",
+          },
+        },
+      },
+    }) as { clientSecret?: unknown; accounts: Record<string, { clientSecret?: unknown }> };
+
+    expect(parsed.clientSecret).toEqual({
+      source: "env",
+      provider: "env",
+      id: "DINGTALK_TEST_SECRET",
+    });
+    expect(parsed.accounts.main?.clientSecret).toEqual({
+      source: "file",
+      provider: "local",
+      id: "~/.config/dingtalk-secret",
+    });
+  });
+
+  it("treats env SecretInput as configured only when the env value exists", () => {
+    process.env.DINGTALK_TEST_SECRET = "sec-from-env";
+
+    expect(
+      isConfigured({
+        channels: {
+          dingtalk: {
+            clientId: "id",
+            clientSecret: { source: "env", provider: "env", id: "DINGTALK_TEST_SECRET" },
+          },
+        },
+      } as any),
+    ).toBe(true);
+    expect(
+      isConfigured({
+        channels: {
+          dingtalk: {
+            clientId: "id",
+            clientSecret: { source: "env", provider: "env", id: "DINGTALK_MISSING_SECRET" },
+          },
+        },
+      } as any),
+    ).toBe(false);
+  });
+
+  it("resolves file SecretInput values from a local file", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "dingtalk-secret-input-"));
+    const secretPath = join(tempDir, "client-secret.txt");
+    await writeFile(secretPath, "secret-from-file\n", "utf8");
+
+    await expect(
+      resolveSecretInputString({
+        source: "file",
+        provider: "local",
+        id: secretPath,
+      }),
+    ).resolves.toBe("secret-from-file");
+  });
+
+  it("reports env SecretInput resolution failures with source context", async () => {
+    const result = await resolveSecretInputStringWithFailure({
+      source: "env",
+      provider: "env",
+      id: "DINGTALK_MISSING_SECRET",
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.failure).toEqual({
+      source: "env",
+      provider: "env",
+      id: "DINGTALK_MISSING_SECRET",
+      reason: "environment variable is not set or is empty",
+    });
+    expect(formatSecretInputResolutionFailure(result.failure!)).toBe(
+      "env:env:DINGTALK_MISSING_SECRET - environment variable is not set or is empty",
+    );
+  });
+
+  it("reports file SecretInput resolution failures with source context", async () => {
+    const result = await resolveSecretInputStringWithFailure({
+      source: "file",
+      provider: "local",
+      id: "/missing-dingtalk-secret",
+    });
+
+    expect(result.value).toBeUndefined();
+    expect(result.failure).toMatchObject({
+      source: "file",
+      provider: "local",
+      id: "/missing-dingtalk-secret",
+    });
+    expect(result.failure?.reason).toContain("ENOENT");
+  });
+
+  it("parses normalized SecretInput strings back into object refs", () => {
+    expect(parseSecretInputString("<env:env:DINGTALK_TEST_SECRET>")).toEqual({
+      source: "env",
+      provider: "env",
+      id: "DINGTALK_TEST_SECRET",
+    });
+    expect(parseSecretInputString("plain-secret")).toBe("plain-secret");
+  });
+});

--- a/tests/unit/secret-input.test.ts
+++ b/tests/unit/secret-input.test.ts
@@ -133,4 +133,8 @@ describe("SecretInput support", () => {
     });
     expect(parseSecretInputString("plain-secret")).toBe("plain-secret");
   });
+
+  it("leaves malformed normalized SecretInput strings as plain secrets", () => {
+    expect(parseSecretInputString("<exec:helper:my>id>")).toBe("<exec:helper:my>id>");
+  });
 });

--- a/tests/unit/secret-input.test.ts
+++ b/tests/unit/secret-input.test.ts
@@ -6,6 +6,7 @@ import { isConfigured } from "../../src/config";
 import { DingTalkConfigSchema } from "../../src/config-schema";
 import {
   formatSecretInputResolutionFailure,
+  normalizeSecretInputString,
   parseSecretInputString,
   resolveSecretInputString,
   resolveSecretInputStringWithFailure,
@@ -136,5 +137,20 @@ describe("SecretInput support", () => {
 
   it("leaves malformed normalized SecretInput strings as plain secrets", () => {
     expect(parseSecretInputString("<exec:helper:my>id>")).toBe("<exec:helper:my>id>");
+  });
+
+  it("rejects SecretInput refs that cannot round-trip through normalized placeholders", () => {
+    const providerWithColon = { source: "exec", provider: "vault:kv", id: "my-secret" } as const;
+    const idWithClosingBracket = { source: "file", provider: "local", id: "my>secret" } as const;
+
+    expect(
+      DingTalkConfigSchema.safeParse({ clientId: "id", clientSecret: providerWithColon }).success,
+    ).toBe(false);
+    expect(
+      DingTalkConfigSchema.safeParse({ clientId: "id", clientSecret: idWithClosingBracket })
+        .success,
+    ).toBe(false);
+    expect(normalizeSecretInputString(providerWithColon)).toBeUndefined();
+    expect(normalizeSecretInputString(idWithClosingBracket)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary\n- allow DingTalk clientSecret to be provided as a SecretInput string or env/file/exec reference\n- resolve SecretInput only on runtime paths that need the raw secret, while status/onboarding display normalized references\n- bound exec helper calls with a timeout and avoid resolving exec-backed secrets on access-token cache hits\n\nThis is split out from the closed combined PR #526 so SecretInput support can be reviewed independently from Gateway RPC compatibility. The approach is based on the official connector's SecretInput pattern while preserving existing string clientSecret compatibility.\n\n## Validation\n- pnpm test tests/unit/secret-input.test.ts tests/unit/secret-input-exec.test.ts tests/unit/auth-secret-input-cache.test.ts\n- pnpm type-check