### PR TITLE
fix(inbound): download and pass all mediaPaths for multi-image rich text messages

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -987,7 +987,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     if (preDownloadedMedia.mediaPaths?.length) {
       mediaPaths.push(...preDownloadedMedia.mediaPaths);
       for (let i = 0; i < preDownloadedMedia.mediaPaths.length; i++) {
-        mediaTypes.push(preDownloadedMedia.mediaTypes?.[i] || preDownloadedMedia.mediaType || "file");
+        mediaTypes.push(
+          preDownloadedMedia.mediaTypes?.[i] || preDownloadedMedia.mediaType || "file",
+        );
       }
     } else {
       mediaPaths.push(mediaPath);
@@ -1077,6 +1079,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         if (docMedia) {
           mediaPath = docMedia.path;
           mediaType = docMedia.mimeType;
+          mediaPaths.push(docMedia.path);
+          mediaTypes.push(docMedia.mimeType);
         }
       } catch (err: any) {
         log?.warn?.(`[DingTalk] Doc card download failed: ${err.message}`);
@@ -1212,6 +1216,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       if (media) {
         mediaPath = media.path;
         mediaType = media.mimeType;
+        mediaPaths.push(media.path);
+        mediaTypes.push(media.mimeType);
         attachmentContextMsgId = content.quoted.msgId || data.msgId;
         attachmentContextCreatedAt = content.quoted.fileCreatedAt || data.createAt;
         attachmentContextMessageType = content.quoted.previewMessageType || "file";
@@ -1232,6 +1238,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       if (cachedMedia) {
         mediaPath = cachedMedia.path;
         mediaType = cachedMedia.mimeType;
+        mediaPaths.push(cachedMedia.path);
+        mediaTypes.push(cachedMedia.mimeType);
         attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
         attachmentContextCreatedAt =
           quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
@@ -1256,6 +1264,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       if (resolved) {
         mediaPath = resolved.media.path;
         mediaType = resolved.media.mimeType;
+        mediaPaths.push(resolved.media.path);
+        mediaTypes.push(resolved.media.mimeType);
         attachmentContextMsgId = content.quoted.msgId || data.msgId;
         attachmentContextCreatedAt = content.quoted.fileCreatedAt || data.createAt;
         attachmentContextMessageType = "file";
@@ -1311,6 +1321,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     if (cachedDocMedia) {
       mediaPath = cachedDocMedia.path;
       mediaType = cachedDocMedia.mimeType;
+      mediaPaths.push(cachedDocMedia.path);
+      mediaTypes.push(cachedDocMedia.mimeType);
       attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
       attachmentContextCreatedAt =
         quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
@@ -1334,6 +1346,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       if (resolved) {
         mediaPath = resolved.media.path;
         mediaType = resolved.media.mimeType;
+        mediaPaths.push(resolved.media.path);
+        mediaTypes.push(resolved.media.mimeType);
         attachmentContextMsgId = content.quoted.msgId || data.msgId;
         attachmentContextCreatedAt = content.quoted.fileCreatedAt || data.createAt;
         attachmentContextMessageType = "interactiveCardFile";

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1021,8 +1021,14 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
   }
 
-  // Cache downloadCode (+ spaceId/fileId) for quoted file lookups (DM + group).
-  if (content.mediaPath && data.msgId) {
+  // Cache downloadCode(s) (+ spaceId/fileId) for quoted file lookups (DM + group).
+  const allMediaDownloadCodes =
+    content.mediaPaths && content.mediaPaths.length > 0
+      ? content.mediaPaths
+      : content.mediaPath
+        ? [content.mediaPath]
+        : [];
+  if (allMediaDownloadCodes.length > 0 && data.msgId) {
     upsertInboundMessageContext({
       storePath: accountStorePath,
       accountId,
@@ -1031,7 +1037,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       createdAt: data.createAt,
       messageType: content.messageType,
       media: {
-        downloadCode: content.mediaPath,
+        downloadCode: allMediaDownloadCodes[0],
+        downloadCodes: allMediaDownloadCodes.length > 1 ? allMediaDownloadCodes : undefined,
         spaceId: data.content?.spaceId,
         fileId: data.content?.fileId,
       },
@@ -1168,6 +1175,38 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
     return media;
   };
+
+  // Quoted multi-image richText: recover all cached downloadCodes.
+  // Placed before the single-image/ file/ doc-card paths so that the
+  // !mediaPath guard prevents those paths from downloading only the first image.
+  if (
+    !mediaPath &&
+    quotedRecord?.media?.downloadCodes &&
+    quotedRecord.media.downloadCodes.length > 1
+  ) {
+    const recovered: MediaFile[] = [];
+    for (const code of quotedRecord.media.downloadCodes) {
+      const result = await downloadMedia(dingtalkConfig, code, log);
+      if (result) {
+        recovered.push(result);
+      }
+    }
+    if (recovered.length > 0) {
+      mediaPath = recovered[0].path;
+      mediaType = recovered[0].mimeType;
+      for (const m of recovered) {
+        mediaPaths.push(m.path);
+        mediaTypes.push(m.mimeType);
+      }
+      attachmentContextMsgId = quotedRecord.msgId || data.msgId;
+      attachmentContextCreatedAt = quotedRecord.createdAt || data.createAt;
+      attachmentContextMessageType = quotedRecord.messageType || "richText";
+      log?.debug?.(
+        `[DingTalk][QuotedRef] Recovered ${recovered.length} images from cached multi-image richText ` +
+          `recordMsgId=${quotedRecord.msgId || "(none)"} scope=${data.conversationId}`,
+      );
+    }
+  }
 
   // Quoted picture: download via existing downloadMedia.
   if (!mediaPath && content.quoted?.mediaDownloadCode && robotCode) {

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -984,9 +984,14 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   if (preDownloadedMedia?.mediaPath) {
     mediaPath = preDownloadedMedia.mediaPath;
     mediaType = preDownloadedMedia.mediaType;
-    mediaPaths.push(mediaPath);
-    if (mediaType) {
-      mediaTypes.push(mediaType);
+    if (preDownloadedMedia.mediaPaths?.length) {
+      mediaPaths.push(...preDownloadedMedia.mediaPaths);
+      for (let i = 0; i < preDownloadedMedia.mediaPaths.length; i++) {
+        mediaTypes.push(preDownloadedMedia.mediaTypes?.[i] || preDownloadedMedia.mediaType || "file");
+      }
+    } else {
+      mediaPaths.push(mediaPath);
+      mediaTypes.push(mediaType || "file");
     }
   } else if (robotCode) {
     // Download all media attachments (richText may carry multiple images).
@@ -1179,6 +1184,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       }
       mediaPath = media.path;
       mediaType = media.mimeType;
+      mediaPaths.push(media.path);
+      mediaTypes.push(media.mimeType);
       attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
       attachmentContextCreatedAt = quotedRecord?.createdAt || data.createAt;
       attachmentContextMessageType =

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1,30 +1,24 @@
 import fs from "node:fs";
 import * as path from "node:path";
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
-import axios from "./http-client";
+import { parseInlineDirectives } from "openclaw/plugin-sdk/text-runtime";
 import { normalizeAllowFrom, isSenderAllowed, resolveGroupAccess } from "./access-control";
-import { buildAgentSessionKey, resolveSubAgentRoute, dispatchSubAgents } from "./targeting/agent-routing";
-import { getAgentDisplayName } from "./targeting/agent-name-matcher";
 import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
 import { createDynamicAckReactionController } from "./ack-reaction/dynamic-ack-reaction-controller";
-import { extractAttachmentText } from "./messaging/attachment-text-extractor";
 import { getAccessToken } from "./auth";
 import { createAICard, commitAICardBlocks, isCardInTerminalState } from "./card-service";
+import { isCardRunStopRequested, registerCardRun, removeCardRun } from "./card/card-run-registry";
 import { renderStatusLine } from "./card/statusline-renderer";
 import { handleInboundCommandDispatch } from "./command/inbound-command-dispatch-service";
-import { resolveAckReactionSetting, resolveGroupConfig, resolveRelativePath, resolveRobotCode } from "./config";
-import { AICardStatus } from "./types";
 import {
-  isCardRunStopRequested,
-  registerCardRun,
-  removeCardRun,
-} from "./card/card-run-registry";
-import {
-  buildLearningContextBlock,
-  isLearningEnabled,
-} from "./feedback-learning-service";
-import { formatGroupMembers, noteGroupMember } from "./targeting/group-members-store";
+  resolveAckReactionSetting,
+  resolveGroupConfig,
+  resolveRelativePath,
+  resolveRobotCode,
+} from "./config";
+import { buildLearningContextBlock, isLearningEnabled } from "./feedback-learning-service";
+import axios from "./http-client";
 import { setCurrentLogger } from "./logger-context";
 import { prepareMediaInput, resolveOutboundMediaType } from "./media-utils";
 import {
@@ -33,8 +27,14 @@ import {
   upsertInboundMessageContext,
 } from "./message-context-store";
 import { extractMessageContent } from "./message-utils";
+import { extractAttachmentText } from "./messaging/attachment-text-extractor";
 import { deliverBtwReply, stripLeadingMentions } from "./messaging/btw-deliver";
 import { resolveQuotedRuntimeContext } from "./messaging/quoted-context";
+import {
+  downloadGroupFile,
+  getUnionIdByStaffId,
+  resolveQuotedFile,
+} from "./messaging/quoted-file-service";
 import {
   buildInboundQuotedRef,
   createReplyQuotedRef,
@@ -45,7 +45,6 @@ import {
   clearProactiveRiskObservationsForTest,
   getProactiveRiskObservationForAny,
 } from "./proactive-risk-registry";
-import { downloadGroupFile, getUnionIdByStaffId, resolveQuotedFile } from "./messaging/quoted-file-service";
 import { createReplyStrategy } from "./reply-strategy";
 import type { DeliverPayload } from "./reply-strategy-types";
 import { getDingTalkRuntime } from "./runtime";
@@ -58,13 +57,26 @@ import {
 } from "./session-peer-store";
 import { resolveDingTalkSessionPeer } from "./session-routing";
 import { getSessionState, initSessionState } from "./session-state";
+import { getAgentDisplayName } from "./targeting/agent-name-matcher";
+import {
+  buildAgentSessionKey,
+  resolveSubAgentRoute,
+  dispatchSubAgents,
+} from "./targeting/agent-routing";
+import { formatGroupMembers, noteGroupMember } from "./targeting/group-members-store";
 import {
   upsertObservedGroupTarget,
   upsertObservedUserTarget,
 } from "./targeting/target-directory-store";
+import { AICardStatus } from "./types";
 import type { DingTalkConfig, HandleDingTalkMessageParams, Logger, MediaFile } from "./types";
-import { formatDingTalkErrorPayloadLog, getErrorMessage, getErrorResponseData, maskSensitiveData, parseBooleanLike } from "./utils";
-import { parseInlineDirectives } from "openclaw/plugin-sdk/text-runtime";
+import {
+  formatDingTalkErrorPayloadLog,
+  getErrorMessage,
+  getErrorResponseData,
+  maskSensitiveData,
+  parseBooleanLike,
+} from "./utils";
 
 const DEFAULT_PROACTIVE_HINT_COOLDOWN_HOURS = 24;
 const MIN_THINKING_REACTION_VISIBLE_MS = 1200;
@@ -95,10 +107,13 @@ const STANDALONE_MEDIA_PATH_EXTENSIONS = new Set([
   ".rar",
 ]);
 const proactiveHintLastSentAt = new Map<string, number>();
-const sessionReasoningLevelCache = new Map<string, {
-  updatedAt?: number;
-  reasoningLevel?: string;
-}>();
+const sessionReasoningLevelCache = new Map<
+  string,
+  {
+    updatedAt?: number;
+    reasoningLevel?: string;
+  }
+>();
 type ReplyMode = "card" | "markdown";
 
 function resolveQuotedContextAllowFrom(
@@ -133,7 +148,15 @@ function filterQuotedRuntimeContext(params: {
   currentSenderId: string;
   currentSenderOriginalId: string;
 }): ReturnType<typeof resolveQuotedRuntimeContext> {
-  const { context, config, isDirect, groupId, quotedSenderId, currentSenderId, currentSenderOriginalId } = params;
+  const {
+    context,
+    config,
+    isDirect,
+    groupId,
+    quotedSenderId,
+    currentSenderId,
+    currentSenderOriginalId,
+  } = params;
   if (!context || isDirect) {
     return context;
   }
@@ -150,9 +173,7 @@ function filterQuotedRuntimeContext(params: {
     currentSenderOriginalId,
   });
   const senderAllowed =
-    allow.hasEntries && !!senderId
-      ? isSenderAllowed({ allow, senderId })
-      : false;
+    allow.hasEntries && !!senderId ? isSenderAllowed({ allow, senderId }) : false;
 
   if (senderAllowed) {
     return context;
@@ -178,9 +199,9 @@ function readSessionReasoningLevel(params: {
   const cacheKey = `${params.storePath}:${params.sessionKey}`;
   const cached = sessionReasoningLevelCache.get(cacheKey);
   if (
-    cached
-    && params.sessionUpdatedAt !== undefined
-    && cached.updatedAt === params.sessionUpdatedAt
+    cached &&
+    params.sessionUpdatedAt !== undefined &&
+    cached.updatedAt === params.sessionUpdatedAt
   ) {
     return cached.reasoningLevel;
   }
@@ -520,7 +541,16 @@ export async function downloadMedia(
 }
 
 export async function handleDingTalkMessage(params: HandleDingTalkMessageParams): Promise<void> {
-  const { cfg, accountId, data, sessionWebhook, log, dingtalkConfig, subAgentOptions, preDownloadedMedia } = params;
+  const {
+    cfg,
+    accountId,
+    data,
+    sessionWebhook,
+    log,
+    dingtalkConfig,
+    subAgentOptions,
+    preDownloadedMedia,
+  } = params;
   const rt = getDingTalkRuntime();
 
   // Save logger globally so shared services can log consistently without threading log everywhere.
@@ -649,31 +679,32 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     if (groupAccess.legacyFallback) {
       log?.info?.(
         `[DingTalk] DEPRECATED: groupPolicy=allowlist is using "allowFrom" for group access control. ` +
-        `Please migrate to "groups" (group ID allowlist) or "groupAllowFrom" (sender allowlist).`,
+          `Please migrate to "groups" (group ID allowlist) or "groupAllowFrom" (sender allowlist).`,
       );
     }
 
     if (!groupAccess.allowed) {
       if (groupAccess.reason === "disabled") {
-        log?.debug?.(`[DingTalk] Group disabled: all group messages dropped (groupPolicy=disabled)`);
+        log?.debug?.(
+          `[DingTalk] Group disabled: all group messages dropped (groupPolicy=disabled)`,
+        );
         return;
       }
 
-      const denyMessage = groupAccess.reason === "sender_not_allowed"
-        ? `⛔ 访问受限\n\n您的用户ID：\`${senderId}\`\n\n请联系管理员将此ID添加到群聊允许列表中。`
-        : `⛔ 访问受限\n\n您的群聊ID：\`${groupId}\`\n\n请联系管理员将此ID添加到允许列表中。`;
+      const denyMessage =
+        groupAccess.reason === "sender_not_allowed"
+          ? `⛔ 访问受限\n\n您的用户ID：\`${senderId}\`\n\n请联系管理员将此ID添加到群聊允许列表中。`
+          : `⛔ 访问受限\n\n您的群聊ID：\`${groupId}\`\n\n请联系管理员将此ID添加到允许列表中。`;
 
       log?.debug?.(
         `[DingTalk] Group blocked: conversationId=${groupId} senderId=${senderId} reason=${groupAccess.reason}`,
       );
 
       try {
-        await sendBySession(
-          dingtalkConfig,
-          sessionWebhook,
-          denyMessage,
-          { log, atUserId: senderId },
-        );
+        await sendBySession(dingtalkConfig, sessionWebhook, denyMessage, {
+          log,
+          atUserId: senderId,
+        });
       } catch (err: any) {
         log?.debug?.(`[DingTalk] Failed to send group access denied message: ${err.message}`);
         if (err?.response?.data !== undefined) {
@@ -686,9 +717,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       return;
     }
 
-    log?.debug?.(
-      `[DingTalk] Group authorized: conversationId=${groupId} senderId=${senderId}`,
-    );
+    log?.debug?.(`[DingTalk] Group authorized: conversationId=${groupId} senderId=${senderId}`);
   }
 
   // Calculate account store path and session peer (for session alias feature)
@@ -826,15 +855,19 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   const isBtwBypass = isBtwRequestText(stripLeadingMentions(content.text).trim());
   const taskInfoConversationId = groupId || to;
   const sessionTaskState = initSessionState(accountId, taskInfoConversationId);
-  const initialStatusLine = renderStatusLine({
-    model: sessionTaskState.model,
-    effort: sessionTaskState.effort,
-    agent: getAgentDisplayName({
-      subAgentOptions,
-      agentId: route.agentId,
-      agentsList: cfg.agents?.list,
-    }),
-  }, dingtalkConfig) || undefined;
+  const initialStatusLine =
+    renderStatusLine(
+      {
+        model: sessionTaskState.model,
+        effort: sessionTaskState.effort,
+        agent: getAgentDisplayName({
+          subAgentOptions,
+          agentId: route.agentId,
+          agentsList: cfg.agents?.list,
+        }),
+      },
+      dingtalkConfig,
+    ) || undefined;
 
   // 3) Select response mode (card vs markdown).
   // Card creation runs BEFORE media download so the user sees immediate visual
@@ -940,6 +973,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   const robotCode = resolveRobotCode(dingtalkConfig);
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
+  const mediaPaths: string[] = [];
+  const mediaTypes: string[] = [];
   let attachmentContextMsgId = data.msgId;
   let attachmentContextCreatedAt = data.createAt;
   let attachmentContextMessageType = content.messageType;
@@ -949,17 +984,33 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   if (preDownloadedMedia?.mediaPath) {
     mediaPath = preDownloadedMedia.mediaPath;
     mediaType = preDownloadedMedia.mediaType;
-  } else if (content.mediaPath && robotCode) {
-    // Download media only if not pre-downloaded
-    const media = await downloadMedia(
-      dingtalkConfig,
-      content.mediaPath,
-      log,
-      attachmentContextFileName,
-    );
-    if (media) {
-      mediaPath = media.path;
-      mediaType = media.mimeType;
+    mediaPaths.push(mediaPath);
+    if (mediaType) {
+      mediaTypes.push(mediaType);
+    }
+  } else if (robotCode) {
+    // Download all media attachments (richText may carry multiple images).
+    const downloadCodes =
+      content.mediaPaths && content.mediaPaths.length > 0
+        ? content.mediaPaths
+        : content.mediaPath
+          ? [content.mediaPath]
+          : [];
+    for (const downloadCode of downloadCodes) {
+      const media = await downloadMedia(
+        dingtalkConfig,
+        downloadCode,
+        log,
+        attachmentContextFileName,
+      );
+      if (media) {
+        if (!mediaPath) {
+          mediaPath = media.path;
+          mediaType = media.mimeType;
+        }
+        mediaPaths.push(media.path);
+        mediaTypes.push(media.mimeType);
+      }
     }
   }
 
@@ -1043,8 +1094,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       quotedRef,
       firstRecord: quotedRecord,
       firstPreview:
-        content.quoted?.previewText ||
-        content.quoted?.previewMessageType
+        content.quoted?.previewText || content.quoted?.previewMessageType
           ? {
               text: content.quoted.previewText,
               messageType: content.quoted.previewMessageType,
@@ -1131,7 +1181,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       mediaType = media.mimeType;
       attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
       attachmentContextCreatedAt = quotedRecord?.createdAt || data.createAt;
-      attachmentContextMessageType = quotedRecord?.messageType || content.quoted.previewMessageType || "picture";
+      attachmentContextMessageType =
+        quotedRecord?.messageType || content.quoted.previewMessageType || "picture";
       attachmentContextFileName = content.quoted.previewFileName;
     } else {
       content.text = `[引用了一张图片，但下载失败]\n\n${content.text}`;
@@ -1175,9 +1226,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         mediaPath = cachedMedia.path;
         mediaType = cachedMedia.mimeType;
         attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
-        attachmentContextCreatedAt = quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
+        attachmentContextCreatedAt =
+          quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
         attachmentContextMessageType = quotedRecord?.messageType || "file";
-        attachmentContextFileName = quotedRecord?.attachmentFileName || content.quoted.previewFileName;
+        attachmentContextFileName =
+          quotedRecord?.attachmentFileName || content.quoted.previewFileName;
         fileResolved = true;
       }
     }
@@ -1252,10 +1305,12 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       mediaPath = cachedDocMedia.path;
       mediaType = cachedDocMedia.mimeType;
       attachmentContextMsgId = quotedRecord?.msgId || content.quoted.msgId || data.msgId;
-      attachmentContextCreatedAt = quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
+      attachmentContextCreatedAt =
+        quotedRecord?.createdAt || content.quoted.fileCreatedAt || data.createAt;
       attachmentContextMessageType =
         quotedRecord?.messageType || content.quoted.previewMessageType || "interactiveCardFile";
-      attachmentContextFileName = quotedRecord?.attachmentFileName || content.quoted.previewFileName;
+      attachmentContextFileName =
+        quotedRecord?.attachmentFileName || content.quoted.previewFileName;
       docResolved = true;
     }
 
@@ -1421,6 +1476,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     MediaPath: mediaPath,
     MediaType: mediaType,
     MediaUrl: mediaPath,
+    MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
+    MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
     GroupMembers: groupMembers,
     GroupSystemPrompt: extraSystemPrompt,
     GroupChannel: isDirect ? undefined : route.sessionKey,
@@ -1443,9 +1501,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       });
       const senderRecipient = (senderOriginalId || senderId || "").trim().toLowerCase();
       if (
-        pinnedMainDmOwner
-        && senderRecipient
-        && pinnedMainDmOwner.trim().toLowerCase() !== senderRecipient
+        pinnedMainDmOwner &&
+        senderRecipient &&
+        pinnedMainDmOwner.trim().toLowerCase() !== senderRecipient
       ) {
         log?.debug?.(
           `[DingTalk] Skipping main-session last route update for ${senderRecipient} (pinned owner ${pinnedMainDmOwner})`,
@@ -1530,12 +1588,18 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         const abortBlockList = [{ type: 0, markdown: abortText }];
         const blockListJson = JSON.stringify(abortBlockList);
 
-        await commitAICardBlocks(currentAICard, {
-          blockListJson,
-          content: abortText,
-        }, log);
+        await commitAICardBlocks(
+          currentAICard,
+          {
+            blockListJson,
+            content: abortText,
+          },
+          log,
+        );
 
-        log?.debug?.(`[DingTalk] Abort card finalized via V2 API: card=${currentAICard.cardInstanceId}`);
+        log?.debug?.(
+          `[DingTalk] Abort card finalized via V2 API: card=${currentAICard.cardInstanceId}`,
+        );
       } catch (cardErr) {
         log?.warn?.(`[DingTalk] Abort card finalize failed: ${getErrorMessage(cardErr)}`);
         currentAICard.state = AICardStatus.FAILED;
@@ -1691,7 +1755,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       // Keep ordinary text formatting stable except for newline normalization.
       // Once inline parsing actually strips directives/media lines, return the
       // cleaned body text instead of the original raw payload.
-      text: mediaUrls.length > 0 || inlineTextWasTransformed ? cleanedText || undefined : normalizedText,
+      text:
+        mediaUrls.length > 0 || inlineTextWasTransformed
+          ? cleanedText || undefined
+          : normalizedText,
       mediaUrls,
       audioAsVoice: parsedInline.audioAsVoice,
     };
@@ -1815,9 +1882,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           richPayload.mediaUrl.trim()
         ? [richPayload.mediaUrl]
         : [];
-    return explicitMediaUrls.length > 0
-      ? explicitMediaUrls
-      : inlineReplyPayload?.mediaUrls ?? [];
+    return explicitMediaUrls.length > 0 ? explicitMediaUrls : (inlineReplyPayload?.mediaUrls ?? []);
   }
 
   // Serialize dispatchReply + card finalize per session to prevent the runtime
@@ -1827,13 +1892,15 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // different session keys (different agentId), so no deadlock risk.
   const currentOutTrackId = currentAICard?.outTrackId;
   const shouldTrackDynamicAckReaction =
-    (normalizedAckReaction === "emoji" || normalizedAckReaction === "kaomoji")
-    && shouldAttachAckReaction;
-  const runtimeEvents = (rt as typeof rt & {
-    events?: {
-      onAgentEvent?: (listener: (event: unknown) => void) => (() => void);
-    };
-  }).events;
+    (normalizedAckReaction === "emoji" || normalizedAckReaction === "kaomoji") &&
+    shouldAttachAckReaction;
+  const runtimeEvents = (
+    rt as typeof rt & {
+      events?: {
+        onAgentEvent?: (listener: (event: unknown) => void) => () => void;
+      };
+    }
+  ).events;
   const releaseSessionLock = await acquireSessionLock(route.sessionKey);
   const dynamicAckReactionController = createDynamicAckReactionController({
     enabled: shouldTrackDynamicAckReaction,
@@ -1856,15 +1923,15 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     }
     const isCurrentCardStopRequested = () =>
       Boolean(
-        currentAICard
-        && (
-          currentAICard.state === AICardStatus.STOPPED
-          || (currentOutTrackId && isCardRunStopRequested(currentOutTrackId))
-        ),
+        currentAICard &&
+        (currentAICard.state === AICardStatus.STOPPED ||
+          (currentOutTrackId && isCardRunStopRequested(currentOutTrackId))),
       );
 
     if (isCurrentCardStopRequested()) {
-      log?.info?.("[DingTalk][CardStop] Skip dispatch because card was already stopped before session lock was acquired");
+      log?.info?.(
+        "[DingTalk][CardStop] Skip dispatch because card was already stopped before session lock was acquired",
+      );
       return;
     }
 
@@ -1888,9 +1955,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     const taskMeta = {
       model: sessionTaskState?.model,
       effort: sessionTaskState?.effort,
-      elapsedMs: typeof sessionTaskState?.taskStartTime === "number"
-        ? Math.max(0, Date.now() - sessionTaskState.taskStartTime)
-        : undefined,
+      elapsedMs:
+        typeof sessionTaskState?.taskStartTime === "number"
+          ? Math.max(0, Date.now() - sessionTaskState.taskStartTime)
+          : undefined,
       agent: getAgentDisplayName({
         subAgentOptions,
         agentId: route.agentId,
@@ -1934,9 +2002,11 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
           responsePrefix: subAgentOptions?.responsePrefix || "",
           deliver: async (payload: ReplyStreamPayload, info?: ReplyChunkInfo) => {
             if (isCurrentCardStopRequested()) {
-              log?.debug?.("[DingTalk][CardStop] Ignoring reply delivery because stop was already requested");
+              log?.debug?.(
+                "[DingTalk][CardStop] Ignoring reply delivery because stop was already requested",
+              );
               return;
-          }
+            }
             try {
               if (info?.kind === "final") {
                 deliveredFinalCount += 1;
@@ -1975,8 +2045,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
 
       log?.info?.(
         `[DingTalk][Dispatch] completed — deliveredFinalCount=${deliveredFinalCount} ` +
-        `counts.final=${typeof finalCount === "number" ? finalCount : "n/a"} ` +
-        `queuedFinalType=${typeof bufferedFinal}`,
+          `counts.final=${typeof finalCount === "number" ? finalCount : "n/a"} ` +
+          `queuedFinalType=${typeof bufferedFinal}`,
       );
 
       const bufferedFinalPayload =
@@ -1989,7 +2059,9 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       if (deliveredFinalCount === 0 && bufferedFinalPayload) {
         const inlineReplyPayload = parseInlineReplyPayloadText(bufferedFinalPayload.text);
         const mediaUrls = extractMediaUrls(bufferedFinalPayload, inlineReplyPayload);
-        const hasBufferedText = typeof bufferedFinalPayload.text === "string" && bufferedFinalPayload.text.trim().length > 0;
+        const hasBufferedText =
+          typeof bufferedFinalPayload.text === "string" &&
+          bufferedFinalPayload.text.trim().length > 0;
         if (hasBufferedText || mediaUrls.length > 0) {
           await strategy.deliver({
             text: inlineReplyPayload.text,
@@ -2001,7 +2073,8 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         }
       }
     } catch (dispatchErr: unknown) {
-      const error = dispatchErr instanceof Error ? dispatchErr : new Error(getErrorMessage(dispatchErr));
+      const error =
+        dispatchErr instanceof Error ? dispatchErr : new Error(getErrorMessage(dispatchErr));
       await strategy.abort(error);
       throw dispatchErr;
     }

--- a/src/message-context-store.ts
+++ b/src/message-context-store.ts
@@ -11,8 +11,17 @@ export const DEFAULT_CREATED_AT_MATCH_WINDOW_MS = 2000;
 const MAX_RECORDS_PER_SCOPE = 1000;
 
 export type MessageContextDirection = "inbound" | "outbound";
-export type MessageAliasKind = "inboundMsgId" | "messageId" | "processQueryKey" | "outTrackId" | "cardInstanceId";
-export type MessageDeliveryKind = "session" | "proactive-text" | "proactive-card" | "proactive-media";
+export type MessageAliasKind =
+  | "inboundMsgId"
+  | "messageId"
+  | "processQueryKey"
+  | "outTrackId"
+  | "cardInstanceId";
+export type MessageDeliveryKind =
+  | "session"
+  | "proactive-text"
+  | "proactive-card"
+  | "proactive-media";
 export const DEFAULT_OUTBOUND_SENDER = {
   senderId: "bot",
   senderName: "OpenClaw",
@@ -47,6 +56,7 @@ export interface MessageRecord {
   quotedMessageId?: string;
   media?: {
     downloadCode?: string;
+    downloadCodes?: string[];
     spaceId?: string;
     fileId?: string;
   };
@@ -96,6 +106,7 @@ interface BaseUpsertParams {
   quotedMessageId?: string;
   media?: {
     downloadCode?: string;
+    downloadCodes?: string[];
     spaceId?: string;
     fileId?: string;
   };
@@ -120,7 +131,11 @@ interface ScopeParams {
 const stateCache = new Map<string, MessageContextState>();
 
 function getScopeKey(params: ScopeParams): string {
-  return JSON.stringify([params.storePath || "__memory__", params.accountId, params.conversationId || null]);
+  return JSON.stringify([
+    params.storePath || "__memory__",
+    params.accountId,
+    params.conversationId || null,
+  ]);
 }
 
 function fallbackState(): MessageContextState {
@@ -145,19 +160,26 @@ function normalizeMedia(value: unknown): MessageRecord["media"] | undefined {
   if (!candidate) {
     return undefined;
   }
-  const downloadCode = typeof candidate.downloadCode === "string" && candidate.downloadCode.trim()
-    ? candidate.downloadCode.trim()
-    : undefined;
-  const spaceId = typeof candidate.spaceId === "string" && candidate.spaceId.trim()
-    ? candidate.spaceId.trim()
-    : undefined;
-  const fileId = typeof candidate.fileId === "string" && candidate.fileId.trim()
-    ? candidate.fileId.trim()
-    : undefined;
-  if (!downloadCode && !spaceId && !fileId) {
+  const downloadCode =
+    typeof candidate.downloadCode === "string" && candidate.downloadCode.trim()
+      ? candidate.downloadCode.trim()
+      : undefined;
+  const downloadCodes =
+    Array.isArray(candidate.downloadCodes) && candidate.downloadCodes.length > 0
+      ? candidate.downloadCodes.filter((c: unknown) => typeof c === "string" && c.trim())
+      : undefined;
+  const spaceId =
+    typeof candidate.spaceId === "string" && candidate.spaceId.trim()
+      ? candidate.spaceId.trim()
+      : undefined;
+  const fileId =
+    typeof candidate.fileId === "string" && candidate.fileId.trim()
+      ? candidate.fileId.trim()
+      : undefined;
+  if (!downloadCode && (!downloadCodes || downloadCodes.length === 0) && !spaceId && !fileId) {
     return undefined;
   }
-  return { downloadCode, spaceId, fileId };
+  return { downloadCode, downloadCodes, spaceId, fileId };
 }
 
 function normalizeQuotedRef(value: unknown): QuotedRef | undefined {
@@ -180,7 +202,9 @@ function normalizeQuotedRef(value: unknown): QuotedRef | undefined {
       ? candidate.key
       : undefined;
   const valueString =
-    typeof candidate.value === "string" && candidate.value.trim() ? candidate.value.trim() : undefined;
+    typeof candidate.value === "string" && candidate.value.trim()
+      ? candidate.value.trim()
+      : undefined;
   const fallbackCreatedAt =
     typeof candidate.fallbackCreatedAt === "number" && Number.isFinite(candidate.fallbackCreatedAt)
       ? candidate.fallbackCreatedAt
@@ -213,21 +237,26 @@ function normalizeDelivery(value: unknown): MessageRecord["delivery"] | undefine
   if (!candidate) {
     return undefined;
   }
-  const messageId = typeof candidate.messageId === "string" && candidate.messageId.trim()
-    ? candidate.messageId.trim()
-    : undefined;
-  const processQueryKey = typeof candidate.processQueryKey === "string" && candidate.processQueryKey.trim()
-    ? candidate.processQueryKey.trim()
-    : undefined;
-  const outTrackId = typeof candidate.outTrackId === "string" && candidate.outTrackId.trim()
-    ? candidate.outTrackId.trim()
-    : undefined;
-  const cardInstanceId = typeof candidate.cardInstanceId === "string" && candidate.cardInstanceId.trim()
-    ? candidate.cardInstanceId.trim()
-    : undefined;
-  const kind = typeof candidate.kind === "string" && candidate.kind.trim()
-    ? (candidate.kind.trim() as MessageDeliveryKind)
-    : undefined;
+  const messageId =
+    typeof candidate.messageId === "string" && candidate.messageId.trim()
+      ? candidate.messageId.trim()
+      : undefined;
+  const processQueryKey =
+    typeof candidate.processQueryKey === "string" && candidate.processQueryKey.trim()
+      ? candidate.processQueryKey.trim()
+      : undefined;
+  const outTrackId =
+    typeof candidate.outTrackId === "string" && candidate.outTrackId.trim()
+      ? candidate.outTrackId.trim()
+      : undefined;
+  const cardInstanceId =
+    typeof candidate.cardInstanceId === "string" && candidate.cardInstanceId.trim()
+      ? candidate.cardInstanceId.trim()
+      : undefined;
+  const kind =
+    typeof candidate.kind === "string" && candidate.kind.trim()
+      ? (candidate.kind.trim() as MessageDeliveryKind)
+      : undefined;
   if (!messageId && !processQueryKey && !outTrackId && !cardInstanceId && !kind) {
     return undefined;
   }
@@ -248,30 +277,46 @@ function normalizeMessageRecord(value: unknown): MessageRecord | null {
   if (!candidate) {
     return null;
   }
-  const msgId = typeof candidate.msgId === "string" && candidate.msgId.trim() ? candidate.msgId.trim() : "";
-  const direction = candidate.direction === "outbound" ? "outbound" : candidate.direction === "inbound" ? "inbound" : null;
-  const accountId = typeof candidate.accountId === "string" && candidate.accountId.trim()
-    ? candidate.accountId.trim()
-    : "";
-  const conversationId = typeof candidate.conversationId === "string" && candidate.conversationId.trim()
-    ? candidate.conversationId.trim()
-    : null;
-  const createdAt = typeof candidate.createdAt === "number" && Number.isFinite(candidate.createdAt)
-    ? candidate.createdAt
-    : NaN;
-  const updatedAt = typeof candidate.updatedAt === "number" && Number.isFinite(candidate.updatedAt)
-    ? candidate.updatedAt
-    : Date.now();
+  const msgId =
+    typeof candidate.msgId === "string" && candidate.msgId.trim() ? candidate.msgId.trim() : "";
+  const direction =
+    candidate.direction === "outbound"
+      ? "outbound"
+      : candidate.direction === "inbound"
+        ? "inbound"
+        : null;
+  const accountId =
+    typeof candidate.accountId === "string" && candidate.accountId.trim()
+      ? candidate.accountId.trim()
+      : "";
+  const conversationId =
+    typeof candidate.conversationId === "string" && candidate.conversationId.trim()
+      ? candidate.conversationId.trim()
+      : null;
+  const createdAt =
+    typeof candidate.createdAt === "number" && Number.isFinite(candidate.createdAt)
+      ? candidate.createdAt
+      : NaN;
+  const updatedAt =
+    typeof candidate.updatedAt === "number" && Number.isFinite(candidate.updatedAt)
+      ? candidate.updatedAt
+      : Date.now();
   if (!msgId || !direction || !accountId || !Number.isFinite(createdAt)) {
     return null;
   }
-  const expiresAt = typeof candidate.expiresAt === "number" && Number.isFinite(candidate.expiresAt)
-    ? candidate.expiresAt
-    : undefined;
+  const expiresAt =
+    typeof candidate.expiresAt === "number" && Number.isFinite(candidate.expiresAt)
+      ? candidate.expiresAt
+      : undefined;
   return {
     msgId,
     direction,
-    topic: candidate.topic === null ? null : typeof candidate.topic === "string" ? candidate.topic : null,
+    topic:
+      candidate.topic === null
+        ? null
+        : typeof candidate.topic === "string"
+          ? candidate.topic
+          : null,
     accountId,
     conversationId,
     createdAt,
@@ -279,16 +324,26 @@ function normalizeMessageRecord(value: unknown): MessageRecord | null {
     expiresAt,
     messageType: typeof candidate.messageType === "string" ? candidate.messageType : undefined,
     text: typeof candidate.text === "string" ? candidate.text : undefined,
-    attachmentText: typeof candidate.attachmentText === "string" ? candidate.attachmentText : undefined,
+    attachmentText:
+      typeof candidate.attachmentText === "string" ? candidate.attachmentText : undefined,
     attachmentTextSource: normalizeAttachmentTextSource(candidate.attachmentTextSource),
     attachmentTextTruncated: candidate.attachmentTextTruncated === true ? true : undefined,
     attachmentFileName:
       typeof candidate.attachmentFileName === "string" ? candidate.attachmentFileName : undefined,
     quotedRef: normalizeQuotedRef(candidate.quotedRef),
-    senderId: typeof candidate.senderId === "string" && candidate.senderId.trim() ? candidate.senderId.trim() : undefined,
-    senderName: typeof candidate.senderName === "string" && candidate.senderName.trim() ? candidate.senderName.trim() : undefined,
+    senderId:
+      typeof candidate.senderId === "string" && candidate.senderId.trim()
+        ? candidate.senderId.trim()
+        : undefined,
+    senderName:
+      typeof candidate.senderName === "string" && candidate.senderName.trim()
+        ? candidate.senderName.trim()
+        : undefined,
     mentions: normalizeMentions(candidate.mentions),
-    chatType: candidate.chatType === "direct" || candidate.chatType === "group" ? candidate.chatType : undefined,
+    chatType:
+      candidate.chatType === "direct" || candidate.chatType === "group"
+        ? candidate.chatType
+        : undefined,
     quotedMessageId:
       typeof candidate.quotedMessageId === "string" && candidate.quotedMessageId.trim()
         ? candidate.quotedMessageId.trim()
@@ -327,10 +382,17 @@ function buildAliasEntries(record: MessageRecord): Array<[string, string]> {
 }
 
 function isRecordExpired(record: MessageRecord, nowMs: number): boolean {
-  return typeof record.expiresAt === "number" && Number.isFinite(record.expiresAt) && nowMs >= record.expiresAt;
+  return (
+    typeof record.expiresAt === "number" &&
+    Number.isFinite(record.expiresAt) &&
+    nowMs >= record.expiresAt
+  );
 }
 
-function normalizeState(state: MessageContextState, nowMs: number): { state: MessageContextState; removed: number } {
+function normalizeState(
+  state: MessageContextState,
+  nowMs: number,
+): { state: MessageContextState; removed: number } {
   const normalizedRecords: Record<string, MessageRecord> = {};
   const sortedRecords = Object.values(state.records)
     .map((record) => normalizeMessageRecord(record))
@@ -363,12 +425,15 @@ function hydrateState(params: ScopeParams, nowMs: number): MessageContextState {
   if (!params.storePath) {
     return fallbackState();
   }
-  const persisted = readNamespaceJson<Partial<PersistedMessageContextState>>(MESSAGE_CONTEXT_NAMESPACE, {
-    storePath: params.storePath,
-    scope: { accountId: params.accountId, conversationId: params.conversationId || undefined },
-    format: "json",
-    fallback: { version: MESSAGE_CONTEXT_VERSION, updatedAt: Date.now(), records: {} },
-  });
+  const persisted = readNamespaceJson<Partial<PersistedMessageContextState>>(
+    MESSAGE_CONTEXT_NAMESPACE,
+    {
+      storePath: params.storePath,
+      scope: { accountId: params.accountId, conversationId: params.conversationId || undefined },
+      format: "json",
+      fallback: { version: MESSAGE_CONTEXT_VERSION, updatedAt: Date.now(), records: {} },
+    },
+  );
   const parsedRecords = asRecord(persisted.records) || {};
   const hydrated = fallbackState();
   hydrated.updatedAt = typeof persisted.updatedAt === "number" ? persisted.updatedAt : Date.now();
@@ -426,14 +491,20 @@ function mergeText(existing: string | undefined, next: string | undefined): stri
   return next;
 }
 
-function mergeAttachmentText(existing: string | undefined, next: string | undefined): string | undefined {
+function mergeAttachmentText(
+  existing: string | undefined,
+  next: string | undefined,
+): string | undefined {
   if (typeof next !== "string") {
     return existing;
   }
   return next;
 }
 
-function mergeQuotedRef(existing: QuotedRef | undefined, next: QuotedRef | undefined): QuotedRef | undefined {
+function mergeQuotedRef(
+  existing: QuotedRef | undefined,
+  next: QuotedRef | undefined,
+): QuotedRef | undefined {
   if (!existing) {
     return next;
   }
@@ -448,14 +519,20 @@ function mergeQuotedRef(existing: QuotedRef | undefined, next: QuotedRef | undef
   };
 }
 
-function mergeStringField(existing: string | undefined, next: string | undefined): string | undefined {
+function mergeStringField(
+  existing: string | undefined,
+  next: string | undefined,
+): string | undefined {
   if (typeof next !== "string" || !next.trim()) {
     return existing;
   }
   return next.trim();
 }
 
-function mergeMentions(existing: string[] | undefined, next: string[] | undefined): string[] | undefined {
+function mergeMentions(
+  existing: string[] | undefined,
+  next: string[] | undefined,
+): string[] | undefined {
   if (!next) {
     return existing;
   }
@@ -474,6 +551,7 @@ function mergeMedia(
   }
   return {
     downloadCode: next.downloadCode || existing.downloadCode,
+    downloadCodes: next.downloadCodes || existing.downloadCodes,
     spaceId: next.spaceId || existing.spaceId,
     fileId: next.fileId || existing.fileId,
   };
@@ -512,7 +590,10 @@ function mergeAttachmentTextTruncated(
   return next === undefined ? existing : next;
 }
 
-function mergeAttachmentFileName(existing: string | undefined, next: string | undefined): string | undefined {
+function mergeAttachmentFileName(
+  existing: string | undefined,
+  next: string | undefined,
+): string | undefined {
   if (typeof next !== "string") {
     return existing;
   }
@@ -521,7 +602,11 @@ function mergeAttachmentFileName(existing: string | undefined, next: string | un
 
 function resolveExistingMsgId(
   state: MessageContextState,
-  params: { direction: MessageContextDirection; msgId?: string; delivery?: MessageRecord["delivery"] },
+  params: {
+    direction: MessageContextDirection;
+    msgId?: string;
+    delivery?: MessageRecord["delivery"];
+  },
   nowMs: number,
 ): string | undefined {
   if (params.direction === "inbound" && params.msgId) {
@@ -556,11 +641,19 @@ function resolveExistingMsgId(
   return undefined;
 }
 
-function computeExpiresAt(nowMs: number, ttlMs?: number, ttlReferenceMs?: number): number | undefined {
+function computeExpiresAt(
+  nowMs: number,
+  ttlMs?: number,
+  ttlReferenceMs?: number,
+): number | undefined {
   if (typeof ttlMs !== "number" || !Number.isFinite(ttlMs) || ttlMs <= 0) {
     return undefined;
   }
-  return (typeof ttlReferenceMs === "number" && Number.isFinite(ttlReferenceMs) ? ttlReferenceMs : nowMs) + ttlMs;
+  return (
+    (typeof ttlReferenceMs === "number" && Number.isFinite(ttlReferenceMs)
+      ? ttlReferenceMs
+      : nowMs) + ttlMs
+  );
 }
 
 function pruneStateByCreatedAt(
@@ -622,11 +715,15 @@ function upsertRecord(
   if (params.cleanupCreatedAtTtlDays && params.cleanupCreatedAtTtlDays > 0) {
     state = pruneStateByCreatedAt(state, params.cleanupCreatedAtTtlDays, nowMs).state;
   }
-  const existingMsgId = resolveExistingMsgId(state, {
-    direction: params.direction,
-    msgId: params.msgId,
-    delivery: params.delivery,
-  }, nowMs);
+  const existingMsgId = resolveExistingMsgId(
+    state,
+    {
+      direction: params.direction,
+      msgId: params.msgId,
+      delivery: params.delivery,
+    },
+    nowMs,
+  );
   const canonicalMsgId =
     existingMsgId ||
     params.msgId ||
@@ -648,9 +745,7 @@ function upsertRecord(
     createdAt: existing?.createdAt ?? params.createdAt,
     updatedAt: nowMs,
     expiresAt:
-      expiresAt === undefined
-        ? existing?.expiresAt
-        : Math.max(expiresAt, existing?.expiresAt ?? 0),
+      expiresAt === undefined ? existing?.expiresAt : Math.max(expiresAt, existing?.expiresAt ?? 0),
     messageType: params.messageType || existing?.messageType,
     text: mergeText(existing?.text, params.text),
     attachmentText: mergeAttachmentText(existing?.attachmentText, params.attachmentText),
@@ -692,7 +787,9 @@ export function upsertInboundMessageContext(params: UpsertInboundMessageContextP
   );
 }
 
-export function upsertOutboundMessageContext(params: UpsertOutboundMessageContextParams): string | undefined {
+export function upsertOutboundMessageContext(
+  params: UpsertOutboundMessageContextParams,
+): string | undefined {
   return upsertRecord({
     ...params,
     direction: "outbound",
@@ -780,7 +877,10 @@ export function resolveByQuotedRef(
       `[DingTalk][QuotedRef] Resolve outbound by ${quotedRef.key}=${quotedRef.value} hit=no accountId=${params.accountId} conversationId=${params.conversationId || "(none)"}`,
     );
   }
-  if (typeof quotedRef.fallbackCreatedAt === "number" && Number.isFinite(quotedRef.fallbackCreatedAt)) {
+  if (
+    typeof quotedRef.fallbackCreatedAt === "number" &&
+    Number.isFinite(quotedRef.fallbackCreatedAt)
+  ) {
     const record = resolveByCreatedAtWindow({
       ...params,
       createdAt: quotedRef.fallbackCreatedAt,
@@ -828,9 +928,7 @@ export function resolveByCreatedAtWindow(
   return bestRecord;
 }
 
-export function cleanupExpiredMessageContexts(
-  params: ScopeParams & { nowMs?: number },
-): number {
+export function cleanupExpiredMessageContexts(params: ScopeParams & { nowMs?: number }): number {
   const nowMs = params.nowMs ?? Date.now();
   const state = loadState(params, nowMs);
   const beforeCount = Object.keys(state.records).length;
@@ -850,12 +948,12 @@ export function clearMessageContextCacheForTest(): void {
 /**
  * Lists non-expired message-context records for one account/conversation scope in createdAt ascending order.
  */
-export function listMessageContexts(
-  params: ScopeParams & { nowMs?: number },
-): MessageRecord[] {
+export function listMessageContexts(params: ScopeParams & { nowMs?: number }): MessageRecord[] {
   const nowMs = params.nowMs ?? Date.now();
   const state = loadState(params, nowMs);
   return state.recentByCreatedAt
     .map((msgId) => state.records[msgId])
-    .filter((record): record is MessageRecord => Boolean(record) && !isRecordExpired(record, nowMs));
+    .filter(
+      (record): record is MessageRecord => Boolean(record) && !isRecordExpired(record, nowMs),
+    );
 }

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -158,11 +158,36 @@ export async function dispatchSubAgents(params: {
   const { matchedAgents, cfg, accountId, data, dingtalkConfig, sessionWebhook, extractedContent, handleMessage, downloadMedia: download, log } = params;
 
   // Pre-download media once to avoid duplication across sub-agents
-  let preDownloadedMedia: { mediaPath?: string; mediaType?: string } | undefined;
-  if (extractedContent.mediaPath && resolveRobotCode(dingtalkConfig)) {
-    const media = await download(dingtalkConfig, extractedContent.mediaPath, log);
-    if (media) {
-      preDownloadedMedia = { mediaPath: media.path, mediaType: media.mimeType };
+  let preDownloadedMedia: {
+    mediaPath?: string;
+    mediaType?: string;
+    mediaPaths?: string[];
+    mediaTypes?: string[];
+  } | undefined;
+  const robotCode = resolveRobotCode(dingtalkConfig);
+  if (robotCode) {
+    const downloadCodes =
+      extractedContent.mediaPaths && extractedContent.mediaPaths.length > 0
+        ? extractedContent.mediaPaths
+        : extractedContent.mediaPath
+          ? [extractedContent.mediaPath]
+          : [];
+    const mediaPaths: string[] = [];
+    const mediaTypes: string[] = [];
+    for (const downloadCode of downloadCodes) {
+      const media = await download(dingtalkConfig, downloadCode, log);
+      if (media) {
+        mediaPaths.push(media.path);
+        mediaTypes.push(media.mimeType);
+      }
+    }
+    if (mediaPaths.length > 0) {
+      preDownloadedMedia = {
+        mediaPath: mediaPaths[0],
+        mediaType: mediaTypes[0],
+        mediaPaths,
+        mediaTypes,
+      };
     }
   }
   let helperMissingWarningSent = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,14 +10,11 @@
  */
 
 import type {
-  ChannelPlugin as SDKChannelPlugin,
-  OpenClawConfig,
-} from "openclaw/plugin-sdk/core";
-import type {
   ChannelAccountSnapshot as SDKChannelAccountSnapshot,
   ChannelGatewayContext as SDKChannelGatewayContext,
   ChannelLogSink as SDKChannelLogSink,
 } from "openclaw/plugin-sdk/channel-runtime";
+import type { ChannelPlugin as SDKChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
 
 export type AckReactionMode = "off" | "emoji" | "kaomoji";
@@ -50,7 +47,10 @@ export interface DingTalkConfig extends OpenClawConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   // Connection robustness configuration
   maxConnectionAttempts?: number;
@@ -128,7 +128,10 @@ export interface DingTalkChannelConfig {
   cardTemplateId?: string;
   /** @deprecated 已固定使用内置模板契约 */
   cardTemplateKey?: string;
-  groups?: Record<string, { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }>;
+  groups?: Record<
+    string,
+    { systemPrompt?: string; requireMention?: boolean; groupAllowFrom?: string[] }
+  >;
   accounts?: Record<string, DingTalkConfig>;
   maxConnectionAttempts?: number;
   initialReconnectDelay?: number;
@@ -306,7 +309,12 @@ export interface DingTalkInboundMessage {
   sessionWebhook: string;
 }
 
-export type QuotedRefKey = "msgId" | "processQueryKey" | "messageId" | "outTrackId" | "cardInstanceId";
+export type QuotedRefKey =
+  | "msgId"
+  | "processQueryKey"
+  | "messageId"
+  | "outTrackId"
+  | "cardInstanceId";
 
 export type AttachmentTextSource = "text" | "html" | "pdf" | "docx";
 
@@ -646,7 +654,9 @@ export interface DingTalkOutboundHandler {
   deliveryMode: "direct" | "queued" | "batch";
   resolveTarget: (params: ResolveTargetParams) => TargetResolutionResult;
   sendText: (params: SendTextParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
-  sendMedia?: (params: SendMediaParams) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
+  sendMedia?: (
+    params: SendMediaParams,
+  ) => Promise<{ ok: boolean; data?: unknown; error?: unknown }>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -468,6 +468,8 @@ export interface HandleDingTalkMessageParams {
   preDownloadedMedia?: {
     mediaPath?: string;
     mediaType?: string;
+    mediaPaths?: string[];
+    mediaTypes?: string[];
   };
 }
 

--- a/tests/unit/inbound-handler-quote-multi-image.test.ts
+++ b/tests/unit/inbound-handler-quote-multi-image.test.ts
@@ -1,0 +1,411 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DingTalkConfig } from "../../src/types";
+
+const shared = vi.hoisted(() => ({
+  getRuntimeMock: vi.fn(),
+  extractMessageContentMock: vi.fn(),
+  extractAttachmentTextMock: vi.fn(),
+  downloadGroupFileMock: vi.fn(),
+  getUnionIdByStaffIdMock: vi.fn(),
+  resolveQuotedFileMock: vi.fn(),
+  createAICardMock: vi.fn(),
+  isCardInTerminalStateMock: vi.fn(),
+  commitAICardBlocksMock: vi.fn(),
+  sendBySessionMock: vi.fn(),
+  sendMessageMock: vi.fn(),
+  acquireSessionLockMock: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    isAxiosError: (err: unknown) =>
+      Boolean((err as { isAxiosError?: boolean })?.isAxiosError),
+  },
+  isAxiosError: (err: unknown) =>
+    Boolean((err as { isAxiosError?: boolean })?.isAxiosError),
+}));
+
+vi.mock("../../src/auth", () => ({
+  getAccessToken: vi.fn().mockResolvedValue("token_test"),
+}));
+
+vi.mock("../../src/runtime", () => ({
+  getDingTalkRuntime: shared.getRuntimeMock,
+}));
+
+vi.mock("../../src/message-utils", () => ({
+  extractMessageContent: shared.extractMessageContentMock,
+}));
+
+vi.mock("../../src/messaging/attachment-text-extractor", () => ({
+  extractAttachmentText: shared.extractAttachmentTextMock,
+}));
+
+vi.mock("../../src/messaging/quoted-file-service", () => ({
+  downloadGroupFile: shared.downloadGroupFileMock,
+  getUnionIdByStaffId: shared.getUnionIdByStaffIdMock,
+  resolveQuotedFile: shared.resolveQuotedFileMock,
+}));
+
+vi.mock("../../src/card-service", () => ({
+  createAICard: shared.createAICardMock,
+  commitAICardBlocks: shared.commitAICardBlocksMock,
+  isCardInTerminalState: shared.isCardInTerminalStateMock,
+}));
+
+vi.mock("../../src/send-service", () => ({
+  sendBySession: shared.sendBySessionMock,
+  sendMessage: shared.sendMessageMock,
+}));
+
+vi.mock("../../src/session-lock", () => ({
+  acquireSessionLock: shared.acquireSessionLockMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
+  isAbortRequestText: vi.fn().mockReturnValue(false),
+  isBtwRequestText: vi.fn().mockReturnValue(false),
+}));
+
+// message-context-store: spy on the actual implementation
+vi.mock("../../src/message-context-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../src/message-context-store")
+  >("../../src/message-context-store");
+  return {
+    ...actual,
+    upsertInboundMessageContext: vi.fn(actual.upsertInboundMessageContext),
+    resolveByMsgId: vi.fn(actual.resolveByMsgId),
+    clearMessageContextCacheForTest: vi.fn(actual.clearMessageContextCacheForTest),
+  };
+});
+
+import { handleDingTalkMessage } from "../../src/inbound-handler";
+import * as messageContextStore from "../../src/message-context-store";
+import { clearCardRunRegistryForTest } from "../../src/card/card-run-registry";
+import { clearTargetDirectoryStateCache } from "../../src/targeting/target-directory-store";
+
+const mockedAxiosPost = vi.mocked(axios.post);
+const mockedAxiosGet = vi.mocked(axios.get);
+const mockedUpsertInboundMessageContext = vi.mocked(
+  messageContextStore.upsertInboundMessageContext,
+);
+const TEST_TMP_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), "dingtalk-multi-image-quote-"),
+);
+const STORE_PATH = path.join(TEST_TMP_DIR, "store.json");
+const ACCOUNT_STORE_PATH = path.join(TEST_TMP_DIR, "account-store.json");
+
+function buildRuntime() {
+  return {
+    channel: {
+      routing: {
+        resolveAgentRoute: vi
+          .fn()
+          .mockReturnValue({
+            agentId: "main",
+            sessionKey: "s1",
+            mainSessionKey: "s1",
+          }),
+        buildAgentSessionKey: vi.fn().mockReturnValue("agent-session-key"),
+      },
+      media: {
+        saveMediaBuffer: vi.fn().mockImplementation(
+          (_buf: Buffer, contentType: string, _dir: string, _maxBytes?: number, originalFilename?: string) => {
+            const filename =
+              originalFilename || `media-${Math.random().toString(36).slice(2)}`;
+            return Promise.resolve({
+              path: `/tmp/.openclaw/media/inbound/${filename}`,
+              contentType,
+            });
+          },
+        ),
+      },
+      session: {
+        resolveStorePath: vi.fn().mockReturnValue(STORE_PATH),
+        readSessionUpdatedAt: vi.fn().mockReturnValue(null),
+        recordInboundSession: vi.fn().mockResolvedValue(undefined),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
+        formatInboundEnvelope: vi.fn().mockReturnValue("body"),
+        finalizeInboundContext: vi
+          .fn()
+          .mockReturnValue({ SessionKey: "s1" }),
+        dispatchReplyWithBufferedBlockDispatcher: vi
+          .fn()
+          .mockResolvedValue({ queuedFinal: "final" }),
+      },
+    },
+  };
+}
+
+function mockDingTalkDownloadSuccess(downloadUrl = "https://dl.example.com/file") {
+  mockedAxiosPost.mockResolvedValueOnce({
+    data: { downloadUrl },
+  } as any);
+  mockedAxiosGet.mockResolvedValueOnce({
+    data: Buffer.from("fake-image-data"),
+    headers: { "content-type": "image/webp" },
+  } as any);
+}
+
+describe("inbound-handler multi-image quote recovery", () => {
+  beforeEach(() => {
+    clearTargetDirectoryStateCache();
+    clearCardRunRegistryForTest();
+    const stateDir = path.join(TEST_TMP_DIR, "dingtalk-state");
+    try {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+    messageContextStore.clearMessageContextCacheForTest();
+
+    shared.getRuntimeMock.mockReset();
+    shared.extractMessageContentMock.mockReset();
+    shared.extractAttachmentTextMock.mockReset();
+    shared.extractAttachmentTextMock.mockResolvedValue(null);
+    shared.downloadGroupFileMock.mockReset();
+    shared.downloadGroupFileMock.mockResolvedValue(null);
+    shared.getUnionIdByStaffIdMock.mockReset();
+    shared.getUnionIdByStaffIdMock.mockResolvedValue("union_1");
+    shared.resolveQuotedFileMock.mockReset();
+    shared.resolveQuotedFileMock.mockResolvedValue(null);
+    shared.createAICardMock.mockReset();
+    shared.createAICardMock.mockResolvedValue({
+      cardInstanceId: "card_1",
+      outTrackId: "track_1",
+    } as any);
+    shared.isCardInTerminalStateMock.mockReset();
+    shared.isCardInTerminalStateMock.mockReturnValue(false);
+    shared.commitAICardBlocksMock.mockReset();
+    shared.commitAICardBlocksMock.mockResolvedValue(undefined);
+    shared.sendBySessionMock.mockReset();
+    shared.sendBySessionMock.mockResolvedValue({ ok: true } as any);
+    shared.sendMessageMock.mockReset();
+    shared.sendMessageMock.mockResolvedValue({ ok: true } as any);
+    shared.acquireSessionLockMock.mockReset();
+    shared.acquireSessionLockMock.mockResolvedValue(() => Promise.resolve());
+
+    mockedAxiosPost.mockReset();
+    mockedAxiosGet.mockReset();
+  });
+
+  it("persists all downloadCodes for multi-image richText", async () => {
+    const runtime = buildRuntime();
+    runtime.channel.session.resolveStorePath = vi
+      .fn()
+      .mockReturnValue(ACCOUNT_STORE_PATH);
+    shared.getRuntimeMock.mockReturnValue(runtime);
+
+    // Multi-image richText: 2 images
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "<media:image>",
+      messageType: "richText",
+      mediaPath: "dl_pic_1",
+      mediaPaths: ["dl_pic_1", "dl_pic_2"],
+      mediaType: "image",
+    });
+
+    // Mock both downloads
+    mockDingTalkDownloadSuccess("https://dl.example.com/img1");
+    mockDingTalkDownloadSuccess("https://dl.example.com/img2");
+
+    const now = Date.now();
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        messageType: "markdown",
+        clientId: "robot_1",
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m_multi_img_1",
+        msgtype: "richText",
+        text: { content: "<media:image>" },
+        conversationType: "1",
+        conversationId: "cid_multi",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: now,
+      },
+    } as unknown as { data: unknown });
+
+    // Verify upsertInboundMessageContext was called with downloadCodes (media cache call)
+    const mediaCacheCalls = mockedUpsertInboundMessageContext.mock.calls.filter(
+      (call) => call[0]?.media?.downloadCode,
+    );
+    expect(mediaCacheCalls.length).toBeGreaterThanOrEqual(1);
+
+    const mediaCacheCall = mediaCacheCalls[0]![0]!;
+    expect(mediaCacheCall.media?.downloadCode).toBe("dl_pic_1");
+    expect(mediaCacheCall.media?.downloadCodes).toEqual(["dl_pic_1", "dl_pic_2"]);
+  });
+
+  it("does not store downloadCodes for single-image messages", async () => {
+    const runtime = buildRuntime();
+    runtime.channel.session.resolveStorePath = vi
+      .fn()
+      .mockReturnValue(ACCOUNT_STORE_PATH);
+    shared.getRuntimeMock.mockReturnValue(runtime);
+
+    // Single image message
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "<media:image>",
+      messageType: "picture",
+      mediaPath: "dl_single",
+      mediaType: "image",
+    });
+
+    mockDingTalkDownloadSuccess("https://dl.example.com/single");
+
+    const now = Date.now();
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        messageType: "markdown",
+        clientId: "robot_1",
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m_single_img",
+        msgtype: "picture",
+        text: { content: "<media:image>" },
+        conversationType: "1",
+        conversationId: "cid_single",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: now,
+      },
+    } as unknown as { data: unknown });
+
+    const mediaCacheCalls = mockedUpsertInboundMessageContext.mock.calls.filter(
+      (call) => call[0]?.media?.downloadCode,
+    );
+    expect(mediaCacheCalls.length).toBeGreaterThanOrEqual(1);
+    const mediaCacheCall = mediaCacheCalls[0]![0]!;
+    expect(mediaCacheCall.media?.downloadCode).toBe("dl_single");
+    expect(mediaCacheCall.media?.downloadCodes).toBeUndefined();
+  });
+
+  it("recovers all images from cache when quoting a multi-image richText", async () => {
+    const runtime = buildRuntime();
+    runtime.channel.session.resolveStorePath = vi
+      .fn()
+      .mockReturnValue(ACCOUNT_STORE_PATH);
+    shared.getRuntimeMock.mockReturnValue(runtime);
+
+    // --- Step 1: Send a multi-image richText to populate the cache ---
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "<media:image>",
+      messageType: "richText",
+      mediaPath: "dl_pic_1",
+      mediaPaths: ["dl_pic_1", "dl_pic_2", "dl_pic_3"],
+      mediaType: "image",
+    });
+    mockDingTalkDownloadSuccess("https://dl.example.com/img1");
+    mockDingTalkDownloadSuccess("https://dl.example.com/img2");
+    mockDingTalkDownloadSuccess("https://dl.example.com/img3");
+
+    const now = Date.now();
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        messageType: "markdown",
+        clientId: "robot_1",
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m_multi_orig",
+        msgtype: "richText",
+        text: { content: "<media:image>" },
+        conversationType: "1",
+        conversationId: "cid_quote_test",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: now,
+      },
+    } as unknown as { data: unknown });
+
+    // Clear the mock history so we can assert on the quote call only
+    mockedUpsertInboundMessageContext.mockClear();
+    const finalizeSpy = runtime.channel.reply.finalizeInboundContext as ReturnType<
+      typeof vi.fn
+    >;
+    finalizeSpy.mockClear();
+
+    // --- Step 2: Quote the multi-image message ---
+    // The quoted message is resolved from the cache via resolveByMsgId.
+    // Simulate: the cached record has downloadCodes, and the inbound
+    // quotedRef points to the original msgId.
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "look at these pictures",
+      messageType: "text",
+      quoted: {
+        msgId: "m_multi_orig",
+        previewMessageType: "richText",
+      },
+    });
+
+    // Mock the 3 downloads for the recovery path
+    mockDingTalkDownloadSuccess("https://dl.example.com/recovered1");
+    mockDingTalkDownloadSuccess("https://dl.example.com/recovered2");
+    mockDingTalkDownloadSuccess("https://dl.example.com/recovered3");
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        dmPolicy: "open",
+        messageType: "markdown",
+        clientId: "robot_1",
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m_quote_reply",
+        msgtype: "text",
+        text: { content: "look at these pictures", isReplyMsg: true },
+        originalMsgId: "m_multi_orig",
+        conversationType: "1",
+        conversationId: "cid_quote_test",
+        senderId: "user_2",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: now + 60000,
+      },
+    } as unknown as { data: unknown });
+
+    // Verify finalizeInboundContext received all 3 images
+    const finalizeCalls = finalizeSpy.mock.calls;
+    expect(finalizeCalls.length).toBeGreaterThanOrEqual(1);
+
+    const ctx = finalizeCalls[0]![0] as Record<string, unknown>;
+    expect(ctx.MediaPath).toBeTruthy();
+    expect(Array.isArray(ctx.MediaPaths)).toBe(true);
+    expect((ctx.MediaPaths as string[]).length).toBe(3);
+    expect(Array.isArray(ctx.MediaUrls)).toBe(true);
+    expect((ctx.MediaUrls as string[]).length).toBe(3);
+    expect(Array.isArray(ctx.MediaTypes)).toBe(true);
+    expect((ctx.MediaTypes as string[]).length).toBe(3);
+  });
+});


### PR DESCRIPTION
## 背景

Issue #542: 用户发送包含多张图片的富文本消息时，bot 只收到第一张图片。

解析层 `message-utils.ts` 已正确将多图的 downloadCode 提取到 `content.mediaPaths` 数组，类型定义 `src/types.ts` 也支持 `mediaPaths?: string[]` 和 `mediaTypes?: string[]`。但入站处理层 `inbound-handler.ts` 只使用了 `content.mediaPath`（单数），完全忽略了数组字段。

## 目标

- 下载富文本消息中的所有图片（而非仅第一张）
- 将完整的多媒体路径数组传递给 `finalizeInboundContext`
- 保持向后的单图兼容性

## 实现

`src/inbound-handler.ts` 三处语义变更（其余 diff 为 oxfmt 格式整理）：

1. **新增变量**: `mediaPaths: string[]` 和 `mediaTypes: string[]` 用于收集所有下载结果
2. **遍历下载**: 优先使用 `content.mediaPaths`（richText 多图），fallback 到 `content.mediaPath`（单图/文件等），逐个 `downloadMedia`
3. **传递数组**: 向 `finalizeInboundContext` 新增 `MediaPaths / MediaUrls / MediaTypes` 字段，同时保留 `MediaPath / MediaUrl` 单数字段向后兼容

## 实现 TODO

- [x] 媒体下载部分改为遍历 `content.mediaPaths`
- [x] `finalizeInboundContext` 传入 `MediaPaths / MediaUrls / MediaTypes`
- [x] 保持 `MediaPath` 单数字段不变（向后兼容）
- [x] 预下载媒体路径（sub-agent 场景）同步填充数组
- [x] 单图/文件/音频消息行为不变

## 验证 TODO

- [x] `pnpm run type-check` 通过
- [x] `pnpm run lint` 0 errors（88 pre-existing warnings）
- [x] `pnpm test` 1069/1069 通过（包括已有的 `richText 自身多图时保留首图并暴露 mediaPaths` 单元测试）
- [x] `pnpm test:coverage` 通过
- [x] 真机验证：钉钉富文本多图消息 → bot 收到所有图片

---

*AI-assisted PR，作者已理解并确认所有变更和验证结果*