### PR TITLE
fix(card): finalize proactive cards with block variables

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -647,7 +647,11 @@ export async function sendProactiveCardText(
     if (!card) {
       return { ok: false, error: "Failed to create AI card" };
     }
-    await finishAICard(card, content, log);
+    const blockListJson = JSON.stringify([{ type: 0, markdown: content } satisfies CardBlock]);
+    await commitAICardBlocks(card, {
+      blockListJson,
+      content,
+    }, log);
     return {
       ok: true,
       processQueryKey: card.processQueryKey,

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -767,7 +767,7 @@ describe('card-service', () => {
         expect(mockedAxios.put).not.toHaveBeenCalled();
     });
 
-    it('sendProactiveCardText does not persist pending card state', async () => {
+    it('sendProactiveCardText finalizes proactive cards with V2 block variables without pending state', async () => {
         mockedAxios.post.mockResolvedValueOnce({
             status: 200,
             data: {
@@ -793,8 +793,18 @@ describe('card-service', () => {
             cardInstanceId: 'card_instance_1',
         });
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
-        // 3 PUTs: kick to streaming + content isFinalize=true + hide stop button
-        expect(mockedAxios.put).toHaveBeenCalledTimes(3);
+        const instanceUpdates = mockedAxios.put.mock.calls.filter((call: any[]) =>
+            String(call[0]).endsWith('/v1.0/card/instances')
+        );
+        expect(instanceUpdates).toHaveLength(1);
+        const updateBody = instanceUpdates[0]?.[1];
+        expect(updateBody.outTrackId).toBe('track_card_1');
+        expect(updateBody.cardData?.cardParamMap.flowStatus).toBe('3');
+        expect(updateBody.cardData?.cardParamMap.content).toBe('proactive done');
+        expect(updateBody.cardData?.cardParamMap.copy_content).toBe('proactive done');
+        expect(JSON.parse(updateBody.cardData?.cardParamMap.blockList)).toEqual([
+            { type: 0, markdown: 'proactive done' },
+        ]);
         expect(fs.existsSync(stateFilePath)).toBe(false);
         expect(fs.existsSync(legacyStateFilePath)).toBe(false);
     });


### PR DESCRIPTION
## 背景

Issue #544 反馈钉钉单聊主动推送在 `messageType: card` 下最终显示为空白卡片；本地通过 `openclaw message send --channel dingtalk --target manager8031 ... --json` 已复现：CLI 返回 `payload.ok: true`，但钉钉 App 最终卡片为空。

## 目标

让主动文本卡片与正常回复卡片使用一致的 V2 最终态写入方式，避免 streaming finalize 后最终态缺少 `blockList` 导致空白。

## 实现

- 将 `sendProactiveCardText()` 从旧的 `finishAICard()` streaming finalize 改为调用 `commitAICardBlocks()`。
- 为主动文本构造最小 `blockList`：`[{ type: 0, markdown: content }]`。
- 更新单测，断言主动卡片最终实例更新包含 `blockList`、`content`、`copy_content` 和 `flowStatus=3`，且仍不持久化 pending card。

## 实现 TODO

- [x] 修复主动卡片最终态写入路径
- [x] 补充回归测试覆盖 Issue #544 对应行为

## 验证 TODO

- [x] `pnpm vitest run tests/unit/card-service.test.ts -t "sendProactiveCardText finalizes proactive cards"`
- [x] `pnpm vitest run tests/unit/card-service.test.ts`
- [x] `npm run type-check`
- [x] `pnpm test`（100 files / 1069 tests passed）
- [x] `npm run lint`（退出 0；仓库现有 no-explicit-any/no-base-to-string 警告仍存在，非本 PR 引入）
- [x] 合并前使用当前分支部署到本地 OpenClaw 后，再执行一次钉钉真机主动发送确认最终卡片非空白

Fixes #544