### PR TITLE
fix(card): finalize opened streaming lifecycle

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -216,6 +216,10 @@ export function incrementCardDapiCount(card: AICardInstance): number {
   return next;
 }
 
+function markStreamingLifecycleAcknowledged(card: AICardInstance, finished: boolean): void {
+  card.streamLifecycleOpened = !finished;
+}
+
 function extractCardProcessQueryKey(payload: unknown): string | undefined {
   if (!payload || typeof payload !== "object") {
     return undefined;
@@ -283,6 +287,7 @@ async function putAICardStreamingField(
     );
     card.lastUpdated = Date.now();
     incrementCardDapiCount(card);
+    markStreamingLifecycleAcknowledged(card, finished);
   } catch (err: any) {
     if (err.response?.status === 401 && card.config && !tokenAlreadyRefreshed) {
       log?.warn?.("[DingTalk][AICard] Received 401 error, attempting token refresh and retry...");
@@ -300,6 +305,7 @@ async function putAICardStreamingField(
         );
         card.lastUpdated = Date.now();
         incrementCardDapiCount(card);
+        markStreamingLifecycleAcknowledged(card, finished);
         return;
       } catch (retryErr: any) {
         log?.error?.(`[DingTalk][AICard] Retry after token refresh failed: ${retryErr.message}`);
@@ -355,6 +361,7 @@ interface PendingCardRecord {
   state: string;
   lastContent?: string;
   lastBlockListJson?: string;
+  streamLifecycleOpened?: boolean;
 }
 
 interface PendingCardStateFile {
@@ -467,6 +474,7 @@ function upsertPendingCard(card: AICardInstance, storePath?: string, log?: Logge
     state: card.state,
     lastContent: card.lastStreamedContent,
     lastBlockListJson: card.lastBlockListJson,
+    streamLifecycleOpened: card.streamLifecycleOpened,
   };
   const index = state.pendingCards.findIndex((item) => item.cardInstanceId === card.cardInstanceId);
   if (index >= 0) {
@@ -737,6 +745,7 @@ async function finalizePendingCardsByAccount(
       config,
       lastStreamedContent: entry.lastContent,
       lastBlockListJson: entry.lastBlockListJson,
+      streamLifecycleOpened: entry.streamLifecycleOpened,
     };
     try {
       await finalizeStoppedAICard(card, {
@@ -793,6 +802,7 @@ export async function createAICard(
       [template.streamingKey]: "",
       quoteContent: options.quoteContent || "",
       ...(options.statusLine?.trim() ? { statusLine: options.statusLine } : {}),
+      flowStatus: AICardStatus.INPUTING,
       // V2 template uses hasAction (string), V1 uses stop_action (string)
       // DingTalk cardParamMap requires all values to be strings
       hasAction: String(STOP_ACTION_VISIBLE),
@@ -897,18 +907,6 @@ export async function createAICard(
     }
 
     clearAICardDegrade(accountId, log);
-
-    // Kick the card into streaming mode immediately so the UI shows "输出中" and the
-    // stop button becomes visible. Without this, the card sits in "创建中" skeleton state
-    // until the first real content arrives — which may never happen for non-streaming replies.
-    // This sends an empty content stream (isFull=true, isFinalize=false) which transitions
-    // the card from PROCESSING to INPUTING on the DingTalk side.
-    try {
-      await putAICardStreamingField(aiCardInstance, template.contentKey, "", false, log);
-      aiCardInstance.state = AICardStatus.INPUTING;
-    } catch (kickErr: any) {
-      log?.debug?.(`[DingTalk][AICard] Non-critical: failed to kick card into streaming mode: ${kickErr.message}`);
-    }
 
     return aiCardInstance;
   } catch (err: any) {
@@ -1047,6 +1045,23 @@ export async function clearAICardStreamingContent(
   }
 }
 
+async function finalizeAICardStreamingLifecycleIfNeeded(
+  card: AICardInstance,
+  content: string,
+  log?: Logger,
+): Promise<void> {
+  if (!card.streamLifecycleOpened) {
+    return;
+  }
+  const template = DINGTALK_CARD_TEMPLATE;
+  try {
+    await putAICardStreamingField(card, template.streamingKey, content, true, log);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log?.warn?.(`[DingTalk][AICard] Streaming lifecycle finalize failed; continuing instances finalize: ${message}`);
+  }
+}
+
 /**
  * Options for finalizing an AI Card via instances API.
  * All variables are written in a single API call for V2 template compatibility.
@@ -1082,6 +1097,7 @@ export async function commitAICardBlocks(
   }
 
   await ensureFreshToken(card, log);
+  await finalizeAICardStreamingLifecycleIfNeeded(card, options.content, log);
 
   const template = DINGTALK_CARD_TEMPLATE;
   const updates: Record<string, unknown> = {

--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -796,7 +796,7 @@ export async function createAICard(
     // DingTalk createAndDeliver API payload.
     // Note: do NOT include template.statusKey here — the createAndDeliver API may
     // reject unknown fields if the template variable is not yet provisioned.
-    // Status is set to "streaming" via the streaming API immediately after creation.
+    // flowStatus=2 (INPUTING) is set directly so the card shows "输出中" immediately.
     const cardParamMap = {
       config: JSON.stringify({ autoLayout: true, enableForward: true }),
       [template.streamingKey]: "",

--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -242,6 +242,7 @@ async function putAICardStreamingField(
   content: string,
   finished: boolean,
   log?: Logger,
+  options: { suppressDegrade?: boolean } = {},
 ): Promise<void> {
   const tokenAge = Date.now() - card.createdAt;
   const tokenRefreshThreshold = 90 * 60 * 1000;
@@ -321,7 +322,7 @@ async function putAICardStreamingField(
       }
     }
 
-    if (card.accountId && shouldTriggerAICardDegrade(err)) {
+    if (!options.suppressDegrade && card.accountId && shouldTriggerAICardDegrade(err)) {
       activateAICardDegrade(
         card.accountId,
         `card.stream:${err?.response?.status || "unknown"}`,
@@ -400,7 +401,8 @@ function normalizePendingState(parsed: Partial<PendingCardStateFile>): PendingCa
         (entry.outTrackId === undefined || typeof entry.outTrackId === "string") &&
         typeof entry.conversationId === "string" &&
         (entry.lastContent === undefined || typeof entry.lastContent === "string") &&
-        (entry.lastBlockListJson === undefined || typeof entry.lastBlockListJson === "string"),
+        (entry.lastBlockListJson === undefined || typeof entry.lastBlockListJson === "string") &&
+        (entry.streamLifecycleOpened === undefined || typeof entry.streamLifecycleOpened === "boolean"),
       ),
     ),
   };
@@ -1055,7 +1057,9 @@ async function finalizeAICardStreamingLifecycleIfNeeded(
   }
   const template = DINGTALK_CARD_TEMPLATE;
   try {
-    await putAICardStreamingField(card, template.streamingKey, content, true, log);
+    await putAICardStreamingField(card, template.streamingKey, content, true, log, {
+      suppressDegrade: true,
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     log?.warn?.(`[DingTalk][AICard] Streaming lifecycle finalize failed; continuing instances finalize: ${message}`);
@@ -1391,6 +1395,7 @@ export async function finalizeStoppedAICard(
   await ensureFreshToken(card, log);
   const template = DINGTALK_CARD_TEMPLATE;
   const payload = buildStoppedCardFinalizePayload(options);
+  await finalizeAICardStreamingLifecycleIfNeeded(card, payload.content, log);
   try {
     await updateCardVariables(
       card.outTrackId || card.cardInstanceId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -683,6 +683,8 @@ export interface AICardInstance {
   outTrackId?: string;
   /** Cumulative DingTalk API call count for this card instance. */
   dapiUsage?: number;
+  /** True after this card has successfully opened DingTalk's streaming lifecycle. */
+  streamLifecycleOpened?: boolean;
 }
 
 /**

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -703,6 +703,46 @@ describe('card-service', () => {
         expect(afterRecover.pendingCards).toHaveLength(0);
     });
 
+    it('recovers pending cards by finalizing an opened streaming lifecycle before instances commit', async () => {
+        const pending = {
+            version: 1,
+            updatedAt: Date.now(),
+            pendingCards: [
+                {
+                    accountId: 'main',
+                    cardInstanceId: 'card_recover_stream_1',
+                    outTrackId: 'track_recover_stream_1',
+                    conversationId: 'cid_recover_stream_1',
+                    createdAt: Date.now() - 1000,
+                    lastUpdated: Date.now() - 1000,
+                    state: '2',
+                    lastContent: '流式回答',
+                    lastBlockListJson: JSON.stringify([{ type: 0, markdown: '流式回答' }]),
+                    streamLifecycleOpened: true,
+                },
+            ],
+        };
+        fs.mkdirSync(path.dirname(stateFilePath), { recursive: true });
+        fs.writeFileSync(stateFilePath, JSON.stringify(pending, null, 2));
+        mockedAxios.put.mockResolvedValue({ status: 200, data: { ok: true } });
+
+        const recovered = await recoverPendingCardsForAccount(
+            { clientId: 'id', clientSecret: 'sec', cardTemplateId: 'tmpl.schema' } as any,
+            'main',
+            storePath
+        );
+
+        expect(recovered).toBe(1);
+        expect(mockedAxios.put).toHaveBeenCalledTimes(2);
+        expect(mockedAxios.put.mock.calls[0]?.[0]).toContain('/v1.0/card/streaming');
+        expect(mockedAxios.put.mock.calls[0]?.[1]).toMatchObject({
+            outTrackId: 'track_recover_stream_1',
+            content: expect.stringContaining('流式回答'),
+            isFinalize: true,
+        });
+        expect(mockedAxios.put.mock.calls[1]?.[0]).toContain('/v1.0/card/instances');
+    });
+
     it('finalizeActiveCardsForAccount finalizes pending cards with provided reason', async () => {
         const pending = {
             version: 1,
@@ -1084,6 +1124,34 @@ describe('token refresh', () => {
             isError: false,
         });
         expect(mockedAxios.put.mock.calls[1][0]).toContain('/v1.0/card/instances');
+    });
+
+    it('does not degrade future cards when optional streaming lifecycle finalize fails', async () => {
+        const card = {
+            cardInstanceId: 'card_stream_finalize_failure',
+            outTrackId: 'track_stream_finalize_failure',
+            accessToken: 'current_token',
+            conversationId: 'cid_1',
+            accountId: 'main',
+            state: AICardStatus.INPUTING,
+            createdAt: Date.now(),
+            lastUpdated: Date.now(),
+            config: { clientId: 'id', clientSecret: 'sec', aicardDegradeMs: 120000 } as any,
+            streamLifecycleOpened: true,
+        } as any;
+
+        mockedAxios.put
+            .mockRejectedValueOnce({ response: { status: 500 }, message: 'stream finalize failed' })
+            .mockResolvedValueOnce({ status: 200, data: { ok: true } });
+
+        await commitAICardBlocks(card, {
+            blockListJson: JSON.stringify([{ type: 0, markdown: 'test' }]),
+            content: 'test content',
+        });
+
+        expect(mockedAxios.put).toHaveBeenCalledTimes(2);
+        expect(isAICardDegraded('main')).toBe(false);
+        expect(card.state).toBe(AICardStatus.FINISHED);
     });
 
     it('commits blocks without streaming finalize when streaming lifecycle was not opened', async () => {

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -1085,4 +1085,27 @@ describe('token refresh', () => {
         });
         expect(mockedAxios.put.mock.calls[1][0]).toContain('/v1.0/card/instances');
     });
+
+    it('commits blocks without streaming finalize when streaming lifecycle was not opened', async () => {
+        const card = {
+            cardInstanceId: 'card_no_stream_finalize',
+            outTrackId: 'track_no_stream_finalize',
+            accessToken: 'current_token',
+            conversationId: 'cid_1',
+            state: AICardStatus.PROCESSING,
+            createdAt: Date.now(),
+            lastUpdated: Date.now(),
+            config: { clientId: 'id', clientSecret: 'sec' } as any,
+        } as any;
+
+        mockedAxios.put.mockResolvedValue({ status: 200, data: { ok: true } });
+
+        await commitAICardBlocks(card, {
+            blockListJson: JSON.stringify([{ type: 0, markdown: 'test' }]),
+            content: 'test content',
+        });
+
+        expect(mockedAxios.put).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.put.mock.calls[0][0]).toContain('/v1.0/card/instances');
+    });
 });

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -90,14 +90,15 @@ describe('card-service', () => {
         );
 
         expect(card).toBeTruthy();
-        // Card is kicked into INPUTING (streaming) immediately after creation
-        expect(card?.state).toBe(AICardStatus.INPUTING);
+        expect(card?.state).toBe(AICardStatus.PROCESSING);
         expect(card?.processQueryKey).toBe('carrier_1');
         expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+        expect(mockedAxios.put).not.toHaveBeenCalled();
         const body = mockedAxios.post.mock.calls[0]?.[1];
         expect(body.cardData?.cardParamMap).toEqual({
             config: '{"autoLayout":true,"enableForward":true}',
             content: '',
+            flowStatus: '2',
             hasAction: 'true',
             stop_action: 'true',
             quoteContent: '',
@@ -262,6 +263,7 @@ describe('card-service', () => {
         await streamAICard(card, 'stream text', false);
 
         expect(card.state).toBe(AICardStatus.INPUTING);
+        expect(card.streamLifecycleOpened).toBe(true);
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
 
@@ -1049,5 +1051,38 @@ describe('token refresh', () => {
         // Token should NOT be refreshed
         expect(mockedGetAccessToken).not.toHaveBeenCalled();
         expect(card.accessToken).toBe('current_token');
+    });
+
+    it('finalizes the streaming lifecycle before committing blocks when streaming was opened', async () => {
+        const card = {
+            cardInstanceId: 'card_stream_finalize',
+            outTrackId: 'track_stream_finalize',
+            accessToken: 'current_token',
+            conversationId: 'cid_1',
+            state: AICardStatus.INPUTING,
+            createdAt: Date.now(),
+            lastUpdated: Date.now(),
+            config: { clientId: 'id', clientSecret: 'sec' } as any,
+            streamLifecycleOpened: true,
+        } as any;
+
+        mockedAxios.put.mockResolvedValue({ status: 200, data: { ok: true } });
+
+        await commitAICardBlocks(card, {
+            blockListJson: JSON.stringify([{ type: 0, markdown: 'test' }]),
+            content: 'test content',
+        });
+
+        expect(mockedAxios.put).toHaveBeenCalledTimes(2);
+        expect(mockedAxios.put.mock.calls[0][0]).toContain('/v1.0/card/streaming');
+        expect(mockedAxios.put.mock.calls[0][1]).toMatchObject({
+            outTrackId: 'track_stream_finalize',
+            key: 'content',
+            content: 'test content',
+            isFull: true,
+            isFinalize: true,
+            isError: false,
+        });
+        expect(mockedAxios.put.mock.calls[1][0]).toContain('/v1.0/card/instances');
     });
 });


### PR DESCRIPTION
## 背景

v3.6.0 新上线的 V2 卡片模板在创建卡片时使用 `callbackType: "STREAM"`，并且创建后会额外发送一次空的 `/v1.0/card/streaming` 以进入输出态。但正常完成时只通过 `/v1.0/card/instances` 写入 `flowStatus=3`，没有关闭已打开的 streaming lifecycle，可能导致钉钉侧等待超时后才真正收口。

## 目标

- 保留 `callbackType: "STREAM"`，不影响卡片按钮回调。
- 默认非实时流式路径减少一次无内容 DingTalk API 调用。
- 只有实际打开过 streaming lifecycle 的卡片，finalize 时才补 `isFinalize=true`。

## 实现

- 在 `createAndDeliver` 的 `cardParamMap` 中直接写入 `flowStatus=2`，让卡片初始视觉态进入输出中。
- 移除创建后的空 content streaming kick。
- 为 `AICardInstance` 增加 `streamLifecycleOpened` 标记，并在 streaming API 成功后维护该标记。
- `commitAICardBlocks` 在 instances 固化前，仅对已打开 streaming lifecycle 的卡片补一次 `/v1.0/card/streaming isFinalize=true`；随后继续通过单次 instances API 写入 `blockList/content/flowStatus=3`。
- pending card 持久化保留 `streamLifecycleOpened`，避免恢复路径丢失 lifecycle 状态。

## 实现 TODO

- [x] 移除创建阶段空 streaming kick
- [x] 按需关闭已打开的 streaming lifecycle
- [x] 保持 V2 final 视觉完成态由 instances API 单次固化
- [x] 补充单元测试覆盖 API 调用次数与 finalize 顺序

## 验证 TODO

- [x] `pnpm vitest run tests/unit/card-service.test.ts`
- [x] `npm run type-check`
- [x] `npm run lint`（通过，保留仓库既有 warnings）
- [x] `pnpm test`