### PR TITLE
fix(card): bound AI card finalize stream waits

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -43,6 +43,8 @@ const AICARD_DEGRADE_DEFAULT_MS = 30 * 60 * 1000;
 const CARD_CACHE_MAX_PER_CONVERSATION = 20;
 const CARD_CACHE_MAX_CONVERSATIONS = 500;
 const DYNAMIC_SUMMARY_EXTENSION = { dynamicSummary: "true" } as const;
+const CARD_STREAMING_REQUEST_TIMEOUT_MS = 8000;
+const CARD_STREAMING_SLOW_WARN_MS = 1000;
 
 const aicardDegradeByAccount = new Map<string, { untilMs: number; reason: string }>();
 
@@ -236,6 +238,30 @@ function extractCardProcessQueryKey(payload: unknown): string | undefined {
   return undefined;
 }
 
+function logCardStreamingResponse(
+  log: Logger | undefined,
+  params: {
+    key: string;
+    finished: boolean;
+    elapsedMs: number;
+    status?: number;
+    data?: unknown;
+    retry?: boolean;
+  },
+): void {
+  const prefix = params.retry
+    ? "[DingTalk][AICard] Retry streaming response"
+    : "[DingTalk][AICard] Streaming response";
+  const detail =
+    `${prefix}: status=${params.status ?? "(none)"} elapsedMs=${params.elapsedMs} ` +
+    `key=${params.key} isFinalize=${params.finished} data=${JSON.stringify(params.data)}`;
+  if (params.elapsedMs >= CARD_STREAMING_SLOW_WARN_MS) {
+    log?.warn?.(detail);
+    return;
+  }
+  log?.debug?.(detail);
+}
+
 async function putAICardStreamingField(
   card: AICardInstance,
   key: string,
@@ -274,6 +300,7 @@ async function putAICardStreamingField(
   );
 
   const requestConfig = {
+    timeout: CARD_STREAMING_REQUEST_TIMEOUT_MS,
     headers: {
       "x-acs-dingtalk-access-token": card.accessToken,
       "Content-Type": "application/json",
@@ -282,10 +309,15 @@ async function putAICardStreamingField(
   };
 
   try {
+    const startedAt = Date.now();
     const streamResp = await axios.put(`${DINGTALK_API}/v1.0/card/streaming`, streamBody, requestConfig);
-    log?.debug?.(
-      `[DingTalk][AICard] Streaming response: status=${streamResp.status}, data=${JSON.stringify(streamResp.data)}`,
-    );
+    logCardStreamingResponse(log, {
+      key,
+      finished,
+      elapsedMs: Date.now() - startedAt,
+      status: streamResp.status,
+      data: streamResp.data,
+    });
     card.lastUpdated = Date.now();
     incrementCardDapiCount(card);
     markStreamingLifecycleAcknowledged(card, finished);
@@ -294,6 +326,7 @@ async function putAICardStreamingField(
       log?.warn?.("[DingTalk][AICard] Received 401 error, attempting token refresh and retry...");
       try {
         card.accessToken = await getAccessToken(card.config, log);
+        const retryStartedAt = Date.now();
         const retryResp = await axios.put(`${DINGTALK_API}/v1.0/card/streaming`, streamBody, {
           ...requestConfig,
           headers: {
@@ -301,9 +334,14 @@ async function putAICardStreamingField(
             "x-acs-dingtalk-access-token": card.accessToken,
           },
         });
-        log?.debug?.(
-          `[DingTalk][AICard] Retry after token refresh succeeded: status=${retryResp.status}`,
-        );
+        logCardStreamingResponse(log, {
+          key,
+          finished,
+          elapsedMs: Date.now() - retryStartedAt,
+          status: retryResp.status,
+          data: retryResp.data,
+          retry: true,
+        });
         card.lastUpdated = Date.now();
         incrementCardDapiCount(card);
         markStreamingLifecycleAcknowledged(card, finished);

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -37,12 +37,38 @@ import { formatDingTalkErrorPayloadLog } from "./utils";
 
 const EMPTY_FINAL_REPLY = "✅ Done";
 const DEFAULT_CARD_FAILED_MESSAGE = "回复生成失败，请重试";
+const FINALIZE_IN_FLIGHT_WAIT_TIMEOUT_MS = 3000;
 type CardReplyLifecycleState = "open" | "final_seen" | "sealed";
 
 /** Deferred media attachment for out-of-card delivery */
 interface DeferredMedia {
   url: string;
   type: "voice" | "video" | "file";
+}
+
+async function waitForInFlightCardStreamWithTimeout(
+  promise: Promise<void>,
+  log: ReplyStrategyContext["log"],
+  phase: "finalize" | "abort",
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const tracked = promise.then(() => "done" as const);
+  tracked.catch(() => undefined);
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => resolve("timeout"), FINALIZE_IN_FLIGHT_WAIT_TIMEOUT_MS);
+  });
+  const result = await Promise.race([tracked, timeout]);
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+  if (result === "timeout") {
+    log?.warn?.(
+      `[DingTalk][Finalize] Timed out waiting for in-flight card stream ` +
+      `phase=${phase} timeoutMs=${FINALIZE_IN_FLIGHT_WAIT_TIMEOUT_MS}; continuing with final commit`,
+    );
+    return false;
+  }
+  return true;
 }
 
 export function createCardReplyStrategy(
@@ -671,8 +697,10 @@ export function createCardReplyStrategy(
       try {
         await flushPendingReasoning();
 
-        await controller.flush();
-        await controller.waitForInFlight();
+        const flushed = await waitForInFlightCardStreamWithTimeout(controller.flush(), log, "finalize");
+        if (flushed) {
+          await waitForInFlightCardStreamWithTimeout(controller.waitForInFlight(), log, "finalize");
+        }
 
         // Prepare finalize options for single instances API call
         const fallbackAnswer = finalTextForFallback || (sawFinalDelivery ? EMPTY_FINAL_REPLY : undefined);
@@ -786,7 +814,7 @@ export function createCardReplyStrategy(
       }
       if (!isCardInTerminalState(card.state)) {
         controller.stop();
-        await controller.waitForInFlight();
+        await waitForInFlightCardStreamWithTimeout(controller.waitForInFlight(), log, "abort");
         try {
           // For V2 template, finalize via instances API
           const errorBlockListJson = JSON.stringify([{ type: 0, markdown: "❌ 处理失败" }]);

--- a/tests/unit/card-service.test.ts
+++ b/tests/unit/card-service.test.ts
@@ -267,6 +267,26 @@ describe('card-service', () => {
         expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
 
+    it('streamAICard sets a timeout on DingTalk streaming requests', async () => {
+        mockedAxios.put.mockResolvedValue({ status: 200, data: { ok: true } });
+
+        const card = {
+            cardInstanceId: 'card_timeout',
+            accessToken: 'token_abc',
+            conversationId: 'cidA1B2C3',
+            createdAt: Date.now(),
+            lastUpdated: Date.now(),
+            state: AICardStatus.PROCESSING,
+            config: { cardTemplateKey: 'content' },
+        } as any;
+
+        await streamAICard(card, 'stream text', false);
+
+        expect(mockedAxios.put.mock.calls[0]?.[2]).toEqual(expect.objectContaining({
+            timeout: 8000,
+        }));
+    });
+
     it('streamAICard retries once on 401 and succeeds', async () => {
         mockedAxios.put
             .mockRejectedValueOnce({ response: { status: 401 }, message: 'token expired' })

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -294,6 +294,35 @@ describe("reply-strategy-card", () => {
             expect(commitAICardBlocksMock).toHaveBeenCalledTimes(1);
         });
 
+        it("answer mode finalize times out a stuck streaming update and commits final content", async () => {
+            const card = makeCard();
+            const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+            const strategy = createCardReplyStrategy(buildCtx(card, {
+                config: { clientId: "id", clientSecret: "s", messageType: "card", cardStreamingMode: "answer" } as any,
+                log,
+            }));
+            const opts = strategy.getReplyOptions();
+            streamAICardContentMock.mockImplementationOnce(() => new Promise(() => undefined));
+
+            await opts.onPartialReply?.({ text: "阶段性答案" });
+            await vi.advanceTimersByTimeAsync(0);
+            expect(streamAICardContentMock).toHaveBeenCalledTimes(1);
+
+            await strategy.deliver({ text: "最终答案", mediaUrls: [], kind: "final" });
+            const finalizePromise = strategy.finalize().then(() => "done");
+            const outcome = Promise.race([
+                finalizePromise,
+                vi.advanceTimersByTimeAsync(3_100).then(() => "timeout"),
+            ]);
+
+            await expect(outcome).resolves.toBe("done");
+            expect(commitAICardBlocksMock).toHaveBeenCalledTimes(1);
+            expect(commitAICardBlocksMock.mock.calls[0]?.[1]?.content).toContain("最终答案");
+            expect(log.warn).toHaveBeenCalledWith(
+                expect.stringContaining("[DingTalk][Finalize] Timed out waiting for in-flight card stream"),
+            );
+        });
+
         it("answer mode rewrites local markdown image snapshots to placeholder text before final upload", async () => {
             const card = makeCard();
             const strategy = createCardReplyStrategy(buildCtx(card, {


### PR DESCRIPTION
## 背景

Fixes #534。

用户反馈 AI Card 在 bot 已经生成最终回复后，钉钉侧仍要等待 5-10 秒甚至更久才看到最终卡片。issue 日志显示延迟发生在 card streaming in-flight 请求完成之前，生产日志级别下这段时间也缺少可见日志。

## 目标

- 避免 `finalize()` 无限等待卡住的 streaming PUT。
- 给 DingTalk `/v1.0/card/streaming` 请求增加客户端超时。
- 对慢 streaming 请求输出可见 warn 日志，便于判断是钉钉 API 或网络链路抖动。

## 实现

- `putAICardStreamingField` 增加 8s axios timeout。
- streaming PUT 成功路径记录 `elapsedMs`，超过 1s 时升级为 warn。
- `reply-strategy-card` 在 finalize/abort 收尾时最多等待 in-flight stream 3s，超时后记录 warn 并继续提交最终 `commitAICardBlocks`。
- 增加单测覆盖：
  - stuck streaming update 不再阻塞 final card commit。
  - streaming PUT 请求携带 timeout。

## 实现 TODO

- [x] 给 AI Card streaming PUT 增加 timeout 和慢请求日志
- [x] 给 finalize/abort 的 in-flight stream wait 增加超时兜底
- [x] 补充单元测试

## 验证 TODO

- [x] `pnpm test tests/unit/reply-strategy-card.test.ts tests/unit/card-service.test.ts -- --runInBand`
- [x] `pnpm type-check`
- [x] `git diff --check`
- [x] `pnpm run lint`（退出码 0；仓库现有 no-explicit-any 等 warning 仍存在，非本次新增阻塞）
