### PR TITLE
fix(http): allow opt-in IPv4-only HTTP agent for IPv6-broken environments

### DIFF
--- a/docs/user/troubleshooting/connection.en.md
+++ b/docs/user/troubleshooting/connection.en.md
@@ -165,6 +165,41 @@ If the script cannot produce a real HTTP status, investigate:
 - proxy configuration
 - TLS certificate trust
 
+### Case 4: bare `Send message failed:` with `AggregateError ETIMEDOUT` (IPv6 routing problem)
+
+Symptoms:
+
+- Logs show repeated `[DingTalk] Send message failed:` with an empty error message,
+  immediately followed by `[DingTalk] Reply failed: Reply send failed`.
+- Inbound reception works fine and ack reactions succeed, but outbound replies
+  via `sendBySession` (sessionWebhook URL on `oapi.dingtalk.com`) consistently
+  time out at the 10s axios timeout.
+- Sometimes only the `reply-strategy-markdown` `finalize()` fallback ("✅ Done")
+  appears to reach the user, masking the real reply.
+
+Root cause: on some hosts (notably some Aliyun ECS instances), `oapi.dingtalk.com`
+resolves to both IPv4 (e.g. `161.117.70.119`) and IPv6 (`240b:4000:f20::*`),
+but outbound to the IPv6 range is blocked at the network layer. In a fresh
+Node process, Happy Eyeballs falls back to IPv4 within ~250ms; in long-lived
+gateway processes the fallback can occasionally stall past axios's 10s timeout
+and surface as `AggregateError code=ETIMEDOUT` with empty `err.message`.
+
+Quick check from the affected host:
+
+```bash
+curl -4 -sS -o /dev/null -w "v4 %{http_code} %{time_total}s\n" --max-time 5 https://oapi.dingtalk.com/
+curl -6 -sS -o /dev/null -w "v6 %{http_code} %{time_total}s\n" --max-time 5 https://oapi.dingtalk.com/
+```
+
+If `v4` returns `200` but `v6` fails or hangs, set the opt-in env var before
+starting the gateway / openclaw process to force IPv4 only:
+
+```bash
+export OPENCLAW_DINGTALK_FORCE_IPV4=1
+```
+
+When the variable is unset, behavior is unchanged.
+
 ## What the Plugin Now Logs
 
 Startup failures now try to include more detail when DingTalk returns a structured error response, for example:

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import * as https from "node:https";
+import * as http from "node:http";
 import type { AxiosInstance } from "axios";
 
 export const DEFAULT_HTTP_TIMEOUT_MS = 10_000;
@@ -7,11 +9,26 @@ type AxiosInstanceWithGuards = AxiosInstance & {
   isAxiosError: typeof axios.isAxiosError;
 };
 
+// Opt-in IPv4-only mode for environments where IPv6 to DingTalk OAPI is
+// reachable in DNS but unreachable via routing (e.g. some Aliyun ECS hosts
+// where outbound to oapi.dingtalk.com's 240b:4000:f20::* range is blocked).
+// In long-lived processes Node's Happy Eyeballs fallback can occasionally
+// stall past the 10s axios timeout and surface as `AggregateError ETIMEDOUT`
+// with empty err.message. Set OPENCLAW_DINGTALK_FORCE_IPV4=1 to bypass.
+const forceIpv4 = process.env.OPENCLAW_DINGTALK_FORCE_IPV4 === "1";
+const agentOpts = forceIpv4 ? { family: 4 as const, keepAlive: true } : undefined;
+const httpsAgent = agentOpts ? new https.Agent(agentOpts) : undefined;
+const httpAgent = agentOpts ? new http.Agent(agentOpts) : undefined;
+
 // Centralize repo-level axios policy without mutating the global axios singleton
 // that third-party dependencies may also share.
 const httpClient = (
   typeof axios?.create === "function"
-    ? axios.create({ timeout: DEFAULT_HTTP_TIMEOUT_MS })
+    ? axios.create({
+        timeout: DEFAULT_HTTP_TIMEOUT_MS,
+        ...(httpsAgent ? { httpsAgent } : {}),
+        ...(httpAgent ? { httpAgent } : {}),
+      })
     : axios
 ) as AxiosInstanceWithGuards;
 


### PR DESCRIPTION
## Problem

On some hosts (notably some Aliyun ECS instances), `oapi.dingtalk.com` resolves
to both IPv4 (e.g. `161.117.70.119`) and IPv6 (`240b:4000:f20::*`). The IPv4
path is reachable (curl returns 200 in ~450ms), but outbound to the IPv6 range
is blocked at the network layer (`ping6` says "Network is unreachable").

In a fresh Node process, Happy Eyeballs falls back to IPv4 within ~250ms and
everything works. In long-lived gateway processes, axios calls to
`oapi.dingtalk.com/robot/sendBySession` consistently time out at the plugin's
10s axios timeout with:

```
AggregateError  code=ETIMEDOUT  status=undefined
```

`err.message` is empty (Node's `socket.js` emits `AggregateError` without a
populated message when all family attempts fail), so `[DingTalk] Send message
failed:` appears bare in logs and is hard to diagnose.

The proactive path (`api.dingtalk.com/v1.0/robot/groupMessages/send`) does not
consistently exhibit this, which masks the issue: `reply-strategy-markdown.ts`'s
`finalize()` fallback emits `"✅ Done"` that sometimes succeeds, hiding the
underlying sessionWebhook failure.

## User-visible symptom

Every reply via sessionWebhook fails. Users see only the `"✅ Done"` fallback
instead of the actual agent reply. Logs show repeated:

```
[DingTalk] Send message failed:
[DingTalk] Reply failed: Reply send failed
```

## Reproduction (when affected)

1. Host where `curl -6 https://oapi.dingtalk.com/` fails ("Couldn't connect")
   but `curl -4` returns 200.
2. Long-lived openclaw gateway process on Node 22+.
3. Inbound DingTalk message → reply attempt fails after ~8-10s.

## Fix

Add an opt-in env var `OPENCLAW_DINGTALK_FORCE_IPV4=1`. When set, the plugin's
http client uses `https.Agent({ family: 4 })` to bypass IPv6 entirely. Default
behavior is unchanged for environments where IPv6 works correctly.

Also adds a Case 4 troubleshooting section to `docs/user/troubleshooting/connection.en.md`
with symptoms, a diagnostic curl one-liner, and the workaround.

## Tested

- Verified on Aliyun ECS where this issue reproduced 100% in long-lived gateway
  processes. With `OPENCLAW_DINGTALK_FORCE_IPV4=1` set, all `sendBySession`
  calls succeed (validated by 11 split-profile gateways running zero send
  failures across normal + cross-agent message flows).
- Without the env var (default), no behavior change in normal environments.

## Files changed

- `src/http-client.ts` — opt-in IPv4-only `https.Agent` / `http.Agent`
- `docs/user/troubleshooting/connection.en.md` — Case 4 docs section