### PR TITLE
fix(routing): target mentioned agent slash commands

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -60,8 +60,10 @@ import { getSessionState, initSessionState } from "./session-state";
 import { getAgentDisplayName } from "./targeting/agent-name-matcher";
 import {
   buildAgentSessionKey,
-  resolveSubAgentRoute,
   dispatchSubAgents,
+  HostRoutingHelperUnavailableError,
+  resolveMentionedSlashCommandTarget,
+  resolveSubAgentRoute,
 } from "./targeting/agent-routing";
 import { formatGroupMembers, noteGroupMember } from "./targeting/group-members-store";
 import {
@@ -772,25 +774,69 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     config: dingtalkConfig,
   });
 
-  const route = subAgentOptions
-    ? {
+  const mentionedSlashCommandTarget = !subAgentOptions
+    ? resolveMentionedSlashCommandTarget({
+        extractedContent,
+        cfg,
+        isGroup,
+      })
+    : null;
+
+  let route: { agentId: string; sessionKey: string; mainSessionKey: string };
+  if (subAgentOptions) {
+    route = {
+      agentId: subAgentOptions.agentId,
+      sessionKey: buildAgentSessionKey({
+        rt,
+        cfg,
+        accountId,
         agentId: subAgentOptions.agentId,
+        peerKind: sessionPeer.kind,
+        peerId: sessionPeer.peerId,
+      }),
+      mainSessionKey: "",
+    };
+  } else if (mentionedSlashCommandTarget) {
+    try {
+      route = {
+        agentId: mentionedSlashCommandTarget.agentId,
         sessionKey: buildAgentSessionKey({
           rt,
           cfg,
           accountId,
-          agentId: subAgentOptions.agentId,
+          agentId: mentionedSlashCommandTarget.agentId,
           peerKind: sessionPeer.kind,
           peerId: sessionPeer.peerId,
         }),
         mainSessionKey: "",
+      };
+    } catch (error) {
+      if (!(error instanceof HostRoutingHelperUnavailableError)) {
+        throw error;
       }
-    : rt.channel.routing.resolveAgentRoute({
-        cfg,
-        channel: "dingtalk",
-        accountId,
-        peer: { kind: sessionPeer.kind, id: sessionPeer.peerId },
-      });
+      log?.error?.(`[DingTalk] Mentioned slash command routing failed: ${getErrorMessage(error)}`);
+      try {
+        await sendBySession(
+          dingtalkConfig,
+          sessionWebhook,
+          "⚠️ 当前宿主版本不支持 DingTalk 子助手路由所需的 session helper，请升级 OpenClaw 后重试。",
+          isGroup ? { atUserId: senderId, log } : { log },
+        );
+      } catch (notifyError: unknown) {
+        log?.debug?.(
+          `[DingTalk] Failed to send sub-agent helper-missing notice: ${getErrorMessage(notifyError)}`,
+        );
+      }
+      return;
+    }
+  } else {
+    route = rt.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "dingtalk",
+      accountId,
+      peer: { kind: sessionPeer.kind, id: sessionPeer.peerId },
+    });
+  }
 
   // @Sub-Agent routing: resolve @mentions to agents (skip in recursive sub-agent calls)
   if (!subAgentOptions) {
@@ -801,6 +847,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       dingtalkConfig,
       sessionWebhook,
       senderId,
+      mentionedSlashCommandTarget,
       log,
     });
     if (subAgentRoute) {
@@ -832,7 +879,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     dingtalkConfig,
     senderId,
     isDirect,
-    extractedText: extractedContent.text,
+    extractedText: mentionedSlashCommandTarget?.commandText ?? extractedContent.text,
     messageType: extractedContent.messageType,
     data: {
       conversationId: data.conversationId,
@@ -1497,6 +1544,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     const inboundText = attachmentExtractedText
       ? `${inboundBody.trimEnd()}\n\n${attachmentExtractedText}`
       : inboundBody;
+    const commandBody = mentionedSlashCommandTarget?.commandText ?? inboundText;
     const learningEnabled = isLearningEnabled(dingtalkConfig);
     const learningContextBlock = buildLearningContextBlock({
       enabled: learningEnabled,
@@ -1546,7 +1594,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     const ctx = rt.channel.reply.finalizeInboundContext({
       Body: body,
       RawBody: inboundText,
-      CommandBody: inboundText,
+      CommandBody: commandBody,
       QuotedRef: quotedRef,
       QuotedRefJson: quotedRef ? JSON.stringify(quotedRef) : undefined,
       ReplyToId: quotedRuntimeContext?.replyToId,

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -61,9 +61,8 @@ import { getAgentDisplayName } from "./targeting/agent-name-matcher";
 import {
   buildAgentSessionKey,
   dispatchSubAgents,
-  HostRoutingHelperUnavailableError,
-  resolveMentionedSlashCommandTarget,
-  resolveSubAgentRoute,
+  resolveMessageTarget,
+  sendUnmatchedAgentNotice,
 } from "./targeting/agent-routing";
 import { formatGroupMembers, noteGroupMember } from "./targeting/group-members-store";
 import {
@@ -582,8 +581,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // for use in card quoteContent which should show the user's original message.
   const rawInboundText = extractedContent.text.trim();
 
-  // Add context hint for sub-agent mode, stripping quoted prefix to avoid protocol noise in agent context.
-  if (subAgentOptions) {
+  // Add context hint for sub-agent content mode, stripping quoted prefix to avoid protocol noise
+  // in agent context. Skipped for targeted slash commands (`commandText` set): the hint would
+  // pollute RawBody, and the command never reaches the agent's LLM anyway.
+  if (subAgentOptions && !subAgentOptions.commandText) {
     const cleanText = extractedContent.text.replace(/^\[引用[^\]]*\]\s*/, "");
     const contextHint = `[你被 @ 为"${subAgentOptions.matchedName}"]\n\n`;
     extractedContent.text = contextHint + cleanText;
@@ -774,16 +775,17 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     config: dingtalkConfig,
   });
 
-  const mentionedSlashCommandTarget = !subAgentOptions
-    ? resolveMentionedSlashCommandTarget({
-        extractedContent,
-        cfg,
-        isGroup,
-      })
-    : null;
+  // Single routing decision for this message. Skipped for recursive sub-agent
+  // calls, where routing is already fixed by subAgentOptions.
+  const messageTarget = subAgentOptions
+    ? null
+    : resolveMessageTarget({ extractedContent, cfg, isGroup });
 
   let route: { agentId: string; sessionKey: string; mainSessionKey: string };
   if (subAgentOptions) {
+    // Recursive sub-agent dispatch (content or targeted command): route to the
+    // agent's own session. A missing host helper throws here and is caught by
+    // dispatchSubAgents in the parent call.
     route = {
       agentId: subAgentOptions.agentId,
       sessionKey: buildAgentSessionKey({
@@ -796,40 +798,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       }),
       mainSessionKey: "",
     };
-  } else if (mentionedSlashCommandTarget) {
-    try {
-      route = {
-        agentId: mentionedSlashCommandTarget.agentId,
-        sessionKey: buildAgentSessionKey({
-          rt,
-          cfg,
-          accountId,
-          agentId: mentionedSlashCommandTarget.agentId,
-          peerKind: sessionPeer.kind,
-          peerId: sessionPeer.peerId,
-        }),
-        mainSessionKey: "",
-      };
-    } catch (error) {
-      if (!(error instanceof HostRoutingHelperUnavailableError)) {
-        throw error;
-      }
-      log?.error?.(`[DingTalk] Mentioned slash command routing failed: ${getErrorMessage(error)}`);
-      try {
-        await sendBySession(
-          dingtalkConfig,
-          sessionWebhook,
-          "⚠️ 当前宿主版本不支持 DingTalk 子助手路由所需的 session helper，请升级 OpenClaw 后重试。",
-          isGroup ? { atUserId: senderId, log } : { log },
-        );
-      } catch (notifyError: unknown) {
-        log?.debug?.(
-          `[DingTalk] Failed to send sub-agent helper-missing notice: ${getErrorMessage(notifyError)}`,
-        );
-      }
-      return;
-    }
   } else {
+    // Default route. For subagent-content / subagent-command targets the
+    // dispatch below re-enters this function with subAgentOptions set, so this
+    // route is only consumed when the target is "default".
     route = rt.channel.routing.resolveAgentRoute({
       cfg,
       channel: "dingtalk",
@@ -838,21 +810,15 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     });
   }
 
-  // @Sub-Agent routing: resolve @mentions to agents (skip in recursive sub-agent calls)
-  if (!subAgentOptions) {
-    const subAgentRoute = await resolveSubAgentRoute({
-      extractedContent,
-      cfg,
-      isGroup,
-      dingtalkConfig,
-      sessionWebhook,
-      senderId,
-      mentionedSlashCommandTarget,
-      log,
-    });
-    if (subAgentRoute) {
+  // @Sub-Agent routing: dispatch @mention-targeted messages to their agent(s).
+  // Both content (`@agent <message>`) and commands (`@agent /new`) re-enter
+  // handleDingTalkMessage via dispatchSubAgents with subAgentOptions set, so the
+  // agent session key, helper-missing fallback, and recursion live in one path.
+  if (messageTarget && messageTarget.kind !== "default") {
+    if (messageTarget.kind === "subagent-command") {
       await dispatchSubAgents({
-        ...subAgentRoute,
+        matchedAgents: [messageTarget.agent],
+        commandText: messageTarget.commandText,
         cfg,
         accountId,
         data,
@@ -865,6 +831,38 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
       });
       return;
     }
+
+    if (messageTarget.hasInvalidAgentNames) {
+      await sendUnmatchedAgentNotice({
+        unmatchedNames: messageTarget.unmatchedNames,
+        isGroup,
+        senderId,
+        dingtalkConfig,
+        sessionWebhook,
+        log,
+      });
+    }
+    if (messageTarget.matchedAgents.length > 0) {
+      log?.info?.(
+        `[DingTalk] Sub-agent resolve: matched=${messageTarget.matchedAgents
+          .map((a) => a.agentId)
+          .join(",")} unmatched=${messageTarget.unmatchedNames.join(",")}`,
+      );
+      await dispatchSubAgents({
+        matchedAgents: messageTarget.matchedAgents,
+        cfg,
+        accountId,
+        data,
+        dingtalkConfig,
+        sessionWebhook,
+        extractedContent,
+        handleMessage: handleDingTalkMessage,
+        downloadMedia,
+        log,
+      });
+      return;
+    }
+    // Only invalid agent names and no match: fall through to the default route.
   }
 
   // Route resolved before media download for session context and routing metadata.
@@ -879,7 +877,7 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     dingtalkConfig,
     senderId,
     isDirect,
-    extractedText: mentionedSlashCommandTarget?.commandText ?? extractedContent.text,
+    extractedText: subAgentOptions?.commandText ?? extractedContent.text,
     messageType: extractedContent.messageType,
     data: {
       conversationId: data.conversationId,
@@ -1544,7 +1542,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
     const inboundText = attachmentExtractedText
       ? `${inboundBody.trimEnd()}\n\n${attachmentExtractedText}`
       : inboundBody;
-    const commandBody = mentionedSlashCommandTarget?.commandText ?? inboundText;
+    // Targeted slash commands (`@agent /new`) pass the @mention-stripped command
+    // text as CommandBody so the framework command layer recognizes it, while
+    // RawBody keeps the user's original input for audit/quote display.
+    const commandBody = subAgentOptions?.commandText ?? inboundText;
     const learningEnabled = isLearningEnabled(dingtalkConfig);
     const learningContextBlock = buildLearningContextBlock({
       enabled: learningEnabled,

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -61,39 +61,88 @@ export function buildAgentSessionKey(params: {
   }).toLowerCase();
 }
 
-type MentionedSlashCommandTarget = {
-  agentId: string;
-  commandText: string;
-};
+/**
+ * The single routing decision for an inbound message.
+ *
+ * - `default` — route to the peer's default agent via `resolveAgentRoute`.
+ *   Covers messages with no @mention, learn/session commands, and slash
+ *   commands that mention only real users.
+ * - `subagent-content` — `@agent <message>` targeting one or more configured
+ *   agents; each is dispatched recursively. `unmatchedNames` /
+ *   `hasInvalidAgentNames` drive the "agent not found" notice.
+ * - `subagent-command` — `@agent /command` targeting a configured agent. The
+ *   command is dispatched to that agent's session with the @mention prefix
+ *   stripped from `commandText`.
+ */
+export type MessageTarget =
+  | { kind: "default" }
+  | {
+      kind: "subagent-content";
+      matchedAgents: AgentNameMatch[];
+      unmatchedNames: string[];
+      hasInvalidAgentNames: boolean;
+    }
+  | { kind: "subagent-command"; agent: AgentNameMatch; commandText: string };
 
-export function resolveMentionedSlashCommandTarget(params: {
+/**
+ * Resolve how an inbound message should be routed.
+ *
+ * This is the single source of truth for "who does this message target": both
+ * content sub-agent routing and targeted slash commands are decided here, so
+ * the @mention/alias parsing happens exactly once. The function is pure — the
+ * caller is responsible for any side effects (dispatch, fallback notices).
+ *
+ * In group chats @mentions come from the DingTalk SDK (`atMentions`); in DMs
+ * `extractMessageContent` populates the same field for text messages, so the
+ * same logic enables sub-agent routing in DMs without an `isGroup` guard.
+ */
+export function resolveMessageTarget(params: {
   extractedContent: MessageContent;
   cfg: OpenClawConfig;
   isGroup: boolean;
-}): MentionedSlashCommandTarget | null {
+}): MessageTarget {
   const { extractedContent, cfg, isGroup } = params;
   const atMentions = extractedContent.atMentions || [];
+  // No @mentions or no configured agents → nothing to route dynamically.
   if (atMentions.length === 0 || !cfg.agents?.list || cfg.agents.list.length === 0) {
-    return null;
+    return { kind: "default" };
   }
 
+  // Strip quoted prefix before inspecting commands to avoid false positives
+  // when the quoted message itself contains a command.
   const textForCommandCheck = extractedContent.text.replace(/^\[引用[^\]]*\]\s*/, "");
-  const commandText = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
-  if (maybeResolveTextAlias(commandText, cfg) === null) {
-    return null;
+  // Learn/session commands are handled by the plugin command layer on the
+  // default route, so they must bypass sub-agent routing entirely.
+  if (parseLearnCommand(textForCommandCheck).scope !== "unknown") {
+    return { kind: "default" };
   }
 
+  // DM has no @picker list from DingTalk; only group chats provide atUsers for real-user hints.
   const atUserDingtalkIds = isGroup ? extractedContent.atUserDingtalkIds : undefined;
-  const { matchedAgents } = resolveAtAgents(atMentions, cfg, atUserDingtalkIds);
-  const firstMatch = matchedAgents[0];
-  if (!firstMatch) {
-    return null;
+  const { matchedAgents, unmatchedNames, hasInvalidAgentNames } = resolveAtAgents(
+    atMentions,
+    cfg,
+    atUserDingtalkIds,
+  );
+
+  // Slash commands like /new, /stop, /reasoning must reach the framework's own
+  // command layer. When one targets a configured agent, route it to that
+  // agent's session with the leading @mention tokens stripped. When no agent
+  // matched, fall through: an unmatched agent name still produces the "not
+  // found" notice, while a slash command that only @mentions real users (or no
+  // agent at all) goes to the default route.
+  const commandText = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
+  if (maybeResolveTextAlias(commandText, cfg) !== null) {
+    const firstMatch = matchedAgents[0];
+    if (firstMatch) {
+      return { kind: "subagent-command", agent: firstMatch, commandText };
+    }
   }
 
-  return {
-    agentId: firstMatch.agentId,
-    commandText,
-  };
+  if (matchedAgents.length === 0 && !hasInvalidAgentNames) {
+    return { kind: "default" };
+  }
+  return { kind: "subagent-content", matchedAgents, unmatchedNames, hasInvalidAgentNames };
 }
 
 /**
@@ -106,97 +155,43 @@ function sanitizeAgentName(name: string): string {
 }
 
 /**
- * Resolve @mention-based sub-agent routing for a group or direct message.
+ * Send the "agent not found" fallback notice for unmatched @mention names.
  *
- * In group chats, @mentions are populated by the DingTalk SDK (atMentions field).
- * In direct messages (DM), the SDK also populates atMentions for text-type messages
- * via extractMessageContent in message-utils.ts, so the same field is reused here.
- * The !isGroup guard is removed to enable sub-agent routing in DM as well.
- *
- * Returns matched agents if any @mentions resolve to configured agents,
- * or null if the message should be handled by the default agent.
+ * In group chats the notice @s the sender back; in DMs it is a plain reply.
+ * Failures are swallowed — the notice is best-effort and must not abort the
+ * inbound pipeline.
  */
-export async function resolveSubAgentRoute(params: {
-  extractedContent: MessageContent;
-  cfg: OpenClawConfig;
+export async function sendUnmatchedAgentNotice(params: {
+  unmatchedNames: string[];
   isGroup: boolean;
+  senderId: string;
   dingtalkConfig: DingTalkConfig;
   sessionWebhook: string;
-  senderId: string;
-  mentionedSlashCommandTarget?: MentionedSlashCommandTarget | null;
   log?: Logger;
-}): Promise<{
-  matchedAgents: AgentNameMatch[];
-  preDownloadedMedia?: { mediaPath?: string; mediaType?: string };
-} | null> {
-  const {
-    extractedContent,
-    cfg,
-    isGroup,
-    dingtalkConfig,
-    sessionWebhook,
-    senderId,
-    mentionedSlashCommandTarget = resolveMentionedSlashCommandTarget({
-      extractedContent,
-      cfg,
-      isGroup,
-    }),
-    log,
-  } = params;
-
-  const atMentions = extractedContent.atMentions || [];
-  // DM has no @picker list from DingTalk; only group chats provide atUsers for real-user hints.
-  const atUserDingtalkIds = isGroup ? extractedContent.atUserDingtalkIds : undefined;
-  // Strip quoted prefix before checking commands to avoid false positives
-  // when the quoted message itself contains a command.
-  const textForCommandCheck = extractedContent.text.replace(/^\[引用[^\]]*\]\s*/, "");
-  const isLearnCommand = parseLearnCommand(textForCommandCheck).scope !== "unknown";
-  // Slash commands like /new, /stop, /reasoning etc. must bypass sub-agent
-  // routing so they reach the framework's own command handling layer.
-  if (
-    atMentions.length === 0 ||
-    !cfg.agents?.list ||
-    cfg.agents.list.length === 0 ||
-    isLearnCommand ||
-    mentionedSlashCommandTarget !== null
-  ) {
-    return null;
+}): Promise<void> {
+  const { unmatchedNames, isGroup, senderId, dingtalkConfig, sessionWebhook, log } = params;
+  const fallbackReason = `未找到名为"${unmatchedNames.join("、")}"的助手`;
+  try {
+    const sendOptions = isGroup ? { atUserId: senderId, log } : { log };
+    await sendBySession(dingtalkConfig, sessionWebhook, `⚠️ ${fallbackReason}`, sendOptions);
+  } catch (err: unknown) {
+    log?.debug?.(`[DingTalk] Failed to send fallback notice: ${getErrorMessage(err)}`);
   }
-
-  const { matchedAgents, unmatchedNames, realUserCount, hasInvalidAgentNames } = resolveAtAgents(
-    atMentions,
-    cfg,
-    atUserDingtalkIds,
-  );
-  log?.info?.(
-    `[DingTalk] Sub-agent resolve: matched=${matchedAgents.map((a) => a.agentId).join(",")} unmatched=${unmatchedNames.join(",")} realUsers=${realUserCount}`,
-  );
-
-  // Send fallback notice for unmatched agent names
-  if (hasInvalidAgentNames) {
-    const fallbackReason = `未找到名为"${unmatchedNames.join("、")}"的助手`;
-    try {
-      const sendOptions = isGroup ? { atUserId: senderId, log } : { log };
-      await sendBySession(dingtalkConfig, sessionWebhook, `⚠️ ${fallbackReason}`, {
-        ...sendOptions,
-      });
-    } catch (err: unknown) {
-      log?.debug?.(`[DingTalk] Failed to send fallback notice: ${getErrorMessage(err)}`);
-    }
-  }
-
-  if (matchedAgents.length === 0) {
-    return null;
-  }
-
-  return { matchedAgents };
 }
 
 /**
  * Process matched sub-agents by dispatching each to handleDingTalkMessage.
+ *
+ * When `commandText` is set, this is a targeted slash command (`@agent /new`):
+ * `matchedAgents` holds the single resolved agent, the command is threaded
+ * through `subAgentOptions.commandText`, and no response prefix is added.
+ * Otherwise it is content routing — each matched agent is dispatched with a
+ * `> 🤖 **agent**:` prefix. Both modes share the same recursive dispatch path,
+ * so the host-helper-missing fallback below is the only copy.
  */
 export async function dispatchSubAgents(params: {
   matchedAgents: AgentNameMatch[];
+  commandText?: string;
   cfg: OpenClawConfig;
   accountId: string;
   data: DingTalkInboundMessage;
@@ -213,6 +208,7 @@ export async function dispatchSubAgents(params: {
 }): Promise<void> {
   const {
     matchedAgents,
+    commandText,
     cfg,
     accountId,
     data,
@@ -272,8 +268,11 @@ export async function dispatchSubAgents(params: {
         dingtalkConfig,
         subAgentOptions: {
           agentId: agentMatch.agentId,
-          responsePrefix: `> 🤖 **${sanitizeAgentName(agentMatch.matchedName)}**:\n\n`,
+          responsePrefix: commandText
+            ? ""
+            : `> 🤖 **${sanitizeAgentName(agentMatch.matchedName)}**:\n\n`,
           matchedName: agentMatch.matchedName,
+          commandText,
         },
         preDownloadedMedia,
       });

--- a/src/targeting/agent-routing.ts
+++ b/src/targeting/agent-routing.ts
@@ -7,18 +7,27 @@
  * (channel + accountId + peer), not content-based dynamic routing.
  */
 
-import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { maybeResolveTextAlias } from "openclaw/plugin-sdk/command-auth";
-import { resolveAtAgents } from "./agent-name-matcher";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { resolveRobotCode } from "../config";
 import { parseLearnCommand } from "../learning-command-service";
 import { getDingTalkRuntime } from "../runtime";
 import { sendBySession } from "../send-service";
+import type {
+  AgentNameMatch,
+  DingTalkConfig,
+  DingTalkInboundMessage,
+  HandleDingTalkMessageParams,
+  Logger,
+  MessageContent,
+} from "../types";
 import { getErrorMessage } from "../utils";
-import type { AgentNameMatch, DingTalkConfig, DingTalkInboundMessage, HandleDingTalkMessageParams, Logger, MessageContent } from "../types";
+import { resolveAtAgents } from "./agent-name-matcher";
 
 export class HostRoutingHelperUnavailableError extends Error {
-  constructor(message = "DingTalk sub-agent routing requires runtime.channel.routing.buildAgentSessionKey from the host runtime.") {
+  constructor(
+    message = "DingTalk sub-agent routing requires runtime.channel.routing.buildAgentSessionKey from the host runtime.",
+  ) {
     super(message);
     this.name = "HostRoutingHelperUnavailableError";
   }
@@ -42,16 +51,49 @@ export function buildAgentSessionKey(params: {
   if (typeof routing.buildAgentSessionKey !== "function") {
     throw new HostRoutingHelperUnavailableError();
   }
-  return (
-    (routing.buildAgentSessionKey as (p: unknown) => string)({
-      agentId,
-      channel: "dingtalk",
-      accountId,
-      peer: { kind: peerKind, id: peerId },
-      dmScope: cfg.session?.dmScope,
-      identityLinks: cfg.session?.identityLinks,
-    })
-  ).toLowerCase();
+  return (routing.buildAgentSessionKey as (p: unknown) => string)({
+    agentId,
+    channel: "dingtalk",
+    accountId,
+    peer: { kind: peerKind, id: peerId },
+    dmScope: cfg.session?.dmScope,
+    identityLinks: cfg.session?.identityLinks,
+  }).toLowerCase();
+}
+
+type MentionedSlashCommandTarget = {
+  agentId: string;
+  commandText: string;
+};
+
+export function resolveMentionedSlashCommandTarget(params: {
+  extractedContent: MessageContent;
+  cfg: OpenClawConfig;
+  isGroup: boolean;
+}): MentionedSlashCommandTarget | null {
+  const { extractedContent, cfg, isGroup } = params;
+  const atMentions = extractedContent.atMentions || [];
+  if (atMentions.length === 0 || !cfg.agents?.list || cfg.agents.list.length === 0) {
+    return null;
+  }
+
+  const textForCommandCheck = extractedContent.text.replace(/^\[引用[^\]]*\]\s*/, "");
+  const commandText = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
+  if (maybeResolveTextAlias(commandText, cfg) === null) {
+    return null;
+  }
+
+  const atUserDingtalkIds = isGroup ? extractedContent.atUserDingtalkIds : undefined;
+  const { matchedAgents } = resolveAtAgents(atMentions, cfg, atUserDingtalkIds);
+  const firstMatch = matchedAgents[0];
+  if (!firstMatch) {
+    return null;
+  }
+
+  return {
+    agentId: firstMatch.agentId,
+    commandText,
+  };
 }
 
 /**
@@ -81,12 +123,26 @@ export async function resolveSubAgentRoute(params: {
   dingtalkConfig: DingTalkConfig;
   sessionWebhook: string;
   senderId: string;
+  mentionedSlashCommandTarget?: MentionedSlashCommandTarget | null;
   log?: Logger;
 }): Promise<{
   matchedAgents: AgentNameMatch[];
   preDownloadedMedia?: { mediaPath?: string; mediaType?: string };
 } | null> {
-  const { extractedContent, cfg, isGroup, dingtalkConfig, sessionWebhook, senderId, log } = params;
+  const {
+    extractedContent,
+    cfg,
+    isGroup,
+    dingtalkConfig,
+    sessionWebhook,
+    senderId,
+    mentionedSlashCommandTarget = resolveMentionedSlashCommandTarget({
+      extractedContent,
+      cfg,
+      isGroup,
+    }),
+    log,
+  } = params;
 
   const atMentions = extractedContent.atMentions || [];
   // DM has no @picker list from DingTalk; only group chats provide atUsers for real-user hints.
@@ -97,16 +153,12 @@ export async function resolveSubAgentRoute(params: {
   const isLearnCommand = parseLearnCommand(textForCommandCheck).scope !== "unknown";
   // Slash commands like /new, /stop, /reasoning etc. must bypass sub-agent
   // routing so they reach the framework's own command handling layer.
-  // Strip leading @mention tokens first since DM text may look like "@Agent /new".
-  const textWithoutMentions = textForCommandCheck.replace(/^(?:@\S+\s+)*/u, "").trim();
-  const isSlashCommand = maybeResolveTextAlias(textWithoutMentions, cfg) !== null;
-
   if (
     atMentions.length === 0 ||
     !cfg.agents?.list ||
     cfg.agents.list.length === 0 ||
     isLearnCommand ||
-    isSlashCommand
+    mentionedSlashCommandTarget !== null
   ) {
     return null;
   }
@@ -152,18 +204,35 @@ export async function dispatchSubAgents(params: {
   sessionWebhook: string;
   extractedContent: MessageContent;
   handleMessage: (params: HandleDingTalkMessageParams) => Promise<void>;
-  downloadMedia: (config: DingTalkConfig, mediaPath: string, log?: Logger) => Promise<{ path: string; mimeType: string } | null>;
+  downloadMedia: (
+    config: DingTalkConfig,
+    mediaPath: string,
+    log?: Logger,
+  ) => Promise<{ path: string; mimeType: string } | null>;
   log?: Logger;
 }): Promise<void> {
-  const { matchedAgents, cfg, accountId, data, dingtalkConfig, sessionWebhook, extractedContent, handleMessage, downloadMedia: download, log } = params;
+  const {
+    matchedAgents,
+    cfg,
+    accountId,
+    data,
+    dingtalkConfig,
+    sessionWebhook,
+    extractedContent,
+    handleMessage,
+    downloadMedia: download,
+    log,
+  } = params;
 
   // Pre-download media once to avoid duplication across sub-agents
-  let preDownloadedMedia: {
-    mediaPath?: string;
-    mediaType?: string;
-    mediaPaths?: string[];
-    mediaTypes?: string[];
-  } | undefined;
+  let preDownloadedMedia:
+    | {
+        mediaPath?: string;
+        mediaType?: string;
+        mediaPaths?: string[];
+        mediaTypes?: string[];
+      }
+    | undefined;
   const robotCode = resolveRobotCode(dingtalkConfig);
   if (robotCode) {
     const downloadCodes =
@@ -210,9 +279,7 @@ export async function dispatchSubAgents(params: {
       });
     } catch (error) {
       const message = getErrorMessage(error);
-      log?.error?.(
-        `[DingTalk] Sub-agent ${agentMatch.agentId} failed: ${message}`,
-      );
+      log?.error?.(`[DingTalk] Sub-agent ${agentMatch.agentId} failed: ${message}`);
       if (error instanceof HostRoutingHelperUnavailableError && !helperMissingWarningSent) {
         helperMissingWarningSent = true;
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,6 +453,13 @@ export interface SubAgentOptions {
   responsePrefix: string;
   /** The matched agent name */
   matchedName: string;
+  /**
+   * When set, this dispatch is a targeted slash command (`@agent /new`).
+   * The value is the command text with the leading `@mention` stripped, used
+   * as `CommandBody` so the framework command layer can recognize it. Content
+   * sub-agent dispatches leave this undefined.
+   */
+  commandText?: string;
 }
 
 /**

--- a/tests/unit/inbound-handler-abort.test.ts
+++ b/tests/unit/inbound-handler-abort.test.ts
@@ -53,6 +53,17 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   isBtwRequestText: vi.fn().mockReturnValue(false),
 }));
 
+vi.mock("openclaw/plugin-sdk/command-auth", () => ({
+  maybeResolveTextAlias: (raw: string) => {
+    const token = raw.trim().toLowerCase().match(/^\/([^\s:]+)(?:\s|$)/);
+    if (!token) {
+      return null;
+    }
+    const alias = `/${token[1]}`;
+    return new Set(["/new", "/stop"]).has(alias) ? alias : null;
+  },
+}));
+
 vi.mock("../../src/message-context-store", async () => {
   const actual = await vi.importActual<typeof import("../../src/message-context-store")>(
     "../../src/message-context-store",
@@ -78,7 +89,8 @@ vi.mock("../../src/messaging/attachment-text-extractor", () => ({
 }));
 
 vi.mock("../../src/media-utils", async () => {
-  const actual = await vi.importActual<typeof import("../../src/media-utils")>("../../src/media-utils");
+  const actual =
+    await vi.importActual<typeof import("../../src/media-utils")>("../../src/media-utils");
   return {
     ...actual,
     prepareMediaInput: vi.fn(),
@@ -92,7 +104,9 @@ function buildRuntime() {
   return {
     channel: {
       routing: {
-        resolveAgentRoute: vi.fn().mockReturnValue({ agentId: "main", sessionKey: "s1", mainSessionKey: "s1" }),
+        resolveAgentRoute: vi
+          .fn()
+          .mockReturnValue({ agentId: "main", sessionKey: "s1", mainSessionKey: "s1" }),
         buildAgentSessionKey: vi.fn().mockReturnValue("agent-session-key"),
       },
       media: {
@@ -110,14 +124,14 @@ function buildRuntime() {
         resolveEnvelopeFormatOptions: vi.fn().mockReturnValue({}),
         formatInboundEnvelope: vi.fn().mockReturnValue("body"),
         finalizeInboundContext: vi.fn().mockReturnValue({ SessionKey: "s1" }),
-        dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockImplementation(
-          async ({ dispatcherOptions, replyOptions }) => {
+        dispatchReplyWithBufferedBlockDispatcher: vi
+          .fn()
+          .mockImplementation(async ({ dispatcherOptions, replyOptions }) => {
             await replyOptions?.onReasoningStream?.({ text: "thinking" });
             await dispatcherOptions.deliver({ text: "tool output" }, { kind: "tool" });
             await dispatcherOptions.deliver({ text: "final output" }, { kind: "final" });
             return { queuedFinal: "queued final" };
-          },
-        ),
+          }),
       },
     },
   };
@@ -139,10 +153,13 @@ describe("inbound-handler abort pre-lock bypass", () => {
   beforeEach(() => {
     shared.sendBySessionMock.mockReset();
     shared.sendMessageMock.mockReset();
+    shared.sendMessageMock.mockResolvedValue({ ok: true });
     shared.sendMessageMock.mockImplementation(
       async (_config: unknown, _to: unknown, text: unknown, options: unknown) => {
         // Simulate real sendMessage behavior: update lastStreamedContent when appending to card
-        const opts = options as { card?: { lastStreamedContent: unknown }; cardUpdateMode?: string } | undefined;
+        const opts = options as
+          | { card?: { lastStreamedContent: unknown }; cardUpdateMode?: string }
+          | undefined;
         if (opts?.card && opts?.cardUpdateMode === "append") {
           opts.card.lastStreamedContent = text;
         }
@@ -321,17 +338,20 @@ describe("inbound-handler abort pre-lock bypass", () => {
     // DingTalk does not strip @BotName from text.content, so isAbortRequestText must match bare command
 
     // Group message test
-    shared.extractMessageContentMock.mockReturnValueOnce({ text: "@Bot 停止", messageType: "text" });
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "@Bot 停止",
+      messageType: "text",
+    });
     shared.isAbortRequestTextMock.mockImplementationOnce((text: string) => text === "停止");
     shared.sendBySessionMock.mockResolvedValueOnce({ data: {} });
 
     const rtGroup = buildRuntime();
-    vi.mocked(rtGroup.channel.reply.dispatchReplyWithBufferedBlockDispatcher).mockImplementationOnce(
-      async ({ dispatcherOptions }: any) => {
-        await dispatcherOptions.deliver({ text: "已停止响应" });
-        return { queuedFinal: true, counts: { final: 1 } };
-      },
-    );
+    vi.mocked(
+      rtGroup.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
+    ).mockImplementationOnce(async ({ dispatcherOptions }: any) => {
+      await dispatcherOptions.deliver({ text: "已停止响应" });
+      return { queuedFinal: true, counts: { final: 1 } };
+    });
     shared.getRuntimeMock.mockReturnValueOnce(rtGroup);
 
     await handleDingTalkMessage({
@@ -393,5 +413,165 @@ describe("inbound-handler abort pre-lock bypass", () => {
     // @mention stripped in DM -> "/stop" matches -> session lock should NOT be acquired
     expect(shared.acquireSessionLockMock).not.toHaveBeenCalled();
     expect(rtDM.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("inbound-handler targeted sub-agent slash commands", () => {
+  const baseData = {
+    msgId: "command_m1",
+    msgtype: "text",
+    text: { content: "@work /new" },
+    conversationType: "1",
+    conversationId: "cid_command",
+    senderId: "user_1",
+    chatbotUserId: "bot_1",
+    sessionWebhook: "https://session.webhook/command",
+    createAt: Date.now(),
+  };
+
+  beforeEach(() => {
+    shared.sendBySessionMock.mockReset();
+    shared.sendMessageMock.mockReset();
+    shared.sendMessageMock.mockResolvedValue({ ok: true });
+    shared.extractMessageContentMock.mockReset();
+    shared.extractMessageContentMock.mockReturnValue({
+      text: "@work /new",
+      messageType: "text",
+      atMentions: [{ name: "work" }],
+    });
+    shared.acquireSessionLockMock.mockReset();
+    shared.acquireSessionLockMock.mockResolvedValue(vi.fn());
+    shared.isAbortRequestTextMock.mockReset();
+    shared.isAbortRequestTextMock.mockReturnValue(false);
+    shared.getRuntimeMock.mockReturnValue(buildRuntime());
+  });
+
+  it("routes @agent slash commands to the mentioned agent session with a stripped CommandBody", async () => {
+    const rt = buildRuntime();
+    vi.mocked(rt.channel.routing.buildAgentSessionKey).mockReturnValue("agent-session-key");
+    vi.mocked(rt.channel.reply.finalizeInboundContext).mockImplementation((ctx: any) => ctx);
+    shared.getRuntimeMock.mockReturnValue(rt);
+
+    await handleDingTalkMessage({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", name: "马里奥", default: true },
+            { id: "work", name: "工作助手" },
+          ],
+        },
+      },
+      accountId: "main",
+      sessionWebhook: "https://session.webhook/command",
+      log: undefined,
+      dingtalkConfig: { dmPolicy: "open" } as DingTalkConfig,
+      data: baseData as unknown as DingTalkInboundMessage,
+    } as any);
+
+    expect(rt.channel.routing.buildAgentSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+        peer: { kind: "direct", id: "user_1" },
+      }),
+    );
+    expect(shared.acquireSessionLockMock).toHaveBeenCalledWith("agent-session-key");
+    expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "agent-session-key",
+          CommandBody: "/new",
+          RawBody: "@work /new",
+        }),
+      }),
+    );
+  });
+
+  it("notifies when @agent slash commands require a missing host session helper", async () => {
+    const rt = buildRuntime();
+    (rt.channel.routing as any).buildAgentSessionKey = undefined;
+    shared.sendBySessionMock.mockResolvedValueOnce({ data: {} });
+    shared.getRuntimeMock.mockReturnValue(rt);
+
+    await expect(
+      handleDingTalkMessage({
+        cfg: {
+          agents: {
+            list: [
+              { id: "main", name: "马里奥", default: true },
+              { id: "work", name: "工作助手" },
+            ],
+          },
+        },
+        accountId: "main",
+        sessionWebhook: "https://session.webhook/command",
+        log: undefined,
+        dingtalkConfig: { dmPolicy: "open" } as DingTalkConfig,
+        data: baseData as unknown as DingTalkInboundMessage,
+      } as any),
+    ).resolves.toBeUndefined();
+
+    expect(shared.sendBySessionMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://session.webhook/command",
+      "⚠️ 当前宿主版本不支持 DingTalk 子助手路由所需的 session helper，请升级 OpenClaw 后重试。",
+      { log: undefined },
+    );
+    expect(shared.acquireSessionLockMock).not.toHaveBeenCalled();
+    expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("routes group @agent slash commands to the mentioned agent group session", async () => {
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "/new",
+      messageType: "text",
+      atMentions: [{ name: "work" }],
+      atUserDingtalkIds: [],
+    });
+
+    const rt = buildRuntime();
+    vi.mocked(rt.channel.routing.buildAgentSessionKey).mockReturnValue("agent-group-session-key");
+    vi.mocked(rt.channel.reply.finalizeInboundContext).mockImplementation((ctx: any) => ctx);
+    shared.getRuntimeMock.mockReturnValue(rt);
+
+    await handleDingTalkMessage({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", name: "马里奥", default: true },
+            { id: "work", name: "工作助手" },
+          ],
+        },
+      },
+      accountId: "main",
+      sessionWebhook: "https://session.webhook/command",
+      log: undefined,
+      dingtalkConfig: { groupPolicy: "open" } as DingTalkConfig,
+      data: {
+        ...baseData,
+        msgId: "command_group_m1",
+        text: { content: "/new" },
+        conversationType: "2",
+        conversationId: "cid_group_command",
+        conversationTitle: "测试群",
+      } as unknown as DingTalkInboundMessage,
+    } as any);
+
+    expect(rt.channel.routing.buildAgentSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+        peer: { kind: "group", id: "cid_group_command" },
+      }),
+    );
+    expect(shared.acquireSessionLockMock).toHaveBeenCalledWith("agent-group-session-key");
+    expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "agent-group-session-key",
+          CommandBody: "/new",
+          RawBody: "/new",
+          ChatType: "group",
+        }),
+      }),
+    );
   });
 });

--- a/tests/unit/inbound-handler-abort.test.ts
+++ b/tests/unit/inbound-handler-abort.test.ts
@@ -521,8 +521,10 @@ describe("inbound-handler targeted sub-agent slash commands", () => {
   });
 
   it("routes group @agent slash commands to the mentioned agent group session", async () => {
-    shared.extractMessageContentMock.mockReturnValueOnce({
-      text: "/new",
+    // Real DingTalk group payload: the bot @mention is stripped by the protocol,
+    // but the @agent token survives in text.content and is parsed into atMentions.
+    shared.extractMessageContentMock.mockReturnValue({
+      text: "@work /new",
       messageType: "text",
       atMentions: [{ name: "work" }],
       atUserDingtalkIds: [],
@@ -549,7 +551,7 @@ describe("inbound-handler targeted sub-agent slash commands", () => {
       data: {
         ...baseData,
         msgId: "command_group_m1",
-        text: { content: "/new" },
+        text: { content: "@work /new" },
         conversationType: "2",
         conversationId: "cid_group_command",
         conversationTitle: "测试群",
@@ -568,7 +570,7 @@ describe("inbound-handler targeted sub-agent slash commands", () => {
         ctx: expect.objectContaining({
           SessionKey: "agent-group-session-key",
           CommandBody: "/new",
-          RawBody: "/new",
+          RawBody: "@work /new",
           ChatType: "group",
         }),
       }),

--- a/tests/unit/inbound-handler-abort.test.ts
+++ b/tests/unit/inbound-handler-abort.test.ts
@@ -576,4 +576,66 @@ describe("inbound-handler targeted sub-agent slash commands", () => {
       }),
     );
   });
+
+  it("routes @agent /stop to the mentioned agent session via the lock-bypassing abort path", async () => {
+    // /stop reaches the abort fast-path (isAbortRequestText) rather than the
+    // CommandBody dispatch, but the ctx it dispatches with must still carry the
+    // mentioned agent's SessionKey so the abort targets that agent's run.
+    shared.extractMessageContentMock.mockReturnValue({
+      text: "@work /stop",
+      messageType: "text",
+      atMentions: [{ name: "work" }],
+    });
+    shared.isAbortRequestTextMock.mockImplementation((text: string) => text === "/stop");
+    shared.sendBySessionMock.mockResolvedValue({ data: {} });
+
+    const rt = buildRuntime();
+    vi.mocked(rt.channel.routing.buildAgentSessionKey).mockReturnValue("work-session-key");
+    vi.mocked(rt.channel.reply.finalizeInboundContext).mockImplementation((ctx: any) => ctx);
+    vi.mocked(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).mockImplementationOnce(
+      async ({ dispatcherOptions }: any) => {
+        await dispatcherOptions.deliver({ text: "已停止响应" });
+        return { queuedFinal: true, counts: { final: 1 } };
+      },
+    );
+    shared.getRuntimeMock.mockReturnValue(rt);
+
+    await handleDingTalkMessage({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", name: "马里奥", default: true },
+            { id: "work", name: "工作助手" },
+          ],
+        },
+      },
+      accountId: "main",
+      sessionWebhook: "https://session.webhook/command",
+      log: undefined,
+      dingtalkConfig: { dmPolicy: "open" } as DingTalkConfig,
+      data: {
+        ...baseData,
+        msgId: "command_stop_m1",
+        text: { content: "@work /stop" },
+      } as unknown as DingTalkInboundMessage,
+    } as any);
+
+    expect(rt.channel.routing.buildAgentSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "work",
+        peer: { kind: "direct", id: "user_1" },
+      }),
+    );
+    // abort fast-path must not acquire the session lock
+    expect(shared.acquireSessionLockMock).not.toHaveBeenCalled();
+    expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "work-session-key",
+          CommandBody: "/stop",
+          RawBody: "@work /stop",
+        }),
+      }),
+    );
+  });
 });

--- a/tests/unit/llm-output-hook.test.ts
+++ b/tests/unit/llm-output-hook.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { clearAllForTest, getUsageByRunId, recordRunStart } from "../../src/run-usage-store";
 
+const INDEX_IMPORT_TIMEOUT_MS = 15_000;
+
 vi.mock("../../src/channel", () => ({
   dingtalkPlugin: {},
 }));
@@ -52,7 +54,7 @@ describe("llm_output hook registration", () => {
       "llm_output",
       expect.any(Function),
     );
-  });
+  }, INDEX_IMPORT_TIMEOUT_MS);
 
   it("accumulates usage from llm_output events", async () => {
     const mod = await import("../../index");
@@ -81,7 +83,7 @@ describe("llm_output hook registration", () => {
       output: 50,
       total: 150,
     });
-  });
+  }, INDEX_IMPORT_TIMEOUT_MS);
 
   it("skips events without usage data", async () => {
     const mod = await import("../../index");
@@ -104,5 +106,5 @@ describe("llm_output hook registration", () => {
     );
 
     expect(getUsageByRunId("run-skip")).toEqual({});
-  });
+  }, INDEX_IMPORT_TIMEOUT_MS);
 });

--- a/tests/unit/targeting/dm-subagent-routing.test.ts
+++ b/tests/unit/targeting/dm-subagent-routing.test.ts
@@ -7,28 +7,52 @@
  * enable sub-agent routing in DMs without duplicating the extraction logic.
  */
 
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { extractMessageContent } from "../../../src/message-utils";
+import { sendBySession } from "../../../src/send-service";
 import { resolveAtAgents } from "../../../src/targeting/agent-name-matcher";
 import {
   buildAgentSessionKey,
   dispatchSubAgents,
   HostRoutingHelperUnavailableError,
+  resolveMentionedSlashCommandTarget,
   resolveSubAgentRoute,
 } from "../../../src/targeting/agent-routing";
-import { extractMessageContent } from "../../../src/message-utils";
-import { sendBySession } from "../../../src/send-service";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
-import type { DingTalkConfig, DingTalkInboundMessage, Logger, MessageContent } from "../../../src/types";
+import type {
+  DingTalkConfig,
+  DingTalkInboundMessage,
+  Logger,
+  MessageContent,
+} from "../../../src/types";
 
 vi.mock("../../../src/send-service", () => ({
   sendBySession: vi.fn(),
 }));
 
 const KNOWN_COMMANDS = new Set([
-  "/new", "/stop", "/clear", "/compact", "/reasoning", "/model",
-  "/config", "/session", "/session-alias", "/whoami", "/whereami",
-  "/help", "/status", "/tools", "/reset", "/think", "/verbose",
-  "/bash", "/activation", "/agents", "/restart", "/usage",
+  "/new",
+  "/stop",
+  "/clear",
+  "/compact",
+  "/reasoning",
+  "/model",
+  "/config",
+  "/session",
+  "/session-alias",
+  "/whoami",
+  "/whereami",
+  "/help",
+  "/status",
+  "/tools",
+  "/reset",
+  "/think",
+  "/verbose",
+  "/bash",
+  "/activation",
+  "/agents",
+  "/restart",
+  "/usage",
 ]);
 
 vi.mock("openclaw/plugin-sdk/command-auth", () => ({
@@ -198,29 +222,40 @@ describe("resolveSubAgentRoute in DM", () => {
     expect(mockedSendBySession).not.toHaveBeenCalled();
   });
 
-  it.each(["/new", "/stop", "/clear", "/compact", "/reasoning stream", "/reasoning on", "/model", "/config", "/session", "/whoami", "/whereami", "/session-alias show", "/session-alias clear"])(
-    "skips sub-agent routing for slash command '%s' with @mention",
-    async (command) => {
-      const extractedContent: MessageContent = {
-        text: `@agent-alpha ${command}`,
-        messageType: "text",
-        atMentions: [{ name: "agent-alpha" }],
-      };
+  it.each([
+    "/new",
+    "/stop",
+    "/clear",
+    "/compact",
+    "/reasoning stream",
+    "/reasoning on",
+    "/model",
+    "/config",
+    "/session",
+    "/whoami",
+    "/whereami",
+    "/session-alias show",
+    "/session-alias clear",
+  ])("skips sub-agent routing for slash command '%s' with @mention", async (command) => {
+    const extractedContent: MessageContent = {
+      text: `@agent-alpha ${command}`,
+      messageType: "text",
+      atMentions: [{ name: "agent-alpha" }],
+    };
 
-      const result = await resolveSubAgentRoute({
-        extractedContent,
-        cfg,
-        isGroup: false,
-        dingtalkConfig,
-        sessionWebhook: "https://session.webhook",
-        senderId: "user-001",
-        log,
-      });
+    const result = await resolveSubAgentRoute({
+      extractedContent,
+      cfg,
+      isGroup: false,
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      senderId: "user-001",
+      log,
+    });
 
-      expect(result).toBeNull();
-      expect(mockedSendBySession).not.toHaveBeenCalled();
-    },
-  );
+    expect(result).toBeNull();
+    expect(mockedSendBySession).not.toHaveBeenCalled();
+  });
 
   it("skips sub-agent routing for slash commands in group chat", async () => {
     const extractedContent: MessageContent = {
@@ -263,6 +298,43 @@ describe("resolveSubAgentRoute in DM", () => {
 
     expect(result).not.toBeNull();
     expect(result?.matchedAgents[0]?.agentId).toBe("agent-alpha");
+  });
+});
+
+describe("resolveMentionedSlashCommandTarget", () => {
+  it("returns the mentioned agent and stripped command text in DM", () => {
+    const result = resolveMentionedSlashCommandTarget({
+      extractedContent: {
+        text: "@agent-alpha /new",
+        messageType: "text",
+        atMentions: [{ name: "agent-alpha" }],
+      },
+      cfg,
+      isGroup: false,
+    });
+
+    expect(result).toEqual({
+      agentId: "agent-alpha",
+      commandText: "/new",
+    });
+  });
+
+  it("returns the mentioned group agent when DingTalk strips the @ token from text", () => {
+    const result = resolveMentionedSlashCommandTarget({
+      extractedContent: {
+        text: "/new",
+        messageType: "text",
+        atMentions: [{ name: "agent-alpha" }],
+        atUserDingtalkIds: [],
+      },
+      cfg,
+      isGroup: true,
+    });
+
+    expect(result).toEqual({
+      agentId: "agent-alpha",
+      commandText: "/new",
+    });
   });
 });
 
@@ -349,9 +421,13 @@ describe("dispatchSubAgents", () => {
         text: "@Alpha助手 你好",
         messageType: "text",
       },
-      handleMessage: vi.fn().mockRejectedValue(
-        new HostRoutingHelperUnavailableError("host helper unavailable without mentioning the old symbol"),
-      ),
+      handleMessage: vi
+        .fn()
+        .mockRejectedValue(
+          new HostRoutingHelperUnavailableError(
+            "host helper unavailable without mentioning the old symbol",
+          ),
+        ),
       downloadMedia: vi.fn().mockResolvedValue(null),
       log,
     });
@@ -391,9 +467,13 @@ describe("dispatchSubAgents", () => {
         text: "@Alpha助手 @Beta助手 你好",
         messageType: "text",
       },
-      handleMessage: vi.fn().mockRejectedValue(
-        new HostRoutingHelperUnavailableError("host helper unavailable without mentioning the old symbol"),
-      ),
+      handleMessage: vi
+        .fn()
+        .mockRejectedValue(
+          new HostRoutingHelperUnavailableError(
+            "host helper unavailable without mentioning the old symbol",
+          ),
+        ),
       downloadMedia: vi.fn().mockResolvedValue(null),
       log,
     });

--- a/tests/unit/targeting/dm-subagent-routing.test.ts
+++ b/tests/unit/targeting/dm-subagent-routing.test.ts
@@ -1,10 +1,11 @@
 /**
- * Tests for DM (direct message) @mention-based sub-agent routing.
+ * Tests for @mention-based message routing (resolveMessageTarget) and the
+ * helpers that act on its decision: dispatchSubAgents, sendUnmatchedAgentNotice,
+ * and buildAgentSessionKey.
  *
- * extractMessageContent already parses @name tokens from text-type messages
- * and populates atMentions — this applies to both group and DM messages.
- * Removing the !isGroup guard in resolveSubAgentRoute is sufficient to
- * enable sub-agent routing in DMs without duplicating the extraction logic.
+ * extractMessageContent parses @name tokens from text-type messages and
+ * populates atMentions for both group and DM messages, so resolveMessageTarget
+ * needs no isGroup guard to enable sub-agent routing in DMs.
  */
 
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
@@ -16,15 +17,10 @@ import {
   buildAgentSessionKey,
   dispatchSubAgents,
   HostRoutingHelperUnavailableError,
-  resolveMentionedSlashCommandTarget,
-  resolveSubAgentRoute,
+  resolveMessageTarget,
+  sendUnmatchedAgentNotice,
 } from "../../../src/targeting/agent-routing";
-import type {
-  DingTalkConfig,
-  DingTalkInboundMessage,
-  Logger,
-  MessageContent,
-} from "../../../src/types";
+import type { DingTalkConfig, DingTalkInboundMessage, Logger } from "../../../src/types";
 
 vi.mock("../../../src/send-service", () => ({
   sendBySession: vi.fn(),
@@ -148,164 +144,77 @@ describe("DM sub-agent @mention routing", () => {
   });
 });
 
-describe("resolveSubAgentRoute in DM", () => {
-  const mockedSendBySession = vi.mocked(sendBySession);
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("does not include atUserId in DM fallback notice", async () => {
-    const extractedContent: MessageContent = {
-      text: "@nonexistent 你好",
-      messageType: "text",
-      atMentions: [{ name: "nonexistent" }],
-    };
-
-    const result = await resolveSubAgentRoute({
-      extractedContent,
+describe("resolveMessageTarget", () => {
+  it("returns 'default' for messages without @mentions", () => {
+    const result = resolveMessageTarget({
+      extractedContent: { text: "你好", messageType: "text" },
       cfg,
       isGroup: false,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
     });
 
-    expect(result).toBeNull();
-    expect(mockedSendBySession).toHaveBeenCalledTimes(1);
-    const options = mockedSendBySession.mock.calls[0]?.[3] as Record<string, unknown>;
-    expect(options).toMatchObject({ log });
-    expect(options).not.toHaveProperty("atUserId");
+    expect(result).toEqual({ kind: "default" });
   });
 
-  it("keeps atUserId in group fallback notice", async () => {
-    const extractedContent: MessageContent = {
-      text: "@nonexistent 你好",
-      messageType: "text",
-      atMentions: [{ name: "nonexistent" }],
-      atUserDingtalkIds: [],
-    };
-
-    await resolveSubAgentRoute({
-      extractedContent,
-      cfg,
-      isGroup: true,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
-    });
-
-    const options = mockedSendBySession.mock.calls[0]?.[3] as Record<string, unknown>;
-    expect(options).toMatchObject({ log, atUserId: "user-001" });
-  });
-
-  it("skips sub-agent routing for /learn commands in DM", async () => {
-    const extractedContent: MessageContent = {
-      text: "/learn list",
-      messageType: "text",
-      atMentions: [{ name: "agent-alpha" }],
-    };
-
-    const result = await resolveSubAgentRoute({
-      extractedContent,
+  it("returns 'default' for /learn commands even with an @mention", () => {
+    const result = resolveMessageTarget({
+      extractedContent: {
+        text: "/learn list",
+        messageType: "text",
+        atMentions: [{ name: "agent-alpha" }],
+      },
       cfg,
       isGroup: false,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
     });
 
-    expect(result).toBeNull();
-    expect(mockedSendBySession).not.toHaveBeenCalled();
+    expect(result).toEqual({ kind: "default" });
+  });
+
+  it("routes normal @mention messages to subagent-content", () => {
+    const result = resolveMessageTarget({
+      extractedContent: {
+        text: "@agent-alpha 你好",
+        messageType: "text",
+        atMentions: [{ name: "agent-alpha" }],
+      },
+      cfg,
+      isGroup: false,
+    });
+
+    expect(result.kind).toBe("subagent-content");
+    if (result.kind === "subagent-content") {
+      expect(result.matchedAgents.map((a) => a.agentId)).toEqual(["agent-alpha"]);
+      expect(result.hasInvalidAgentNames).toBe(false);
+    }
+  });
+
+  it("reports an unmatched agent name as subagent-content with no matches", () => {
+    const result = resolveMessageTarget({
+      extractedContent: {
+        text: "@nonexistent 你好",
+        messageType: "text",
+        atMentions: [{ name: "nonexistent" }],
+      },
+      cfg,
+      isGroup: false,
+    });
+
+    expect(result).toEqual({
+      kind: "subagent-content",
+      matchedAgents: [],
+      unmatchedNames: ["nonexistent"],
+      hasInvalidAgentNames: true,
+    });
   });
 
   it.each([
-    "/new",
-    "/stop",
-    "/clear",
-    "/compact",
-    "/reasoning stream",
-    "/reasoning on",
-    "/model",
-    "/config",
-    "/session",
-    "/whoami",
-    "/whereami",
-    "/session-alias show",
-    "/session-alias clear",
-  ])("skips sub-agent routing for slash command '%s' with @mention", async (command) => {
-    const extractedContent: MessageContent = {
-      text: `@agent-alpha ${command}`,
-      messageType: "text",
-      atMentions: [{ name: "agent-alpha" }],
-    };
-
-    const result = await resolveSubAgentRoute({
-      extractedContent,
-      cfg,
-      isGroup: false,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
-    });
-
-    expect(result).toBeNull();
-    expect(mockedSendBySession).not.toHaveBeenCalled();
-  });
-
-  it("skips sub-agent routing for slash commands in group chat", async () => {
-    const extractedContent: MessageContent = {
-      text: "/new",
-      messageType: "text",
-      atMentions: [{ name: "agent-alpha" }],
-      atUserDingtalkIds: [],
-    };
-
-    const result = await resolveSubAgentRoute({
-      extractedContent,
-      cfg,
-      isGroup: true,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
-    });
-
-    expect(result).toBeNull();
-    expect(mockedSendBySession).not.toHaveBeenCalled();
-  });
-
-  it("still routes to sub-agent for normal @mention messages", async () => {
-    const extractedContent: MessageContent = {
-      text: "@agent-alpha 你好",
-      messageType: "text",
-      atMentions: [{ name: "agent-alpha" }],
-    };
-
-    const result = await resolveSubAgentRoute({
-      extractedContent,
-      cfg,
-      isGroup: false,
-      dingtalkConfig,
-      sessionWebhook: "https://session.webhook",
-      senderId: "user-001",
-      log,
-    });
-
-    expect(result).not.toBeNull();
-    expect(result?.matchedAgents[0]?.agentId).toBe("agent-alpha");
-  });
-});
-
-describe("resolveMentionedSlashCommandTarget", () => {
-  it("returns the mentioned agent and stripped command text in DM", () => {
-    const result = resolveMentionedSlashCommandTarget({
+    ["/new", "/new"],
+    ["/stop", "/stop"],
+    ["/reasoning stream", "/reasoning stream"],
+    ["/session-alias show", "/session-alias show"],
+  ])("routes '@agent %s' to subagent-command with the @mention stripped", (input, expected) => {
+    const result = resolveMessageTarget({
       extractedContent: {
-        text: "@agent-alpha /new",
+        text: `@agent-alpha ${input}`,
         messageType: "text",
         atMentions: [{ name: "agent-alpha" }],
       },
@@ -314,15 +223,16 @@ describe("resolveMentionedSlashCommandTarget", () => {
     });
 
     expect(result).toEqual({
-      agentId: "agent-alpha",
-      commandText: "/new",
+      kind: "subagent-command",
+      agent: expect.objectContaining({ agentId: "agent-alpha" }),
+      commandText: expected,
     });
   });
 
-  it("returns the mentioned group agent when DingTalk strips the @ token from text", () => {
-    const result = resolveMentionedSlashCommandTarget({
+  it("routes group @agent slash commands to subagent-command", () => {
+    const result = resolveMessageTarget({
       extractedContent: {
-        text: "/new",
+        text: "@agent-alpha /new",
         messageType: "text",
         atMentions: [{ name: "agent-alpha" }],
         atUserDingtalkIds: [],
@@ -332,9 +242,82 @@ describe("resolveMentionedSlashCommandTarget", () => {
     });
 
     expect(result).toEqual({
-      agentId: "agent-alpha",
+      kind: "subagent-command",
+      agent: expect.objectContaining({ agentId: "agent-alpha" }),
       commandText: "/new",
     });
+  });
+
+  it("falls back to a subagent-content notice when a slash command @mentions an unknown agent", () => {
+    const result = resolveMessageTarget({
+      extractedContent: {
+        text: "@nonexistent /new",
+        messageType: "text",
+        atMentions: [{ name: "nonexistent" }],
+      },
+      cfg,
+      isGroup: false,
+    });
+
+    expect(result).toEqual({
+      kind: "subagent-content",
+      matchedAgents: [],
+      unmatchedNames: ["nonexistent"],
+      hasInvalidAgentNames: true,
+    });
+  });
+});
+
+describe("sendUnmatchedAgentNotice", () => {
+  const mockedSendBySession = vi.mocked(sendBySession);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not include atUserId in the DM fallback notice", async () => {
+    await sendUnmatchedAgentNotice({
+      unmatchedNames: ["nonexistent"],
+      isGroup: false,
+      senderId: "user-001",
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      log,
+    });
+
+    expect(mockedSendBySession).toHaveBeenCalledTimes(1);
+    const options = mockedSendBySession.mock.calls[0]?.[3] as Record<string, unknown>;
+    expect(options).toMatchObject({ log });
+    expect(options).not.toHaveProperty("atUserId");
+  });
+
+  it("@s the sender back in the group fallback notice", async () => {
+    await sendUnmatchedAgentNotice({
+      unmatchedNames: ["nonexistent"],
+      isGroup: true,
+      senderId: "user-001",
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      log,
+    });
+
+    const options = mockedSendBySession.mock.calls[0]?.[3] as Record<string, unknown>;
+    expect(options).toMatchObject({ log, atUserId: "user-001" });
+  });
+
+  it("swallows sendBySession failures", async () => {
+    mockedSendBySession.mockRejectedValueOnce(new Error("network error"));
+
+    await expect(
+      sendUnmatchedAgentNotice({
+        unmatchedNames: ["nonexistent"],
+        isGroup: false,
+        senderId: "user-001",
+        dingtalkConfig,
+        sessionWebhook: "https://session.webhook",
+        log,
+      }),
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -486,6 +469,48 @@ describe("dispatchSubAgents", () => {
       expect.objectContaining({
         atUserId: "user-001",
         log,
+      }),
+    );
+  });
+
+  it("threads commandText into subAgentOptions and drops the response prefix for targeted commands", async () => {
+    const handleMessage = vi.fn().mockResolvedValue(undefined);
+
+    await dispatchSubAgents({
+      matchedAgents: [{ agentId: "agent-alpha", matchedName: "Alpha助手", matchSource: "name" }],
+      commandText: "/new",
+      cfg,
+      accountId: "main",
+      data: {
+        msgtype: "text",
+        text: { content: "@Alpha助手 /new" },
+        conversationType: "1",
+        conversationId: "cid_dm_1",
+        senderId: "user-001",
+        chatbotUserId: "bot-001",
+        msgId: "msg-cmd",
+        createAt: Date.now(),
+      } as DingTalkInboundMessage,
+      dingtalkConfig,
+      sessionWebhook: "https://session.webhook",
+      extractedContent: {
+        text: "@Alpha助手 /new",
+        messageType: "text",
+      },
+      handleMessage,
+      downloadMedia: vi.fn().mockResolvedValue(null),
+      log,
+    });
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    expect(handleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subAgentOptions: {
+          agentId: "agent-alpha",
+          responsePrefix: "",
+          matchedName: "Alpha助手",
+          commandText: "/new",
+        },
       }),
     );
   });


### PR DESCRIPTION
## 背景

Issue #460 反馈多 agent 模式下发送 `@agent /new`、`@agent /stop`、`@agent /reasoning stream` 等命令仍会被当成普通消息回复。#478 只让这类消息跳过 sub-agent 内容路由，但后续仍使用默认 agent 的 session，并把原始 `@agent /new` 作为 `CommandBody` 交给 OpenClaw 命令层，导致命令无法被识别。

## 目标

- 让带 `@agent` 前缀的 slash 命令作用到被提及 agent 的 session。
- 传给命令层的 `CommandBody` 去掉前导 `@agent`，例如 `@work /new` 变成 `/new`。
- 保留 `RawBody` 原始用户输入，避免丢失审计/引用展示信息。

## 实现

- 新增 `resolveMentionedSlashCommandTarget`，复用 SDK `maybeResolveTextAlias` 和现有 agent name matcher 识别带 @ 的 slash 命令目标。
- `inbound-handler` 在普通 route 前识别目标 agent，使用 `buildAgentSessionKey` 构造目标 agent session key。
- 命令分发和 runtime `CommandBody` 使用去掉 @ 前缀后的命令文本，普通消息仍保持原路由行为。
- 增加回归测试覆盖 `@work /new`：断言命中 `work` session、`CommandBody=/new`、`RawBody=@work /new`。

## 实现 TODO

- [x] 修复带 @ 的 slash 命令目标 session 路由
- [x] 修复命令层正文规范化
- [x] 增加回归测试

## 验证 TODO

- [x] `pnpm vitest run tests/unit/inbound-handler-abort.test.ts --testNamePattern "routes @agent slash commands"`
- [x] `pnpm vitest run tests/unit/inbound-handler-abort.test.ts tests/unit/targeting/dm-subagent-routing.test.ts tests/unit/inbound-handler-commands.test.ts`
- [x] `pnpm run type-check`
- [x] `pnpm run build:runtime`
- [x] `git diff --check`
- [x] `pnpm test`
- [x] `pnpm run lint`（0 errors，仍有仓库既有 warnings）

Fixes #460
