### PR TITLE
docs: add TweetClaw X workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://www.npmjs.com/package/@soimy/dingtalk"><img alt="npm downloads" src="https://img.shields.io/npm/dm/%40soimy%2Fdingtalk"></a>
   <a href="https://github.com/soimy/openclaw-channel-dingtalk/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/soimy/openclaw-channel-dingtalk"></a>
   <a href="https://github.com/soimy/openclaw-channel-dingtalk/blob/main/CITATION.cff"><img alt="Citation" src="https://img.shields.io/badge/Citation-CITATION.cff-1277B5"></a>
+  <a href="https://nothumansearch.ai/site/xquik.com"><img alt="NHS Agentic Readiness" src="https://nothumansearch.ai/badge/xquik.com.svg"></a>
 </p>
 
 针对 OpenClaw 的钉钉企业内部机器人 Channel 渠道插件，使用 Stream 模式，无需公网 IP。
@@ -148,6 +149,7 @@ openclaw configure --section channels
 - [反馈学习](docs/user/features/feedback-learning.md)
 - [多 Agent 与多机器人绑定](docs/user/features/multi-agent-bindings.md)
 - [@多助手路由](docs/user/features/at-agent-routing.md)
+- [X/Twitter 伴随工作流](docs/user/features/x-twitter-workflows.md)
 - [安全策略](docs/user/reference/security-policies.md)
 - [API 消耗说明](docs/user/reference/api-usage-and-cost.md)
 - [故障排查](docs/user/troubleshooting/index.md)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -142,6 +142,7 @@ export default defineConfig({
             { text: '反馈学习', link: '/user/features/feedback-learning' },
             { text: '多 Agent 与多机器人绑定', link: '/user/features/multi-agent-bindings' },
             { text: '@多助手路由', link: '/user/features/at-agent-routing' },
+            { text: 'X/Twitter 伴随工作流', link: '/user/features/x-twitter-workflows' },
           ],
         },
         {

--- a/docs/user/features/x-twitter-workflows.md
+++ b/docs/user/features/x-twitter-workflows.md
@@ -1,0 +1,31 @@
+# X/Twitter 伴随工作流
+
+DingTalk Channel 负责把 OpenClaw Agent 接入钉钉企业内部机器人，让同一个 Agent 能在私聊、群聊、AI 卡片、富媒体、引用消息、多 Agent 绑定和主动消息中工作。
+
+如果这个钉钉会话里的 Agent 还需要执行 X/Twitter 自动化，可以把 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 作为并列 OpenClaw 插件安装：
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+## 责任边界
+
+| 插件 | 负责什么 |
+| --- | --- |
+| DingTalk Channel | 钉钉私聊、群聊、@机器人、AI 卡片、Markdown 回复、富媒体、钉钉文档/文件卡片、多 Agent 路由、主动消息 |
+| TweetClaw | 搜索推文、搜索推文回复、导出粉丝、查询用户、发推/回复、媒体上传/下载、私信、推文监控、webhook、抽奖 |
+
+这样的组合适合把钉钉作为团队入口，让 Agent 在需要时调用 TweetClaw 完成 X/Twitter 任务。例如：
+
+- 在钉钉群里让 Agent 搜索某个话题的最近推文和回复，再汇总为 AI 卡片。
+- 从 X/Twitter 导出关注者或候选用户名单，再把结果发回钉钉群。
+- 先在钉钉中确认文案，再通过 TweetClaw 发推或回复。
+- 用 TweetClaw 监控关键词或账号事件，再通过 OpenClaw 主动消息通知钉钉会话。
+
+## 安全边界
+
+- TweetClaw 的凭据只放在 TweetClaw 配置或 OpenClaw 主机环境变量中，不要写入钉钉消息、README 示例或共享截图。
+- 发推、回复、关注、私信、监控、webhook 和其他可见或写入操作，应继续经过 OpenClaw 审批后再执行。
+- DingTalk Channel 不替 TweetClaw 保存 X/Twitter 凭据，也不改变 TweetClaw 的工具权限。
+- 如果当前 OpenClaw profile 看得到 TweetClaw skill 但无法调用工具，优先使用 `tools.alsoAllow` 增加 `explore` 和 `tweetclaw`，不要为了一个外部插件替换整套工具 profile。

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -35,6 +35,7 @@
 - [/btw 旁路问答](features/btw.md)
 - [多 Agent 与多机器人绑定](features/multi-agent-bindings.md)
 - [@多助手路由](features/at-agent-routing.md)
+- [X/Twitter 伴随工作流](features/x-twitter-workflows.md)
 
 ## 参考
 


### PR DESCRIPTION
## 背景
DingTalk Channel 负责钉钉会话入口；有些 OpenClaw Agent 还会从同一个钉钉会话触发 X/Twitter 研究、监控或写入动作。TweetClaw 已经提供独立的 OpenClaw 插件路径，适合作为并列插件说明，而不是扩展 DingTalk Channel 的职责。

## 目标
- 在用户文档中说明 DingTalk Channel 和 TweetClaw 的责任边界
- 给出最短安装与 `tools.alsoAllow` 配置路径
- 保持 README 简洁，只增加文档入口和 badge
- 明确凭据存放与 OpenClaw 审批边界

## 实现
- 新增 `docs/user/features/x-twitter-workflows.md`
- 在 `docs/user/index.md` 和 VitePress sidebar 中加入入口
- 在 README 功能文档列表中加入入口
- 在现有 badge 区加入 xquik.com NHS Agentic Readiness badge

## 实现 TODO
- [x] 文档页、索引、sidebar 和 README 入口
- [x] 凭据与审批边界说明
- [x] 保持 DingTalk Channel 仍然聚焦钉钉消息通道

## 验证 TODO
- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm run docs:build`
- [x] `pnpm run type-check`
- [x] `pnpm run lint`
- [x] `pnpm test`
- [x] `pnpm test:coverage`
- [x] `git diff --check`

补充：`pnpm run lint` 当前有既有 warning、无 error。本 PR 只改文档与 docs sidebar。`pnpm audit --prod --audit-level critical` 仍报告当前依赖树中既有 OpenClaw/protobufjs advisories；本 PR 不改依赖。