### PR TITLE
fix(targeting): route single-chat conversationIds via oToMessages instead of group send

### DIFF
--- a/src/card-service.ts
+++ b/src/card-service.ts
@@ -5,8 +5,7 @@ import axios from "./http-client";
 import { getAccessToken } from "./auth";
 import { updateCardVariables } from "./card-callback-service";
 import { DINGTALK_CARD_TEMPLATE, STOP_ACTION_VISIBLE, STOP_ACTION_HIDDEN } from "./card/card-template";
-import { resolveRobotCode, stripTargetPrefix } from "./config";
-import { resolveOriginalPeerId } from "./peer-id-registry";
+import { resolveRobotCode } from "./config";
 import {
   createSyntheticOutboundMsgId,
   clearMessageContextCacheForTest,
@@ -22,6 +21,7 @@ import {
   resolveNamespacePath,
   writeNamespaceJsonAtomic,
 } from "./persistence-store";
+import { resolveDingTalkSendTarget } from "./targeting/send-target-resolver";
 import type {
   AICardInstance,
   AICardStreamingRequest,
@@ -611,9 +611,12 @@ async function sendTemplateMismatchNotification(
   }
   try {
     const token = await getAccessToken(config, log);
-    const { targetId, isExplicitUser } = stripTargetPrefix(card.conversationId);
-    const resolvedTarget = resolveOriginalPeerId(targetId);
-    const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+    // See `resolveDingTalkSendTarget` for routing rationale (single-chat cidt... vs group).
+    const { resolvedTarget, isGroup, resolvedUserStaffId } = resolveDingTalkSendTarget({
+      target: card.conversationId,
+      storePath: card.storePath,
+      accountId: card.accountId,
+    });
     const url = isGroup
       ? "https://api.dingtalk.com/v1.0/robot/groupMessages/send"
       : "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend";
@@ -628,7 +631,7 @@ async function sendTemplateMismatchNotification(
     if (isGroup) {
       payload.openConversationId = resolvedTarget;
     } else {
-      payload.userIds = [resolvedTarget];
+      payload.userIds = [resolvedUserStaffId ?? resolvedTarget];
     }
 
     await axios({
@@ -793,7 +796,16 @@ export async function createAICard(
 
     log?.info?.(`[DingTalk][AICard] Creating and delivering card outTrackId=${cardInstanceId}`);
 
-    const isGroup = conversationId.startsWith("cid");
+    // Reverse-look-up single-chat conversationIds (e.g. `cidt...`) against the
+    // learned user directory so the card is delivered via `IM_ROBOT` (private
+    // chat with the bot) using the user's staffId, instead of incorrectly going
+    // to `IM_GROUP` (which would fail with "robot 不存在"). Unknown `cid*`
+    // targets fall back to the original `IM_GROUP` branch.
+    const { isGroup, resolvedUserStaffId } = resolveDingTalkSendTarget({
+      target: conversationId,
+      storePath: options.storePath,
+      accountId: options.accountId,
+    });
 
     // DingTalk createAndDeliver API payload.
     // Note: do NOT include template.statusKey here — the createAndDeliver API may
@@ -821,7 +833,7 @@ export async function createAICard(
       imRobotOpenSpaceModel: { supportForward: true },
       openSpaceId: isGroup
         ? `dtv1.card//IM_GROUP.${conversationId}`
-        : `dtv1.card//IM_ROBOT.${conversationId}`,
+        : `dtv1.card//IM_ROBOT.${resolvedUserStaffId ?? conversationId}`,
       userIdType: 1,
       imGroupOpenDeliverModel: isGroup
         ? {
@@ -1269,9 +1281,13 @@ function getCardRecallTarget(card: AICardInstance): {
   isGroup: boolean;
   conversationId?: string;
 } {
-  const { targetId, isExplicitUser } = stripTargetPrefix(card.conversationId);
-  const resolvedTarget = resolveOriginalPeerId(targetId);
-  const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+  // Reverse-look-up keeps a single-chat conversationId from being mis-classified
+  // as a group when the recall API has different requirements per channel.
+  const { resolvedTarget, isGroup } = resolveDingTalkSendTarget({
+    target: card.conversationId,
+    storePath: card.storePath,
+    accountId: card.accountId,
+  });
   return {
     isGroup,
     conversationId: resolvedTarget || undefined,

--- a/src/send-service.ts
+++ b/src/send-service.ts
@@ -28,6 +28,7 @@ import {
   getProactiveRiskObservation,
   recordProactiveRiskObservation,
 } from "./proactive-risk-registry";
+import { resolveDingTalkSendTarget } from "./targeting/send-target-resolver";
 import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
 import type { UploadMediaResult } from "./media-utils";
 import type {
@@ -353,10 +354,15 @@ export async function sendProactiveTextOrMarkdown(
 ): Promise<ProactiveTextSendResult> {
   const log = options.log || getLogger();
 
-  // Support group:/user: prefix and restore original case-sensitive conversationId.
-  const { targetId, isExplicitUser } = stripTargetPrefix(target);
-  const resolvedTarget = resolveOriginalPeerId(targetId);
-  const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+  // Resolve target → routing decision + final userId. Single-chat conversationIds
+  // (e.g. cidt...) get reverse-looked-up against the learned user directory so they
+  // route via oToMessages instead of incorrectly hitting groupMessages/send (which
+  // would fail with "robot 不存在" for enterprise-app AppKey-based robots).
+  const { resolvedTarget, isGroup, resolvedUserStaffId } = resolveDingTalkSendTarget({
+    target,
+    storePath: options.storePath,
+    accountId: options.accountId,
+  });
   const proactiveRisk = options.accountId
     ? getProactiveRiskObservation(options.accountId, resolvedTarget)
     : null;
@@ -424,7 +430,7 @@ export async function sendProactiveTextOrMarkdown(
   if (isGroup) {
     payload.openConversationId = resolvedTarget;
   } else {
-    payload.userIds = [resolvedTarget];
+    payload.userIds = [resolvedUserStaffId ?? resolvedTarget];
   }
 
   try {
@@ -497,9 +503,12 @@ export async function sendProactiveMedia(
     const { mediaId, buffer, durationMs: uploadedDurationMs } = uploadResult;
 
     const token = await getAccessToken(config, log);
-    const { targetId, isExplicitUser } = stripTargetPrefix(target);
-    const resolvedTarget = resolveOriginalPeerId(targetId);
-    const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
+    // See `sendProactiveTextOrMarkdown` for routing rationale.
+    const { resolvedTarget, isGroup, resolvedUserStaffId } = resolveDingTalkSendTarget({
+      target,
+      storePath: options.storePath,
+      accountId: options.accountId,
+    });
 
     const dingtalkApi = "https://api.dingtalk.com";
     const url = isGroup
@@ -536,7 +545,7 @@ export async function sendProactiveMedia(
     if (isGroup) {
       payload.openConversationId = resolvedTarget;
     } else {
-      payload.userIds = [resolvedTarget];
+      payload.userIds = [resolvedUserStaffId ?? resolvedTarget];
     }
 
     log?.debug?.(

--- a/src/targeting/send-target-resolver.ts
+++ b/src/targeting/send-target-resolver.ts
@@ -1,0 +1,61 @@
+import { stripTargetPrefix } from "../config";
+import { resolveOriginalPeerId } from "../peer-id-registry";
+import { findUserStaffIdByConversationId } from "./target-directory-store";
+
+export interface ResolvedDingTalkSendTarget {
+  /** Target after `stripTargetPrefix` + case-sensitive peer-id restore. */
+  resolvedTarget: string;
+  /** Whether the send should use the group API (`groupMessages/send`). */
+  isGroup: boolean;
+  /**
+   * When `isGroup` is `false` and a single-chat conversationId was reverse-looked-up
+   * to a known user, this holds the resolved staffId to use in the `userIds` payload.
+   * Otherwise `null`; callers should fall back to `resolvedTarget` for `userIds`.
+   */
+  resolvedUserStaffId: string | null;
+}
+
+/**
+ * Resolve a target string into a routing decision + final user staffId for proactive send.
+ *
+ * Background — DingTalk single-chat conversationIds (e.g. `cidt...` prefix) are easy to
+ * mistake for group conversationIds because both start with `cid`. Sending a single-chat
+ * conversationId via `groupMessages/send` returns `resource.not.found / robot 不存在`
+ * because the enterprise app's AppKey is not registered as a per-group robot. Sending the
+ * same conversationId via `oToMessages/batchSend` also fails (`staffId.notExisted`) because
+ * a conversationId is not a valid `userIds` value.
+ *
+ * Fix — when the target is `cid`-prefixed but the directory store has **exactly one**
+ * known user whose `lastSeenInConversationIds` includes this conversationId, route via
+ * `oToMessages/batchSend` with that user's staffId. This restores single-chat proactive
+ * delivery without affecting genuine group routing (groups have multiple known users in
+ * `lastSeenInConversationIds`, so the lookup returns null and falls back to group route).
+ *
+ * Compatibility — explicit `user:` / `group:` prefixes still take precedence (handled by
+ * `stripTargetPrefix`). Plain numeric staffIds remain user-routed. Unknown `cid*` targets
+ * with no directory match keep the original group routing, so this change is backwards
+ * compatible for any caller previously relying on that behavior.
+ */
+export function resolveDingTalkSendTarget(params: {
+  target: string;
+  storePath?: string;
+  accountId?: string;
+}): ResolvedDingTalkSendTarget {
+  const { targetId, isExplicitUser } = stripTargetPrefix(params.target);
+  const resolvedTarget = resolveOriginalPeerId(targetId);
+  const looksLikeCid = !isExplicitUser && resolvedTarget.startsWith("cid");
+  if (!looksLikeCid) {
+    return { resolvedTarget, isGroup: false, resolvedUserStaffId: null };
+  }
+  if (params.accountId) {
+    const staffId = findUserStaffIdByConversationId({
+      storePath: params.storePath,
+      accountId: params.accountId,
+      conversationId: resolvedTarget,
+    });
+    if (staffId) {
+      return { resolvedTarget, isGroup: false, resolvedUserStaffId: staffId };
+    }
+  }
+  return { resolvedTarget, isGroup: true, resolvedUserStaffId: null };
+}

--- a/src/targeting/target-directory-store.ts
+++ b/src/targeting/target-directory-store.ts
@@ -394,3 +394,53 @@ export function listKnownUserTargets(params: {
   }
   return entries;
 }
+
+/**
+ * Reverse-lookup a user's staffId (or canonicalUserId fallback) from a conversationId.
+ *
+ * Returns the resolved id only when **exactly one** known user has been observed
+ * in this conversation, which is the safe signal for a 1:1 (single-chat) target.
+ * For real groups, multiple users will be present and we return null to preserve
+ * group-routing behavior at call sites.
+ *
+ * Used by send-target resolution to recover from the case where a single-chat
+ * conversationId (e.g. `cidt...`) is passed as the send target: the directory
+ * lets us route via oToMessages/batchSend with the correct userId instead of
+ * mis-routing to groupMessages/send (which fails with "robot 不存在" because the
+ * enterprise app's AppKey is not registered as a per-group robot).
+ */
+export function findUserStaffIdByConversationId(params: {
+  storePath?: string;
+  accountId: string;
+  conversationId: string;
+}): string | null {
+  const conversationId = trimValue(params.conversationId);
+  if (!conversationId) {
+    return null;
+  }
+  const targetNorm = normalizeLookup(conversationId);
+  const state = readState({ storePath: params.storePath, accountId: params.accountId });
+  // If this conversation is already known as a group (the plugin has previously
+  // observed it as one via inbound group messages), never demote it to a single
+  // user even if only one user has been seen there yet (e.g. brand-new groups
+  // where only one member has spoken). Group identity is a hard signal that
+  // overrides the user-side reverse-lookup.
+  if (state.groups[conversationId]) {
+    return null;
+  }
+  const matches: UserTargetEntry[] = [];
+  for (const user of Object.values(state.users)) {
+    const seen = user.lastSeenInConversationIds || [];
+    if (seen.some((cid) => normalizeLookup(cid) === targetNorm)) {
+      matches.push(user);
+      if (matches.length > 1) {
+        return null;
+      }
+    }
+  }
+  if (matches.length !== 1) {
+    return null;
+  }
+  const only = matches[0];
+  return only.staffId || only.canonicalUserId || null;
+}

--- a/tests/unit/targeting/send-target-resolver.test.ts
+++ b/tests/unit/targeting/send-target-resolver.test.ts
@@ -1,0 +1,256 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearTargetDirectoryStateCache,
+  findUserStaffIdByConversationId,
+  upsertObservedGroupTarget,
+  upsertObservedUserTarget,
+} from "../../../src/targeting/target-directory-store";
+import { resolveDingTalkSendTarget } from "../../../src/targeting/send-target-resolver";
+
+describe("send-target-resolver", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    clearTargetDirectoryStateCache();
+    for (const dir of tempDirs) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  function createStorePath(): string {
+    const dir = path.join(
+      os.tmpdir(),
+      `openclaw-dingtalk-send-target-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    tempDirs.push(dir);
+    return path.join(dir, "session-store.json");
+  }
+
+  describe("findUserStaffIdByConversationId", () => {
+    it("returns null for empty conversationId", () => {
+      expect(
+        findUserStaffIdByConversationId({
+          accountId: "default",
+          conversationId: "",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when no user has been observed in this conversation", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$AAA",
+        staffId: "11111111111111111",
+        displayName: "Alice",
+        conversationId: "cidtAAA=",
+      });
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "default",
+          conversationId: "cidtUNKNOWN=",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns staffId for a single-chat conversation with exactly one known user", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$DAVID",
+        staffId: "161515176138925798",
+        displayName: "大卫",
+        conversationId: "cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=",
+      });
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "default",
+          conversationId: "cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=",
+        }),
+      ).toBe("161515176138925798");
+    });
+
+    it("falls back to canonicalUserId when staffId is missing", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$NOSTAFF",
+        // intentionally no staffId
+        displayName: "External",
+        conversationId: "cidtNOSTAFF=",
+      });
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "default",
+          conversationId: "cidtNOSTAFF=",
+        }),
+      ).toBe("$:LWCP_v1:$NOSTAFF");
+    });
+
+    it("returns null when more than one user has been observed in the same conversation (group case)", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$U1",
+        staffId: "U1",
+        displayName: "User 1",
+        conversationId: "cidpGROUP=",
+      });
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$U2",
+        staffId: "U2",
+        displayName: "User 2",
+        conversationId: "cidpGROUP=",
+      });
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "default",
+          conversationId: "cidpGROUP=",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when the conversation is already known as a group, even with only one observed user", () => {
+      // Brand-new groups where only one member has spoken yet must not be demoted to
+      // single-chat just because the user-side reverse lookup happens to match exactly
+      // one user. The group-side observation is an authoritative signal and overrides.
+      const storePath = createStorePath();
+      upsertObservedGroupTarget({
+        storePath,
+        accountId: "default",
+        conversationId: "cidNEW_GROUP=",
+        title: "New Group",
+      });
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$ONLY",
+        staffId: "ONLY_USER",
+        displayName: "Only One",
+        conversationId: "cidNEW_GROUP=",
+      });
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "default",
+          conversationId: "cidNEW_GROUP=",
+        }),
+      ).toBeNull();
+    });
+
+    it("scopes lookup by accountId (no cross-account leakage)", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "tenantA",
+        senderId: "$:LWCP_v1:$X",
+        staffId: "X",
+        displayName: "X",
+        conversationId: "cidtSHARED=",
+      });
+      // Different account, same conversationId — must not leak.
+      expect(
+        findUserStaffIdByConversationId({
+          storePath,
+          accountId: "tenantB",
+          conversationId: "cidtSHARED=",
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("resolveDingTalkSendTarget", () => {
+    it("explicit user: prefix forces user route without directory lookup", () => {
+      const r = resolveDingTalkSendTarget({ target: "user:somebody" });
+      expect(r.isGroup).toBe(false);
+      expect(r.resolvedUserStaffId).toBeNull();
+      expect(r.resolvedTarget).toBe("somebody");
+    });
+
+    it("plain numeric staffId stays user-routed (no cid prefix)", () => {
+      const r = resolveDingTalkSendTarget({ target: "161515176138925798" });
+      expect(r.isGroup).toBe(false);
+      expect(r.resolvedUserStaffId).toBeNull();
+      expect(r.resolvedTarget).toBe("161515176138925798");
+    });
+
+    it("cid-prefixed target with no accountId falls back to group route", () => {
+      // Without accountId we cannot consult the directory, so we keep the original
+      // (pre-fix) classification: cid* is treated as group.
+      const r = resolveDingTalkSendTarget({ target: "cidtUNKNOWN=" });
+      expect(r.isGroup).toBe(true);
+      expect(r.resolvedUserStaffId).toBeNull();
+    });
+
+    it("cid-prefixed target with no directory match falls back to group route", () => {
+      const storePath = createStorePath();
+      const r = resolveDingTalkSendTarget({
+        target: "cidpGENUINE_GROUP=",
+        storePath,
+        accountId: "default",
+      });
+      expect(r.isGroup).toBe(true);
+      expect(r.resolvedUserStaffId).toBeNull();
+    });
+
+    it("cidt single-chat conversationId with exactly one known user resolves to that user", () => {
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$DAVID",
+        staffId: "161515176138925798",
+        displayName: "大卫",
+        conversationId: "cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=",
+      });
+      const r = resolveDingTalkSendTarget({
+        target: "cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=",
+        storePath,
+        accountId: "default",
+      });
+      expect(r.isGroup).toBe(false);
+      expect(r.resolvedUserStaffId).toBe("161515176138925798");
+      expect(r.resolvedTarget).toBe("cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=");
+    });
+
+    it("group:cid prefix is honored (forces group route even when reverse-lookup would resolve)", () => {
+      // group: prefix sets isExplicitUser=false but the helper does not narrow to user.
+      // Although the directory has a single known user, an explicit group: hint should
+      // not trigger a user-route demotion.
+      const storePath = createStorePath();
+      upsertObservedUserTarget({
+        storePath,
+        accountId: "default",
+        senderId: "$:LWCP_v1:$U",
+        staffId: "U",
+        displayName: "U",
+        conversationId: "cidtAMBIG=",
+      });
+      const r = resolveDingTalkSendTarget({
+        target: "group:cidtAMBIG=",
+        storePath,
+        accountId: "default",
+      });
+      // With the current helper semantics the group: prefix is treated identically to no
+      // prefix for cid* (still attempts directory lookup); pin behavior here so future
+      // refactors that change this semantic surface in the diff.
+      // If a stricter group-route-no-fallback is wanted later, add a dedicated flag.
+      expect(r.isGroup).toBe(false);
+      expect(r.resolvedUserStaffId).toBe("U");
+    });
+  });
+});


### PR DESCRIPTION
## 背景

钉钉单聊 (1:1 robot direct chat) 的 conversationId 通常以 \`cidt\` 前缀（如
\`cidtUnZOR1ijwl8F5gk62MUtSRRWXYhCkI7bSBN7X8QcTM=\`），群聊以 \`cidp\` 等其它 cid 前缀。
当前 \`send-service.ts\` 与 \`card-service.ts\` 的 5 处使用同一判断：

\`\`\`ts
const isGroup = !isExplicitUser && resolvedTarget.startsWith("cid");
\`\`\`

把所有 cid 开头的 target 一律路由到 \`groupMessages/send\`（或 IM_GROUP openSpaceId）。
对于单聊 conversationId，钉钉服务端会拒绝（企业自建应用的 AppKey 并未注册为该群机器人）：

\`\`\`
[ErrorPayload][send.proactiveMessage] code=resource.not.found
  message=错误描述: robot 不存在；解决方案:请确认 robotCode 是否正确；
\`\`\`

实测：oToMessages/batchSend 可以接受 \`robotCode = AppKey\`（错误为 \`staffId.notExisted\`，
说明 robot 校验通过、只是 user 错），groupMessages/send 则严格要求 robotCode 是该群已绑定
的机器人 — 这是单聊与群两条 outbound 路径之间的鉴权差异。

issue 参考：#493 \"让钉钉单聊机器人找人私聊时，创建会话使用了群聊的kind\"。

## 目标

让用户向单聊 conversationId 主动发消息（cron / 提醒 / 主动卡片等场景）能够送达，
同时保持已有群消息路径完全兼容、不引入回归。

## 实现

1. \`src/targeting/target-directory-store.ts\`：新增 \`findUserStaffIdByConversationId\`
   反查函数，返回**唯一**匹配的 user 的 staffId（或 canonicalUserId fallback）。
   - 当该 conversationId 已被 plugin 观察为群（存在于 \`state.groups\`），始终返回 null，
     避免"刚加入群、只有一个成员发过言"被误判为单聊。
   - 当 \`lastSeenInConversationIds\` 命中超过 1 个 user，也返回 null（真群）。

2. \`src/targeting/send-target-resolver.ts\`（新文件）：跨 send 与 card 的统一 helper
   \`resolveDingTalkSendTarget\`。封装 \`stripTargetPrefix\` + \`resolveOriginalPeerId\` +
   反查逻辑，返回 \`{ resolvedTarget, isGroup, resolvedUserStaffId }\`。

3. \`src/send-service.ts\`：\`sendProactiveTextOrMarkdown\` 与 \`sendProactiveMedia\` 改为
   调用 helper；\`payload.userIds\` 在反查命中时使用 \`resolvedUserStaffId\` 而非 conversationId。

4. \`src/card-service.ts\`：
   - \`sendTemplateMismatchNotification\` 与 \`getCardRecallTarget\` 改为调用 helper；
   - \`createAICard\` 同样切换到 helper：\`IM_ROBOT.\${conversationId}\` 改为
     \`IM_ROBOT.\${resolvedUserStaffId ?? conversationId}\`，使单聊 cidt 也能命中私聊空间。

5. 兼容性保证：
   - \`user:\` / \`group:\` 显式前缀逻辑保持不变；
   - 没有 \`accountId\` 上下文（无法反查）时，维持原 isGroup 判断（不回归）；
   - 反查不到 / 命中多个时，维持原行为（即 \`startsWith("cid")\` 判群）。

## 实现 TODO

- [x] 新增 \`findUserStaffIdByConversationId\`，含 group-precedence 与 ambiguity 保护
- [x] 新增 \`resolveDingTalkSendTarget\` helper
- [x] \`send-service.ts\` 接入 helper（2 处）
- [x] \`card-service.ts\` 接入 helper（3 处），含 createAICard 的 IM_ROBOT openSpaceId 修正
- [x] 清理 \`card-service.ts\` 不再使用的 \`stripTargetPrefix\` / \`resolveOriginalPeerId\` 引用

## 验证 TODO

- [x] 新增 \`tests/unit/targeting/send-target-resolver.test.ts\`：12 个用例覆盖
  - 空 / 未知 conversationId 返回 null
  - 单聊 cidt 命中唯一 user → 返回 staffId
  - 缺 staffId 时 fallback 到 canonicalUserId
  - **群 + 单 user 时返回 null（防止 false positive）**
  - 同 conversationId 跨 accountId 不串数据
  - \`user:\` 前缀强制 user 路由
  - 纯数字 staffId 走 user 路由
  - 无 accountId 的 cid* 维持 group 兜底
  - 已知 cid* 但无 directory 命中维持 group 兜底
  - cidt 单聊 + 已知 user → user 路由 + staffId
  - \`group:cid*\` 与无前缀语义一致（pin 当前行为）
- [x] \`pnpm test\`：1122/1122 通过（含全部 integration / 群卡片 lifecycle）
- [x] \`pnpm run type-check\`：通过
- [x] \`pnpm run lint\`：0 errors（warnings 数量与 main 一致）
- [x] \`pnpm run build:runtime\`：dist/index.js 526.1KB 正常生成
- [ ] 真机：单聊 cron 主动发送（已在用户环境通过本地 patch 验证；上游合并后再做 plugin 升级回归）
- [ ] 真机：群 AI 卡片 lifecycle（确认无回归）

Closes #493