### PR TITLE
fix(reply): keep DingTalk markdown finals in session replies

### DIFF
--- a/src/reply-strategy-markdown.ts
+++ b/src/reply-strategy-markdown.ts
@@ -114,6 +114,10 @@ export function createMarkdownReplyStrategy(
     getReplyOptions(): ReplyOptions {
       return {
         disableBlockStreaming: ctx.disableBlockStreaming === true,
+        // DingTalk markdown/sessionWebhook mode owns the visible reply surface.
+        // Keep runtime final replies on this strategy even when group chats
+        // default source replies to message-tool-only.
+        sourceReplyDeliveryMode: "automatic",
       };
     },
 

--- a/tests/unit/reply-strategy-markdown.test.ts
+++ b/tests/unit/reply-strategy-markdown.test.ts
@@ -42,6 +42,7 @@ describe("reply-strategy-markdown", () => {
         const opts = strategy.getReplyOptions();
 
         expect(opts.disableBlockStreaming).toBe(false);
+        expect(opts.sourceReplyDeliveryMode).toBe("automatic");
         expect("onBlockReply" in opts).toBe(false);
         expect(opts.onPartialReply).toBeUndefined();
         expect(opts.onReasoningStream).toBeUndefined();


### PR DESCRIPTION
关联：#556、#563

## 背景

OpenClaw 2026.5.7 之后，群聊默认/显式 `messages.groupChat.visibleReplies=message_tool` 会让 source reply delivery 被解析成 `message_tool_only`。这对普通群聊消息是合理默认，但 DingTalk 插件的 markdown/sessionWebhook strategy 本身就是可见回复承载面；如果不覆盖该模式，上游 final reply 会被导向 message tool 路径，插件侧收不到 final，自然也不会进入 sessionWebhook 文本/markdown 回复链路。

PR #557 已经用同类方法修复了 card strategy：card mode 在 `getReplyOptions()` 中声明 `sourceReplyDeliveryMode: "automatic"`，让 final 回到卡片策略。本 PR 将同样的策略应用到 markdown/sessionWebhook 回复。

## 目标

- 群聊 `messages.groupChat.visibleReplies=message_tool` 下，DingTalk markdown/sessionWebhook 回复仍能收到 runtime final。
- 不修改全局 `openclaw.json` 行为，不新增配置项。
- 不包含 PR #558 的 session media proactive API 路由改动。
- 不影响现有 card strategy；card 路径仍由 PR #557 的修复负责。

## 实现

- `src/reply-strategy-markdown.ts`：`getReplyOptions()` 显式返回 `sourceReplyDeliveryMode: "automatic"`。
- `tests/unit/reply-strategy-markdown.test.ts`：补充断言，防止 markdown strategy 再次遗漏该覆盖。

## 实现 TODO

- [x] 移除本 PR 中旧的 empty-final recovery 兜底改动。
- [x] 移除本 PR 中 session media proactive API 路由改动；该内容归属 PR #558。
- [x] 仅保留 markdown/sessionWebhook final delivery mode 根因修复。

## 验证 TODO

- [x] `pnpm vitest run tests/unit/reply-strategy-markdown.test.ts -t "getReplyOptions enables block streaming"` 先失败后通过。
- [x] `pnpm vitest run tests/unit/reply-strategy-markdown.test.ts tests/unit/inbound-handler.test.ts tests/unit/inbound-handler-media.test.ts tests/unit/reply-strategy-card.test.ts` 通过，4 files / 131 tests。
- [x] `pnpm type-check` 通过。
- [x] `pnpm lint` 通过，0 errors，仍有既有 warnings。
- [x] `git diff --check` 通过。
