### PR TITLE
fix(card): dedupe mediaUrls upload in deliver flow

### DIFF
--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -133,6 +133,8 @@ export function createCardReplyStrategy(
   let latestReasoningSnapshot = "";
   /** Non-image media attachments deferred for out-of-card delivery. */
   let pendingNonImageMedia: DeferredMedia[] = [];
+  /** URLs already uploaded as image blocks — prevents duplicate upload when the same mediaUrl appears in both a non-final and final deliver. */
+  const uploadedMediaUrls = new Set<string>();
 
   const getRenderedTimeline = (options: { preferFinalAnswer?: boolean } = {}): string => {
     const fallbackAnswer = finalTextForFallback || (sawFinalDelivery ? EMPTY_FINAL_REPLY : undefined);
@@ -477,6 +479,9 @@ export function createCardReplyStrategy(
         // Inline media upload → image blocks in card; defer non-image attachments
         if (payload.mediaUrls.length > 0) {
           for (const url of payload.mediaUrls) {
+            if (uploadedMediaUrls.has(url)) {
+              continue;
+            }
             try {
               const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
               const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -492,6 +497,7 @@ export function createCardReplyStrategy(
               const result = await uploadMedia(config, prepared.path, "image", log);
               await prepared.cleanup?.();
               if (result?.mediaId) {
+                uploadedMediaUrls.add(url);
                 await controller.appendImageBlock(result.mediaId);
               }
             } catch (err: unknown) {
@@ -555,6 +561,9 @@ export function createCardReplyStrategy(
       // ---- block: only handle reasoning/media (other text blocks are unused) ----
       if (payload.mediaUrls.length > 0) {
         for (const url of payload.mediaUrls) {
+          if (uploadedMediaUrls.has(url)) {
+            continue;
+          }
           try {
             const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
             const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -567,6 +576,7 @@ export function createCardReplyStrategy(
             const result = await uploadMedia(config, prepared.path, "image", log);
             await prepared.cleanup?.();
             if (result?.mediaId) {
+              uploadedMediaUrls.add(url);
               await controller.appendImageBlock(result.mediaId);
             }
           } catch (err: unknown) {

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -348,6 +348,8 @@ export function createCardReplyStrategy(
       }
 
       if (processedMediaUrls.has(candidate.url)) {
+        const placeholder = buildImagePlaceholderText({ alt: candidate.alt, url: candidate.url });
+        nextText = `${nextText.slice(0, candidate.start)}${placeholder}${nextText.slice(candidate.end)}`;
         continue;
       }
 

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -487,7 +487,6 @@ export function createCardReplyStrategy(
             if (processedMediaUrls.has(url)) {
               continue;
             }
-            processedMediaUrls.add(url);
             try {
               const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
               const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -503,10 +502,10 @@ export function createCardReplyStrategy(
               const result = await uploadMedia(config, prepared.path, "image", log);
               await prepared.cleanup?.();
               if (result?.mediaId) {
+                processedMediaUrls.add(url);
                 await controller.appendImageBlock(result.mediaId);
               }
             } catch (err: unknown) {
-              processedMediaUrls.delete(url);
               const msg = err instanceof Error ? err.message : String(err);
               log?.debug?.(`[DingTalk][Card] Failed to upload media as image block: ${msg}`);
             }
@@ -570,7 +569,6 @@ export function createCardReplyStrategy(
           if (processedMediaUrls.has(url)) {
             continue;
           }
-          processedMediaUrls.add(url);
           try {
             const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
             const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -583,10 +581,10 @@ export function createCardReplyStrategy(
             const result = await uploadMedia(config, prepared.path, "image", log);
             await prepared.cleanup?.();
             if (result?.mediaId) {
+              processedMediaUrls.add(url);
               await controller.appendImageBlock(result.mediaId);
             }
           } catch (err: unknown) {
-            processedMediaUrls.delete(url);
             const msg = err instanceof Error ? err.message : String(err);
             log?.debug?.(`[DingTalk][Card] Failed to upload media as image block: ${msg}`);
           }

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -133,8 +133,8 @@ export function createCardReplyStrategy(
   let latestReasoningSnapshot = "";
   /** Non-image media attachments deferred for out-of-card delivery. */
   let pendingNonImageMedia: DeferredMedia[] = [];
-  /** URLs already uploaded as image blocks — prevents duplicate upload when the same mediaUrl appears in both a non-final and final deliver. */
-  const uploadedMediaUrls = new Set<string>();
+  /** URLs already processed in this card session — prevents duplicate upload/send when the same mediaUrl appears in both a non-final and final deliver. */
+  const processedMediaUrls = new Set<string>();
 
   const getRenderedTimeline = (options: { preferFinalAnswer?: boolean } = {}): string => {
     const fallbackAnswer = finalTextForFallback || (sawFinalDelivery ? EMPTY_FINAL_REPLY : undefined);
@@ -347,6 +347,10 @@ export function createCardReplyStrategy(
         continue;
       }
 
+      if (processedMediaUrls.has(candidate.url)) {
+        continue;
+      }
+
       let prepared: Awaited<ReturnType<typeof prepareMediaInput>> | undefined;
       try {
         prepared = await prepareMediaInput(candidate.url, log, config.mediaUrlAllowlist);
@@ -363,6 +367,7 @@ export function createCardReplyStrategy(
           continue;
         }
 
+        processedMediaUrls.add(candidate.url);
         const placeholder = buildImagePlaceholderText({ alt: candidate.alt, url: candidate.url });
         const blockText = candidate.alt.trim() || placeholder.replace(/^见下图/, "").trim() || "图片";
         successfulReroutes.push({
@@ -479,9 +484,10 @@ export function createCardReplyStrategy(
         // Inline media upload → image blocks in card; defer non-image attachments
         if (payload.mediaUrls.length > 0) {
           for (const url of payload.mediaUrls) {
-            if (uploadedMediaUrls.has(url)) {
+            if (processedMediaUrls.has(url)) {
               continue;
             }
+            processedMediaUrls.add(url);
             try {
               const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
               const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -497,10 +503,10 @@ export function createCardReplyStrategy(
               const result = await uploadMedia(config, prepared.path, "image", log);
               await prepared.cleanup?.();
               if (result?.mediaId) {
-                uploadedMediaUrls.add(url);
                 await controller.appendImageBlock(result.mediaId);
               }
             } catch (err: unknown) {
+              processedMediaUrls.delete(url);
               const msg = err instanceof Error ? err.message : String(err);
               log?.debug?.(`[DingTalk][Card] Failed to upload media as image block: ${msg}`);
             }
@@ -561,9 +567,10 @@ export function createCardReplyStrategy(
       // ---- block: only handle reasoning/media (other text blocks are unused) ----
       if (payload.mediaUrls.length > 0) {
         for (const url of payload.mediaUrls) {
-          if (uploadedMediaUrls.has(url)) {
+          if (processedMediaUrls.has(url)) {
             continue;
           }
+          processedMediaUrls.add(url);
           try {
             const prepared = await prepareMediaInput(url, log, config.mediaUrlAllowlist);
             const mediaType = resolveOutboundMediaType({ mediaPath: prepared.path, asVoice: false });
@@ -576,10 +583,10 @@ export function createCardReplyStrategy(
             const result = await uploadMedia(config, prepared.path, "image", log);
             await prepared.cleanup?.();
             if (result?.mediaId) {
-              uploadedMediaUrls.add(url);
               await controller.appendImageBlock(result.mediaId);
             }
           } catch (err: unknown) {
+            processedMediaUrls.delete(url);
             const msg = err instanceof Error ? err.message : String(err);
             log?.debug?.(`[DingTalk][Card] Failed to upload media as image block: ${msg}`);
           }

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -347,7 +347,7 @@ export function createCardReplyStrategy(
         continue;
       }
 
-      if (processedMediaUrls.has(candidate.url)) {
+      if (processedMediaUrls.has(candidate.url.trim())) {
         const placeholder = buildImagePlaceholderText({ alt: candidate.alt, url: candidate.url });
         nextText = `${nextText.slice(0, candidate.start)}${placeholder}${nextText.slice(candidate.end)}`;
         continue;
@@ -369,7 +369,7 @@ export function createCardReplyStrategy(
           continue;
         }
 
-        processedMediaUrls.add(candidate.url);
+        processedMediaUrls.add(candidate.url.trim());
         const placeholder = buildImagePlaceholderText({ alt: candidate.alt, url: candidate.url });
         const blockText = candidate.alt.trim() || placeholder.replace(/^见下图/, "").trim() || "图片";
         successfulReroutes.push({
@@ -486,7 +486,8 @@ export function createCardReplyStrategy(
         // Inline media upload → image blocks in card; defer non-image attachments
         if (payload.mediaUrls.length > 0) {
           for (const url of payload.mediaUrls) {
-            if (processedMediaUrls.has(url)) {
+            const normalizedUrl = url.trim();
+            if (processedMediaUrls.has(normalizedUrl)) {
               continue;
             }
             try {
@@ -504,7 +505,7 @@ export function createCardReplyStrategy(
               const result = await uploadMedia(config, prepared.path, "image", log);
               await prepared.cleanup?.();
               if (result?.mediaId) {
-                processedMediaUrls.add(url);
+                processedMediaUrls.add(normalizedUrl);
                 await controller.appendImageBlock(result.mediaId);
               }
             } catch (err: unknown) {
@@ -568,7 +569,8 @@ export function createCardReplyStrategy(
       // ---- block: only handle reasoning/media (other text blocks are unused) ----
       if (payload.mediaUrls.length > 0) {
         for (const url of payload.mediaUrls) {
-          if (processedMediaUrls.has(url)) {
+          const normalizedUrl = url.trim();
+          if (processedMediaUrls.has(normalizedUrl)) {
             continue;
           }
           try {
@@ -583,7 +585,7 @@ export function createCardReplyStrategy(
             const result = await uploadMedia(config, prepared.path, "image", log);
             await prepared.cleanup?.();
             if (result?.mediaId) {
-              processedMediaUrls.add(url);
+              processedMediaUrls.add(normalizedUrl);
               await controller.appendImageBlock(result.mediaId);
             }
           } catch (err: unknown) {

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -1490,4 +1490,49 @@ describe("reply-strategy-card", () => {
             expect(getUsageByRunId("run-b")).toBeUndefined();
         });
     });
+
+    describe("media dedup", () => {
+        it("dedupes same mediaUrl across non-final and final deliver", async () => {
+            const card = makeCard();
+            const ctx = buildCtx(card);
+            const strategy = createCardReplyStrategy(ctx);
+
+            // Non-final deliver with image URL
+            await strategy.deliver({
+                text: "",
+                mediaUrls: ["file:///test/image.png"],
+                kind: "block",
+            });
+
+            // Final deliver with same URL
+            await strategy.deliver({
+                text: "",
+                mediaUrls: ["file:///test/image.png"],
+                kind: "final",
+            });
+
+            await strategy.finalize();
+
+            // uploadMedia should be called only once (deduped)
+            expect(uploadMediaMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("dedupes same mediaUrl in rerouteMarkdownImagesFromAnswer", async () => {
+            const card = makeCard();
+            const ctx = buildCtx(card);
+            const strategy = createCardReplyStrategy(ctx);
+
+            // Final deliver with both mediaUrls and markdown image referencing same URL
+            await strategy.deliver({
+                text: "Here is the image: ![test](file:///test/image.png)",
+                mediaUrls: ["file:///test/image.png"],
+                kind: "final",
+            });
+
+            await strategy.finalize();
+
+            // uploadMedia should be called only once (deduped across both paths)
+            expect(uploadMediaMock).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -1537,5 +1537,30 @@ describe("reply-strategy-card", () => {
             const commitPayload = commitAICardBlocksMock.mock.calls[0]?.[1];
             expect(commitPayload?.content).not.toContain("file:///");
         });
+
+        it("dedupes mediaUrls with trailing whitespace", async () => {
+            const card = makeCard();
+            const ctx = buildCtx(card);
+            const strategy = createCardReplyStrategy(ctx);
+
+            // Non-final deliver with URL having trailing whitespace
+            await strategy.deliver({
+                text: "",
+                mediaUrls: ["file:///test/image.png  "],
+                kind: "block",
+            });
+
+            // Final deliver with same URL without whitespace
+            await strategy.deliver({
+                text: "",
+                mediaUrls: ["file:///test/image.png"],
+                kind: "final",
+            });
+
+            await strategy.finalize();
+
+            // uploadMedia should be called only once (trim-normalized dedup)
+            expect(uploadMediaMock).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -1533,6 +1533,9 @@ describe("reply-strategy-card", () => {
 
             // uploadMedia should be called only once (deduped across both paths)
             expect(uploadMediaMock).toHaveBeenCalledTimes(1);
+            // The final card content should not contain the raw file:/// path
+            const commitPayload = commitAICardBlocksMock.mock.calls[0]?.[1];
+            expect(commitPayload?.content).not.toContain("file:///");
         });
     });
 });


### PR DESCRIPTION
## 背景

在钉钉群聊中发送包含图片的消息时，卡片回复中出现两张重复图片。

### 根因分析

`reply-strategy-card.ts` 中的 `deliver` 函数有两处处理 `payload.mediaUrls`：

1. 第 556-577 行：非 final 的 deliver 中处理 mediaUrls
2. 第 478-502 行：final 的 deliver 中处理 mediaUrls

当 OpenClaw dispatch 层先后发送带有相同 mediaUrls 的非 final 和 final deliver 时，同一张图片被上传两次，生成两个不同的 mediaId，导致卡片中出现两张重复图片。

## 目标

修复 card 模式下图片重复上传问题，确保同一 URL 的图片只上传一次。

## 实现

在 `createCardReplyStrategy` 函数内部维护一个 `Set<string>` (`uploadedMediaUrls`) 记录已上传的 URL：

- 上传前检查 URL 是否已在集合中，若已存在则跳过
- 上传成功后将 URL 添加到集合

### 影响范围

- 仅影响 `reply-strategy-card.ts`（card 模式）
- 不影响 markdown 模式（`reply-strategy-markdown.ts`）
- 不影响 controller 层、send-service 层
- 修改是函数内部的局部状态，无跨模块影响

## 实现 TODO

- [x] 添加 `uploadedMediaUrls` Set 缓存
- [x] 在两处 mediaUrls 处理逻辑中添加去重检查
- [x] 运行类型检查通过
- [x] 运行 lint 检查通过
- [x] 运行单元测试通过

## 验证 TODO

- [x] 构建 runtime：`pnpm run build:runtime`
- [x] 重启 gateway：`openclaw gateway restart`
- [x] 真机测试：在钉钉群聊发送触发图片回复的消息
- [x] 验证结果：卡片中只显示一张图片（不再重复）