### PR TITLE
fix(security): fail closed for empty DM allowlist

### DIFF
--- a/src/access-control.ts
+++ b/src/access-control.ts
@@ -32,7 +32,7 @@ export function isSenderAllowed(params: {
 }): boolean {
   const { allow, senderId } = params;
   if (!allow.hasEntries) {
-    return true;
+    return false;
   }
   if (allow.hasWildcard) {
     return true;

--- a/tests/unit/access-control.test.ts
+++ b/tests/unit/access-control.test.ts
@@ -20,6 +20,12 @@ describe('access-control', () => {
         expect(isSenderAllowed({ allow: wildcardAllow, senderId: 'whatever' })).toBe(true);
     });
 
+    it('blocks senders for an empty allowlist', () => {
+        const emptyAllow = normalizeAllowFrom([]);
+
+        expect(isSenderAllowed({ allow: emptyAllow, senderId: 'user_a' })).toBe(false);
+    });
+
     it('checks group allow list with case-insensitive comparison', () => {
         const allow = normalizeAllowFrom(['cidABC123']);
 

--- a/tests/unit/inbound-handler-access.test.ts
+++ b/tests/unit/inbound-handler-access.test.ts
@@ -195,6 +195,35 @@ describe("inbound-handler access control", () => {
     expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain("访问受限");
   });
 
+  it("dmPolicy allowlist with empty allowFrom blocks senders", async () => {
+    await handleDingTalkMessage({
+      cfg: {} as Record<string, unknown>,
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        clientId: "id",
+        clientSecret: "sec",
+        dmPolicy: "allowlist",
+        allowFrom: [],
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m2_empty_allow",
+        msgtype: "text",
+        text: { content: "hello" },
+        conversationType: "1",
+        conversationId: "cid1",
+        senderId: "user_blocked",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      } as DingTalkInboundMessage,
+    });
+
+    expect(shared.sendBySessionMock).toHaveBeenCalledTimes(1);
+    expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain("访问受限");
+  });
+
   it("groupPolicy allowlist blocks group not in allowFrom or groups", async () => {
     await handleDingTalkMessage({
       cfg: {} as Record<string, unknown>,

--- a/tests/unit/inbound-handler-access.test.ts
+++ b/tests/unit/inbound-handler-access.test.ts
@@ -224,6 +224,44 @@ describe("inbound-handler access control", () => {
     expect(shared.sendBySessionMock.mock.calls[0]?.[2]).toContain("访问受限");
   });
 
+  it("dmPolicy allowlist with wildcard allowFrom allows any sender", async () => {
+    const rt = buildRuntime();
+    shared.getRuntimeMock.mockReturnValue(rt);
+
+    await handleDingTalkMessage({
+      cfg: {} as Record<string, unknown>,
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: {
+        clientId: "id",
+        clientSecret: "sec",
+        dmPolicy: "allowlist",
+        allowFrom: ["*"],
+      } as unknown as DingTalkConfig,
+      data: {
+        msgId: "m2_wildcard_allow",
+        msgtype: "text",
+        text: { content: "hello" },
+        conversationType: "1",
+        conversationId: "cid1",
+        senderId: "user_anyone",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      } as DingTalkInboundMessage,
+    });
+
+    // Should not send deny message
+    const denyCalls = shared.sendBySessionMock.mock.calls.filter(
+      (call) => typeof call[2] === "string" && call[2].includes("访问受限"),
+    );
+    expect(denyCalls.length).toBe(0);
+    // Positive assertion: the message actually entered the reply dispatch flow
+    // (guards against a false pass where the wildcard path silently short-circuits).
+    expect(rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+  });
+
   it("groupPolicy allowlist blocks group not in allowFrom or groups", async () => {
     await handleDingTalkMessage({
       cfg: {} as Record<string, unknown>,


### PR DESCRIPTION
## Summary

- Treat an explicitly empty DM `allowFrom` list as deny-all when `dmPolicy` is `allowlist`.
- Keep wildcard allowlists working for direct messages.
- Add focused regression coverage for the shared access-control helper and the inbound DM guard.

## Why

`dmPolicy: "allowlist"` is documented as allowing only IDs listed in `allowFrom`. On current `main`, an explicit empty array is normalized to no entries, and the shared sender allowlist helper treats that as allowed. That makes an empty allowlist fail open for direct messages. The group sender allowlist path already treats an explicit empty list as deny-all, so this brings the DM path in line with the same fail-closed behavior.

## Tests

- `pnpm exec vitest run tests/unit/access-control.test.ts tests/unit/inbound-handler-access.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test`
