### PR TITLE
feat: add DingTalk ask user question card

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ openclaw configure --section channels
 
 该能力支持两种入参：
 
-- `questions`：轻量问题 DSL，适合确认、单选、多选和简单文本输入。
-- `fields`：钉钉表单变量协议，适合 `TEXT_AREA`、`NUMBER`、`SELECT`、`MULTI_SELECT`、`DATE`、`TIME`、`DATETIME`、`CHECKBOX`、`SWITCH`、`CHECKBOX_GROUP`、`MULTI_CHECKBOX_GROUP` 等高级表单字段。
+- `questions`：轻量问题 DSL，仅适合简单确认、单选、多选和简单文本输入。
+- `fields`：钉钉表单变量协议，适合多字段收集、复杂表单、日期时间、数字、布尔开关，以及 `TEXT_AREA`、`NUMBER`、`SELECT`、`MULTI_SELECT`、`DATE`、`TIME`、`DATETIME`、`CHECKBOX`、`SWITCH`、`CHECKBOX_GROUP`、`MULTI_CHECKBOX_GROUP` 等高级表单字段。
 
 使用该能力无需额外配置模板 ID；插件内置钉钉互动卡片模板。若当前 OpenClaw 运行时不支持工具注册，插件会跳过该工具注册，不影响既有钉钉消息收发、AI 卡片和反馈学习能力。
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - 支持文本、图片、语音、视频、文件和钉钉文档/文件卡片
 - 支持引用消息恢复和常见文本附件正文抽取
 - 支持 Markdown 回复与 AI 卡片流式回复（v2 结构化 block 渲染、taskInfo 元数据、图片内联）
+- 支持通过 `dingtalk_ask_user_question` 发送钉钉原生交互表单卡片，向用户确认、单选、多选或收集表单字段后再继续会话
 - 支持多 Agent、多机器人绑定和实验性的 `@多助手路由`
 - 支持 `/btw` 旁路问答，绕过主会话锁立即获得独立快答
 - 支持 DingTalk Device Flow 自动注册，扫码授权后自动获取凭证，无需手动复制
@@ -137,6 +138,17 @@ openclaw configure --section channels
 - [配置指南](docs/user/getting-started/configure.md)
 - [钉钉权限与凭证](docs/user/getting-started/permissions.md)
 - [配置项参考](docs/user/reference/configuration.md)
+
+## 交互式提问卡片
+
+安装并允许 `dingtalk` 插件后，OpenClaw 可向模型暴露 `dingtalk_ask_user_question` 工具。模型在钉钉会话中遇到必须由用户确认或补充信息后才能继续的场景时，可以发送一张钉钉原生互动卡片；用户提交或取消后，插件会把结果作为新的会话消息注入，驱动原任务继续执行。
+
+该能力支持两种入参：
+
+- `questions`：轻量问题 DSL，适合确认、单选、多选和简单文本输入。
+- `fields`：钉钉表单变量协议，适合 `TEXT_AREA`、`NUMBER`、`SELECT`、`MULTI_SELECT`、`DATE`、`TIME`、`DATETIME`、`CHECKBOX`、`SWITCH`、`CHECKBOX_GROUP`、`MULTI_CHECKBOX_GROUP` 等高级表单字段。
+
+使用该能力无需额外配置模板 ID；插件内置钉钉互动卡片模板。若当前 OpenClaw 运行时不支持工具注册，插件会跳过该工具注册，不影响既有钉钉消息收发、AI 卡片和反馈学习能力。
 
 ## 重要功能文档
 

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { defineChannelPluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { readStringParam } from "openclaw/plugin-sdk/param-readers";
-import { registerDingTalkAskUserQuestionTool } from "./src/ask-user-question";
 import { getAccessToken } from "./src/auth";
+import { registerDingTalkAskUserQuestionTool } from "./src/card/ask-user-question";
 import { dingtalkPlugin } from "./src/channel";
 import { getConfig, listDingTalkAccountIds, resolveDingTalkAccount } from "./src/config";
 import {
@@ -280,7 +280,7 @@ function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPlugi
 export { dingtalkPlugin } from "./src/channel";
 export { setDingTalkRuntime } from "./src/runtime";
 
-export default defineChannelPluginEntry({
+const dingtalkEntry = defineChannelPluginEntry({
   id: "dingtalk",
   name: "DingTalk Channel",
   description: "DingTalk (钉钉) messaging channel via Stream mode",
@@ -310,3 +310,18 @@ export default defineChannelPluginEntry({
     );
   },
 });
+
+export default {
+  ...dingtalkEntry,
+  register(api: OpenClawPluginApi) {
+    const registrationMode = api.registrationMode as string | undefined;
+    if (registrationMode === "tool-discovery") {
+      registerDingTalkAskUserQuestionTool(api);
+      return;
+    }
+    if (registrationMode === "discovery") {
+      registerDingTalkAskUserQuestionTool(api);
+    }
+    dingtalkEntry.register(api);
+  },
+};

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { defineChannelPluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { readStringParam } from "openclaw/plugin-sdk/param-readers";
+import { registerDingTalkAskUserQuestionTool } from "./src/ask-user-question";
 import { getAccessToken } from "./src/auth";
 import { dingtalkPlugin } from "./src/channel";
 import { getConfig, listDingTalkAccountIds, resolveDingTalkAccount } from "./src/config";
@@ -288,6 +289,7 @@ export default defineChannelPluginEntry({
   registerFull(api) {
     registerDingTalkDocsGatewayMethods(api);
     registerDingTalkConnectorCompatibilityGatewayMethods(api);
+    registerDingTalkAskUserQuestionTool(api);
 
     api.on(
       "llm_output",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "dingtalk",
   "channels": ["dingtalk"],
+  "contracts": {
+    "tools": ["dingtalk_ask_user_question"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": true,

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -649,7 +649,14 @@ const AskUserQuestionSchema = {
     fields: {
       type: "array",
       description:
-        "Advanced DingTalk form variable protocol. Use this when you need field types beyond the simple questions DSL, such as TEXT_AREA, NUMBER, SELECT, MULTI_SELECT, DATE, TIME, DATETIME, CHECKBOX, SWITCH, TEXT_ARRAY, CHECKBOX_GROUP, or MULTI_CHECKBOX_GROUP.",
+        "Advanced DingTalk form fields. Use top-level fields when collecting multiple inputs " +
+        "or when you need field types beyond the simple questions DSL. The plugin will send " +
+        "these fields as the DingTalk card variable form.fields. Do not wrap fields inside form. " +
+        "For simple confirmation, single-select, or multi-select questions, prefer questions. " +
+        "For choice fields (SELECT, MULTI_SELECT, CHECKBOX_GROUP, MULTI_CHECKBOX_GROUP), " +
+        "provide options as { value, text }. Use TEXT for single-line text, TEXT_AREA for " +
+        "multi-line text, NUMBER for numeric input, DATE/TIME/DATETIME for date or time inputs, " +
+        "and CHECKBOX or SWITCH for boolean inputs.",
       minItems: 1,
       maxItems: 20,
       items: {
@@ -683,7 +690,6 @@ const AskUserQuestionSchema = {
           requiredMsg: { type: "string" },
           readOnly: { type: "boolean" },
           placeholder: { type: "string" },
-          format: { type: "string" },
           defaultValue: {},
           defautValue: {
             description:
@@ -691,6 +697,8 @@ const AskUserQuestionSchema = {
           },
           options: {
             type: "array",
+            description:
+              "Required for SELECT, MULTI_SELECT, CHECKBOX_GROUP, and MULTI_CHECKBOX_GROUP. Each option must be { value, text }.",
             items: {
               type: "object",
               additionalProperties: false,

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -1,0 +1,789 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { getAccessToken } from "./auth";
+import { updateCardVariables } from "./card-callback-service";
+import { DINGTALK_ASK_USER_CARD_TEMPLATE } from "./card/card-template";
+import { resolveRobotCode } from "./config";
+import axios from "./http-client";
+import { handleDingTalkMessage } from "./inbound-handler";
+import type {
+  DingTalkConfig,
+  DingTalkInboundMessage,
+  HandleDingTalkMessageParams,
+  Logger,
+} from "./types";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
+
+const DINGTALK_API = "https://api.dingtalk.com";
+const PENDING_QUESTION_TTL_MS = 5 * 60 * 1000;
+const TOOL_NAME = "dingtalk_ask_user_question";
+const ANSWER_FIELD_PREFIX = "answer";
+
+type AskUserOption = {
+  label?: string;
+  value?: string;
+  description?: string;
+};
+
+type AskUserQuestion = {
+  question?: string;
+  header?: string;
+  options?: AskUserOption[];
+  multiSelect?: boolean;
+};
+
+type FormFieldType =
+  | "TEXT"
+  | "TEXT_ARRAY"
+  | "TEXT_AREA"
+  | "NUMBER"
+  | "SELECT"
+  | "MULTI_SELECT"
+  | "DATE"
+  | "TIME"
+  | "DATETIME"
+  | "CHECKBOX"
+  | "SWITCH"
+  | "CHECKBOX_GROUP"
+  | "MULTI_CHECKBOX_GROUP";
+
+type RawValue = string | number | boolean;
+type SelectValue = { index: number; value: RawValue };
+type MultiSelectValue = { index: number[]; value: RawValue[] };
+
+type AskUserQuestionContext = {
+  cfg: HandleDingTalkMessageParams["cfg"];
+  accountId: string;
+  data: DingTalkInboundMessage;
+  sessionWebhook: string;
+  log?: Logger;
+  dingtalkConfig: DingTalkConfig;
+};
+
+type FormField = {
+  name: string;
+  label?: string;
+  type: FormFieldType;
+  hidden?: boolean;
+  required?: boolean;
+  requiredMsg?: string;
+  readOnly?: boolean;
+  placeholder?: string;
+  format?: string;
+  defaultValue?: RawValue | RawValue[] | SelectValue | MultiSelectValue;
+  defautValue?: RawValue | RawValue[] | SelectValue | MultiSelectValue;
+  options?: Array<{ value: string; text: string }>;
+  minRows?: number;
+  maxRows?: number;
+  addText?: string;
+};
+
+type PendingQuestion = AskUserQuestionContext & {
+  questionId: string;
+  outTrackId: string;
+  title: string;
+  questions: Array<{
+    fieldName: string;
+    title: string;
+    options: Array<{ value: string; text: string }>;
+    multiSelect: boolean;
+  }>;
+  submitted: boolean;
+  ttlTimer?: ReturnType<typeof setTimeout>;
+};
+
+type ParsedCardCallback = {
+  outTrackId?: string;
+  actionId?: string;
+  params: Record<string, unknown>;
+  hasBusinessPayload: boolean;
+};
+
+const questionContextStorage = new AsyncLocalStorage<AskUserQuestionContext>();
+const pendingQuestionsByTrackId = new Map<string, PendingQuestion>();
+const pendingQuestionsByQuestionId = new Map<string, PendingQuestion>();
+
+function jsonToolResult(payload: unknown): {
+  content: Array<{ type: "text"; text: string }>;
+  details: unknown;
+} {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+export function withDingTalkQuestionContext<T>(
+  context: AskUserQuestionContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return questionContextStorage.run(context, fn);
+}
+
+function stringifyCardData(data: Record<string, unknown>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(data)) {
+    result[key] = typeof value === "string" ? value : JSON.stringify(value);
+  }
+  return result;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeOption(option: AskUserOption, index: number): { value: string; text: string } {
+  const text = readString(option.label) ?? readString(option.description) ?? `选项 ${index + 1}`;
+  const value = readString(option.value) ?? text;
+  return { value, text };
+}
+
+function normalizeFormOption(option: unknown, index: number): { value: string; text: string } {
+  const record = asRecord(option) ?? {};
+  const value = readString(record.value) ?? `option_${index + 1}`;
+  const text = readString(record.text) ?? value;
+  return { value, text };
+}
+
+export function buildQuestionForm(questions: AskUserQuestion[]): {
+  title: string;
+  desc: string;
+  fields: FormField[];
+  parsed: PendingQuestion["questions"];
+} {
+  const parsed = questions.map((question, index) => {
+    const options = Array.isArray(question.options)
+      ? question.options.map((option, optionIndex) => normalizeOption(option, optionIndex))
+      : [];
+    const title =
+      readString(question.header) ?? readString(question.question) ?? `问题 ${index + 1}`;
+    const fieldName = `${ANSWER_FIELD_PREFIX}_${index}`;
+    return {
+      fieldName,
+      title,
+      options,
+      multiSelect: Boolean(question.multiSelect),
+    };
+  });
+
+  const fields: FormField[] = parsed.map((question) => {
+    if (question.options.length === 0) {
+      return {
+        name: question.fieldName,
+        label: question.title,
+        type: "TEXT",
+        required: true,
+        placeholder: "请输入回答",
+      };
+    }
+    return {
+      name: question.fieldName,
+      label: question.title,
+      type: question.multiSelect ? "MULTI_CHECKBOX_GROUP" : "CHECKBOX_GROUP",
+      required: true,
+      options: question.options,
+    };
+  });
+
+  const first = questions[0] ?? {};
+  const title = readString(first.header) ?? readString(first.question) ?? "需要你的确认";
+  const desc = readString(first.question) ?? title;
+  return { title, desc, fields, parsed };
+}
+
+const FORM_FIELD_TYPES = new Set<FormFieldType>([
+  "TEXT",
+  "TEXT_ARRAY",
+  "TEXT_AREA",
+  "NUMBER",
+  "SELECT",
+  "MULTI_SELECT",
+  "DATE",
+  "TIME",
+  "DATETIME",
+  "CHECKBOX",
+  "SWITCH",
+  "CHECKBOX_GROUP",
+  "MULTI_CHECKBOX_GROUP",
+]);
+
+export function buildQuestionFormFromFields(params: {
+  title?: string;
+  description?: string;
+  fields: FormField[];
+}): {
+  title: string;
+  desc: string;
+  fields: FormField[];
+  parsed: PendingQuestion["questions"];
+} {
+  const fields = params.fields.map((field, index) => {
+    const name = readString(field.name) ?? `${ANSWER_FIELD_PREFIX}_${index}`;
+    const rawType = readString(field.type);
+    const type = rawType && FORM_FIELD_TYPES.has(rawType as FormFieldType) ? rawType : "TEXT";
+    const label = readString(field.label) ?? name;
+    const normalized: FormField = {
+      ...field,
+      name,
+      label,
+      type: type as FormFieldType,
+    };
+    if (Array.isArray(field.options)) {
+      normalized.options = field.options.map((option, optionIndex) =>
+        normalizeFormOption(option, optionIndex),
+      );
+    }
+    return normalized;
+  });
+  const parsed = fields.map((field) => ({
+    fieldName: field.name,
+    title: readString(field.label) ?? field.name,
+    options: Array.isArray(field.options) ? field.options : [],
+    multiSelect: field.type === "MULTI_CHECKBOX_GROUP" || field.type === "MULTI_SELECT",
+  }));
+  const firstLabel = readString(fields[0]?.label);
+  const title = readString(params.title) ?? firstLabel ?? "需要你的确认";
+  const desc = readString(params.description) ?? title;
+  return { title, desc, fields, parsed };
+}
+
+async function createAndDeliverQuestionCard(params: {
+  config: DingTalkConfig;
+  conversationId: string;
+  isDirect: boolean;
+  templateId: string;
+  outTrackId: string;
+  cardData: Record<string, unknown>;
+  log?: Logger;
+}): Promise<void> {
+  const token = await getAccessToken(params.config, params.log);
+  const isGroup = !params.isDirect;
+  const body = {
+    cardTemplateId: params.templateId,
+    outTrackId: params.outTrackId,
+    cardData: {
+      cardParamMap: stringifyCardData(params.cardData),
+    },
+    callbackType: "STREAM",
+    imGroupOpenSpaceModel: { supportForward: true },
+    imRobotOpenSpaceModel: { supportForward: true },
+    openSpaceId: isGroup
+      ? `dtv1.card//IM_GROUP.${params.conversationId}`
+      : `dtv1.card//IM_ROBOT.${params.conversationId}`,
+    userIdType: 1,
+    imGroupOpenDeliverModel: isGroup
+      ? {
+          robotCode: resolveRobotCode(params.config),
+          extension: { dynamicSummary: "true" },
+        }
+      : undefined,
+    imRobotOpenDeliverModel: !isGroup
+      ? {
+          spaceType: "IM_ROBOT",
+          robotCode: resolveRobotCode(params.config),
+          extension: { dynamicSummary: "true" },
+        }
+      : undefined,
+  };
+
+  params.log?.debug?.(
+    `[DingTalk][AskUser] POST /v1.0/card/instances/createAndDeliver body=${JSON.stringify(body)}`,
+  );
+  const resp = await axios.post(`${DINGTALK_API}/v1.0/card/instances/createAndDeliver`, body, {
+    headers: {
+      "x-acs-dingtalk-access-token": token,
+      "Content-Type": "application/json",
+    },
+    ...getProxyBypassOption(params.config),
+  });
+  params.log?.debug?.(
+    `[DingTalk][AskUser] createAndDeliver response status=${resp.status} data=${JSON.stringify(resp.data)}`,
+  );
+  const deliverResults = (
+    resp.data?.result as
+      | { deliverResults?: Array<{ success?: boolean; errorMsg?: string }> }
+      | undefined
+  )?.deliverResults;
+  const failedDelivery = Array.isArray(deliverResults)
+    ? deliverResults.find((item) => item?.success === false)
+    : undefined;
+  if (failedDelivery) {
+    throw new Error(failedDelivery.errorMsg?.trim() || "DingTalk question card delivery failed");
+  }
+}
+
+function storePendingQuestion(ctx: PendingQuestion): void {
+  pendingQuestionsByTrackId.set(ctx.outTrackId, ctx);
+  pendingQuestionsByQuestionId.set(ctx.questionId, ctx);
+  ctx.ttlTimer = setTimeout(() => {
+    if (!pendingQuestionsByTrackId.has(ctx.outTrackId) || ctx.submitted) {
+      return;
+    }
+    consumePendingQuestion(ctx);
+    void updateQuestionCard(ctx, {
+      card_status: "expired",
+      question_desc: "问题已失效，请重新发起。",
+      form_btn_text: "已失效",
+    }).catch((err) => {
+      ctx.log?.warn?.(`[DingTalk][AskUser] Failed to expire question card: ${String(err)}`);
+    });
+  }, PENDING_QUESTION_TTL_MS);
+}
+
+function consumePendingQuestion(ctx: PendingQuestion): void {
+  pendingQuestionsByTrackId.delete(ctx.outTrackId);
+  pendingQuestionsByQuestionId.delete(ctx.questionId);
+  if (ctx.ttlTimer) {
+    clearTimeout(ctx.ttlTimer);
+  }
+}
+
+async function updateQuestionCard(
+  ctx: PendingQuestion,
+  variables: Record<string, unknown>,
+): Promise<void> {
+  const token = await getAccessToken(ctx.dingtalkConfig, ctx.log);
+  await updateCardVariables(ctx.outTrackId, variables, token, ctx.dingtalkConfig);
+}
+
+function parseEmbeddedJson(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseAskUserCardCallback(payload: unknown): ParsedCardCallback {
+  const record = asRecord(payload) ?? {};
+  const content = asRecord(parseEmbeddedJson(record.content));
+  const value = asRecord(parseEmbeddedJson(record.value));
+  const privateData =
+    asRecord(content?.cardPrivateData) ??
+    asRecord(parseEmbeddedJson(record.cardPrivateData)) ??
+    asRecord(value?.cardPrivateData);
+  const params =
+    asRecord(privateData?.params) ?? asRecord(content?.params) ?? asRecord(value?.params) ?? {};
+  const actionIds = privateData?.actionIds;
+  const actionId =
+    Array.isArray(actionIds) && typeof actionIds[0] === "string" ? actionIds[0] : undefined;
+  const outTrackId =
+    readString(record.outTrackId) ??
+    readString(content?.outTrackId) ??
+    readString(value?.outTrackId) ??
+    readString(privateData?.outTrackId);
+  return {
+    outTrackId,
+    actionId,
+    params,
+    hasBusinessPayload: Boolean(params.form || params.user_cancel || params.user_cacel),
+  };
+}
+
+function readFormAnswer(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item));
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const raw = record.value;
+    if (Array.isArray(raw)) {
+      return raw.map((item) => String(item));
+    }
+    if (raw !== undefined && raw !== null) {
+      return [String(raw)];
+    }
+  }
+  return [String(value)];
+}
+
+function formatAnswerText(
+  question: PendingQuestion["questions"][number],
+  values: string[],
+): string {
+  if (values.length === 0) {
+    return "";
+  }
+  const labels = values.map((value) => {
+    return question.options.find((option) => option.value === value)?.text ?? value;
+  });
+  return labels.join(", ");
+}
+
+function buildAnswerMessage(ctx: PendingQuestion, answers: Record<string, string>): string {
+  const lines = Object.entries(answers).map(([question, answer]) => `- ${question}: ${answer}`);
+  return `用户回答了你的问题:\n${lines.join("\n")}`;
+}
+
+async function injectAnswerSyntheticMessage(
+  ctx: PendingQuestion,
+  text: string,
+  suffix: string,
+): Promise<void> {
+  const syntheticData: DingTalkInboundMessage = {
+    msgId: `${ctx.data.msgId || ctx.outTrackId}:ask-user-${suffix}:${ctx.questionId}`,
+    msgtype: "text",
+    createAt: Date.now(),
+    text: { content: text },
+    conversationType: ctx.data.conversationType,
+    conversationId: ctx.data.conversationId,
+    conversationTitle: ctx.data.conversationTitle,
+    senderId: ctx.data.senderId,
+    senderStaffId: ctx.data.senderStaffId,
+    senderNick: ctx.data.senderNick,
+    chatbotUserId: ctx.data.chatbotUserId,
+    sessionWebhook: ctx.data.sessionWebhook,
+  };
+  await withDingTalkQuestionContext(
+    {
+      cfg: ctx.cfg,
+      accountId: ctx.accountId,
+      data: syntheticData,
+      sessionWebhook: ctx.sessionWebhook,
+      log: ctx.log,
+      dingtalkConfig: ctx.dingtalkConfig,
+    },
+    () =>
+      handleDingTalkMessage({
+        cfg: ctx.cfg,
+        accountId: ctx.accountId,
+        data: syntheticData,
+        sessionWebhook: ctx.sessionWebhook,
+        log: ctx.log,
+        dingtalkConfig: ctx.dingtalkConfig,
+      }),
+  );
+}
+
+export async function handleDingTalkAskUserCardCallback(params: {
+  payload: unknown;
+  cfg: HandleDingTalkMessageParams["cfg"];
+  accountId: string;
+  config: DingTalkConfig;
+  log?: Logger;
+}): Promise<{ handled: boolean }> {
+  const parsed = parseAskUserCardCallback(params.payload);
+  const ctx =
+    (parsed.outTrackId ? pendingQuestionsByTrackId.get(parsed.outTrackId) : undefined) ??
+    (parsed.actionId ? pendingQuestionsByQuestionId.get(parsed.actionId) : undefined);
+  if (!ctx) {
+    return { handled: false };
+  }
+
+  if (!parsed.hasBusinessPayload) {
+    params.log?.debug?.(
+      `[DingTalk][AskUser] Ignoring non-business card callback outTrackId=${ctx.outTrackId}`,
+    );
+    return { handled: true };
+  }
+
+  if (ctx.submitted) {
+    params.log?.debug?.(`[DingTalk][AskUser] Duplicate submit ignored question=${ctx.questionId}`);
+    return { handled: true };
+  }
+
+  const isCancel = parsed.params.user_cancel === "true" || parsed.params.user_cacel === "true";
+  ctx.submitted = true;
+
+  if (isCancel) {
+    await updateQuestionCard(ctx, {
+      card_status: "cancelled",
+      question_desc: "已取消。",
+      form_btn_text: "已取消",
+    });
+    consumePendingQuestion(ctx);
+    setImmediate(() => {
+      void injectAnswerSyntheticMessage(ctx, `用户取消了问题: ${ctx.title}`, "cancelled").catch(
+        (err) => {
+          params.log?.error?.(
+            `[DingTalk][AskUser] Failed to inject cancellation message: ${String(err)}`,
+          );
+        },
+      );
+    });
+    return { handled: true };
+  }
+
+  const form = asRecord(parsed.params.form);
+  if (!form) {
+    ctx.submitted = false;
+    params.log?.warn?.(
+      `[DingTalk][AskUser] Missing form payload question=${ctx.questionId} params=${JSON.stringify(parsed.params)}`,
+    );
+    return { handled: true };
+  }
+
+  const answers: Record<string, string> = {};
+  const selectedValues: string[] = [];
+  for (const question of ctx.questions) {
+    const values = readFormAnswer(form[question.fieldName]);
+    selectedValues.push(...values);
+    const answerText = formatAnswerText(question, values);
+    if (answerText) {
+      answers[question.title] = answerText;
+    }
+  }
+
+  if (Object.keys(answers).length === 0) {
+    ctx.submitted = false;
+    params.log?.warn?.(
+      `[DingTalk][AskUser] Empty form answer question=${ctx.questionId} form=${JSON.stringify(form)}`,
+    );
+    return { handled: true };
+  }
+
+  const selectedText = Object.values(answers).join(", ");
+  await updateQuestionCard(ctx, {
+    card_status: "submitted",
+    question_desc: `已选择：${selectedText}。`,
+    selected_text: selectedText,
+    selected_values: JSON.stringify(selectedValues),
+    form_btn_text: "已提交",
+  });
+  consumePendingQuestion(ctx);
+
+  const message = buildAnswerMessage(ctx, answers);
+  setImmediate(() => {
+    void injectAnswerSyntheticMessage(ctx, message, "submitted").catch((err) => {
+      params.log?.error?.(`[DingTalk][AskUser] Failed to inject answer message: ${String(err)}`);
+    });
+  });
+  return { handled: true };
+}
+
+const AskUserQuestionSchema = {
+  type: "object",
+  additionalProperties: false,
+  anyOf: [{ required: ["questions"] }, { required: ["fields"] }],
+  properties: {
+    title: {
+      type: "string",
+      description: "Card title. Used with fields; omit to use the first field label.",
+    },
+    description: {
+      type: "string",
+      description: "Short description shown above the form. Used with fields.",
+    },
+    questions: {
+      type: "array",
+      description:
+        "Blocking question(s) that must be answered by the DingTalk user before the assistant can continue. Prefer exactly one question per card. " +
+        "Do not use for explanations, status updates, capability introductions, or retrospective questions.",
+      minItems: 1,
+      maxItems: 6,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["question", "header", "options"],
+        properties: {
+          question: { type: "string", description: "The question to ask the user" },
+          header: { type: "string", description: "Short label for the question (max 12 chars)" },
+          options: {
+            type: "array",
+            maxItems: 20,
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["label"],
+              properties: {
+                label: { type: "string", description: "Display text for this option" },
+                value: {
+                  type: "string",
+                  description: "Machine-readable value returned to the assistant; omit to use label",
+                },
+                description: {
+                  type: "string",
+                  description: "Explanation of what this option means",
+                },
+              },
+            },
+            description:
+              "Available choices. Leave empty ([]) for free-text input — the user will see a text field instead. " +
+              "Use two options for confirmation.",
+          },
+          multiSelect: {
+            type: "boolean",
+            description: "Whether multiple options can be selected (ignored when options is empty)",
+          },
+        },
+      },
+    },
+    fields: {
+      type: "array",
+      description:
+        "Advanced DingTalk form variable protocol. Use this when you need field types beyond the simple questions DSL, such as TEXT_AREA, NUMBER, SELECT, MULTI_SELECT, DATE, TIME, DATETIME, CHECKBOX, SWITCH, TEXT_ARRAY, CHECKBOX_GROUP, or MULTI_CHECKBOX_GROUP.",
+      minItems: 1,
+      maxItems: 20,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["name", "label", "type"],
+        properties: {
+          name: { type: "string", description: "Unique form field key" },
+          label: { type: "string", description: "Field label shown to the user" },
+          type: {
+            type: "string",
+            enum: [
+              "TEXT",
+              "TEXT_ARRAY",
+              "TEXT_AREA",
+              "NUMBER",
+              "SELECT",
+              "MULTI_SELECT",
+              "DATE",
+              "TIME",
+              "DATETIME",
+              "CHECKBOX",
+              "SWITCH",
+              "CHECKBOX_GROUP",
+              "MULTI_CHECKBOX_GROUP",
+            ],
+            description: "DingTalk form field type",
+          },
+          hidden: { type: "boolean" },
+          required: { type: "boolean" },
+          requiredMsg: { type: "string" },
+          readOnly: { type: "boolean" },
+          placeholder: { type: "string" },
+          format: { type: "string" },
+          defaultValue: {},
+          defautValue: {},
+          options: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              required: ["value", "text"],
+              properties: {
+                value: { type: "string" },
+                text: { type: "string" },
+              },
+            },
+          },
+          minRows: { type: "number" },
+          maxRows: { type: "number" },
+          addText: { type: "string" },
+        },
+      },
+    },
+  },
+} as const;
+
+export function getAskUserQuestionSchemaForTest(): typeof AskUserQuestionSchema {
+  return AskUserQuestionSchema;
+}
+
+export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): void {
+  api.registerTool({
+    name: TOOL_NAME,
+    label: "Ask User Question",
+    description:
+      "Ask the user a blocking question via an interactive DingTalk card when the current task cannot continue without the user's answer. " +
+      "Returns immediately after sending the card. " +
+      "The user's answer will arrive as a new message in the conversation. " +
+      "Do NOT poll or re-call this tool — just wait for the response message. " +
+      "For selection questions, provide options. " +
+      "For free-text input, set options to an empty array. " +
+      "Do not call this tool for normal explanations, why/how questions, capability introductions, or cases where you can answer directly.",
+    parameters: AskUserQuestionSchema as any,
+    async execute(_toolCallId: string, params: unknown) {
+      const context = questionContextStorage.getStore();
+      if (!context) {
+        return jsonToolResult({
+          status: "failed",
+          error: "dingtalk_ask_user_question can only be used in a DingTalk message context",
+        });
+      }
+      const templateId = DINGTALK_ASK_USER_CARD_TEMPLATE.templateId;
+
+      const record = asRecord(params) ?? {};
+      const rawFields = Array.isArray(record.fields) ? (record.fields as FormField[]) : [];
+      const rawQuestions = Array.isArray(record.questions)
+        ? (record.questions as AskUserQuestion[])
+        : [];
+      if (rawFields.length === 0 && rawQuestions.length === 0) {
+        return jsonToolResult({
+          status: "failed",
+          error: "questions or fields must contain at least one item",
+        });
+      }
+
+      const questionId = `q_${randomUUID()}`;
+      const outTrackId = `ask_${randomUUID()}`;
+      const { title, desc, fields, parsed } =
+        rawFields.length > 0
+          ? buildQuestionFormFromFields({
+              title: readString(record.title),
+              description: readString(record.description),
+              fields: rawFields,
+            })
+          : buildQuestionForm(rawQuestions);
+      const cardData = {
+        question_id: questionId,
+        question_title: title,
+        question_desc: desc,
+        card_status: "pending",
+        form_btn_text: "提交",
+        selected_text: "",
+        selected_values: "[]",
+        form: { fields },
+      };
+
+      try {
+        await createAndDeliverQuestionCard({
+          config: context.dingtalkConfig,
+          conversationId:
+            context.data.conversationType === "1"
+              ? context.data.senderStaffId || context.data.senderId || context.data.conversationId
+              : context.data.conversationId,
+          isDirect: context.data.conversationType === "1",
+          templateId,
+          outTrackId,
+          cardData,
+          log: context.log,
+        });
+      } catch (err) {
+        const detail = formatDingTalkErrorPayloadLog("ask_user_create", err, "[DingTalk]");
+        return jsonToolResult({
+          status: "failed",
+          error: detail || (err instanceof Error ? err.message : String(err)),
+        });
+      }
+
+      storePendingQuestion({
+        ...context,
+        questionId,
+        outTrackId,
+        title,
+        questions: parsed,
+        submitted: false,
+      });
+
+      context.log?.info?.(
+        `[DingTalk][AskUser] question card sent question=${questionId} outTrackId=${outTrackId}`,
+      );
+      return jsonToolResult({
+        status: "pending",
+        questionId,
+        outTrackId,
+        message:
+          "Question card sent to the user. Their answer will arrive as a follow-up message in this conversation.",
+      });
+    },
+  });
+  api.logger?.debug?.(`${TOOL_NAME}: registered tool`);
+}

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -323,12 +323,21 @@ function storePendingQuestion(ctx: PendingQuestion): void {
       return;
     }
     consumePendingQuestion(ctx);
-    void updateQuestionCard(ctx, {
+    void updateQuestionCardBestEffort(ctx, {
       card_status: "expired",
       question_desc: "问题已失效，请重新发起。",
       form_btn_text: "已失效",
-    }).catch((err) => {
-      ctx.log?.warn?.(`[DingTalk][AskUser] Failed to expire question card: ${String(err)}`);
+    });
+    setImmediate(() => {
+      void injectAnswerSyntheticMessage(
+        ctx,
+        `问题已超时，请重新发起: ${ctx.title}`,
+        "expired",
+      ).catch((err) => {
+        ctx.log?.error?.(
+          `[DingTalk][AskUser] Failed to inject expiration message: ${String(err)}`,
+        );
+      });
     });
   }, PENDING_QUESTION_TTL_MS);
 }

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -334,9 +334,7 @@ function storePendingQuestion(ctx: PendingQuestion): void {
         `问题已超时，请重新发起: ${ctx.title}`,
         "expired",
       ).catch((err) => {
-        ctx.log?.error?.(
-          `[DingTalk][AskUser] Failed to inject expiration message: ${String(err)}`,
-        );
+        ctx.log?.error?.(`[DingTalk][AskUser] Failed to inject expiration message: ${String(err)}`);
       });
     });
   }, PENDING_QUESTION_TTL_MS);
@@ -453,6 +451,10 @@ function buildAnswerMessage(ctx: PendingQuestion, answers: AnswerEntry[]): strin
   return `用户回答了你的问题:\n${lines.join("\n")}`;
 }
 
+function buildEmptyAnswerMessage(ctx: PendingQuestion): string {
+  return `用户提交了空表单: ${ctx.title}`;
+}
+
 async function injectAnswerSyntheticMessage(
   ctx: PendingQuestion,
   text: string,
@@ -563,10 +565,24 @@ export async function handleDingTalkAskUserCardCallback(params: {
   }
 
   if (answers.length === 0) {
-    ctx.submitted = false;
     params.log?.warn?.(
       `[DingTalk][AskUser] Empty form answer question=${ctx.questionId} form=${JSON.stringify(form)}`,
     );
+    await updateQuestionCardBestEffort(ctx, {
+      card_status: "submitted",
+      question_desc: "已提交，未填写任何内容。",
+      selected_text: "",
+      selected_values: "[]",
+      form_btn_text: "已提交",
+    });
+    consumePendingQuestion(ctx);
+    setImmediate(() => {
+      void injectAnswerSyntheticMessage(ctx, buildEmptyAnswerMessage(ctx), "empty").catch((err) => {
+        params.log?.error?.(
+          `[DingTalk][AskUser] Failed to inject empty answer message: ${String(err)}`,
+        );
+      });
+    });
     return { handled: true };
   }
 
@@ -627,7 +643,8 @@ const AskUserQuestionSchema = {
                 label: { type: "string", description: "Display text for this option" },
                 value: {
                   type: "string",
-                  description: "Machine-readable value returned to the assistant; omit to use label",
+                  description:
+                    "Machine-readable value returned to the assistant; omit to use label",
                 },
                 description: {
                   type: "string",
@@ -722,9 +739,29 @@ export function getAskUserQuestionSchemaForTest(): typeof AskUserQuestionSchema 
   return AskUserQuestionSchema;
 }
 
+export function registerPendingQuestionForTest(
+  ctx: Omit<PendingQuestion, "ttlTimer" | "submitted"> & { submitted?: boolean },
+): void {
+  storePendingQuestion({
+    ...ctx,
+    submitted: Boolean(ctx.submitted),
+  });
+}
+
+export function clearPendingQuestionsForTest(): void {
+  for (const ctx of pendingQuestionsByTrackId.values()) {
+    if (ctx.ttlTimer) {
+      clearTimeout(ctx.ttlTimer);
+    }
+  }
+  pendingQuestionsByTrackId.clear();
+  pendingQuestionsByQuestionId.clear();
+}
+
 export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): void {
-  const registerTool = (api as OpenClawPluginApi & { registerTool?: OpenClawPluginApi["registerTool"] })
-    .registerTool;
+  const registerTool = (
+    api as OpenClawPluginApi & { registerTool?: OpenClawPluginApi["registerTool"] }
+  ).registerTool;
   if (typeof registerTool !== "function") {
     api.logger?.debug?.(`${TOOL_NAME}: registerTool unavailable, skipping tool registration`);
     return;

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -349,6 +349,19 @@ async function updateQuestionCard(
   await updateCardVariables(ctx.outTrackId, variables, token, ctx.dingtalkConfig);
 }
 
+async function updateQuestionCardBestEffort(
+  ctx: PendingQuestion,
+  variables: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await updateQuestionCard(ctx, variables);
+  } catch (err) {
+    ctx.log?.warn?.(
+      `[DingTalk][AskUser] Failed to update question card ${ctx.questionId}: ${String(err)}`,
+    );
+  }
+}
+
 function parseEmbeddedJson(value: unknown): unknown {
   if (typeof value !== "string") {
     return value;
@@ -502,7 +515,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
   ctx.submitted = true;
 
   if (isCancel) {
-    await updateQuestionCard(ctx, {
+    await updateQuestionCardBestEffort(ctx, {
       card_status: "cancelled",
       question_desc: "已取消。",
       form_btn_text: "已取消",
@@ -549,7 +562,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
   }
 
   const selectedText = answers.map(({ answer }) => answer).join(", ");
-  await updateQuestionCard(ctx, {
+  await updateQuestionCardBestEffort(ctx, {
     card_status: "submitted",
     question_desc: `已选择：${selectedText}。`,
     selected_text: selectedText,

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -688,7 +688,14 @@ export function getAskUserQuestionSchemaForTest(): typeof AskUserQuestionSchema 
 }
 
 export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): void {
-  api.registerTool({
+  const registerTool = (api as OpenClawPluginApi & { registerTool?: OpenClawPluginApi["registerTool"] })
+    .registerTool;
+  if (typeof registerTool !== "function") {
+    api.logger?.debug?.(`${TOOL_NAME}: registerTool unavailable, skipping tool registration`);
+    return;
+  }
+
+  registerTool.call(api, {
     name: TOOL_NAME,
     label: "Ask User Question",
     description:

--- a/src/ask-user-question.ts
+++ b/src/ask-user-question.ts
@@ -51,6 +51,7 @@ type FormFieldType =
 type RawValue = string | number | boolean;
 type SelectValue = { index: number; value: RawValue };
 type MultiSelectValue = { index: number[]; value: RawValue[] };
+type AnswerEntry = { question: string; answer: string };
 
 type AskUserQuestionContext = {
   cfg: HandleDingTalkMessageParams["cfg"];
@@ -72,6 +73,7 @@ type FormField = {
   placeholder?: string;
   format?: string;
   defaultValue?: RawValue | RawValue[] | SelectValue | MultiSelectValue;
+  // DingTalk form protocol documentation also exposes this misspelled key.
   defautValue?: RawValue | RawValue[] | SelectValue | MultiSelectValue;
   options?: Array<{ value: string; text: string }>;
   minRows?: number;
@@ -424,8 +426,8 @@ function formatAnswerText(
   return labels.join(", ");
 }
 
-function buildAnswerMessage(ctx: PendingQuestion, answers: Record<string, string>): string {
-  const lines = Object.entries(answers).map(([question, answer]) => `- ${question}: ${answer}`);
+function buildAnswerMessage(ctx: PendingQuestion, answers: AnswerEntry[]): string {
+  const lines = answers.map(({ question, answer }) => `- ${question}: ${answer}`);
   return `用户回答了你的问题:\n${lines.join("\n")}`;
 }
 
@@ -527,18 +529,18 @@ export async function handleDingTalkAskUserCardCallback(params: {
     return { handled: true };
   }
 
-  const answers: Record<string, string> = {};
+  const answers: AnswerEntry[] = [];
   const selectedValues: string[] = [];
   for (const question of ctx.questions) {
     const values = readFormAnswer(form[question.fieldName]);
     selectedValues.push(...values);
     const answerText = formatAnswerText(question, values);
     if (answerText) {
-      answers[question.title] = answerText;
+      answers.push({ question: question.title, answer: answerText });
     }
   }
 
-  if (Object.keys(answers).length === 0) {
+  if (answers.length === 0) {
     ctx.submitted = false;
     params.log?.warn?.(
       `[DingTalk][AskUser] Empty form answer question=${ctx.questionId} form=${JSON.stringify(form)}`,
@@ -546,7 +548,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
     return { handled: true };
   }
 
-  const selectedText = Object.values(answers).join(", ");
+  const selectedText = answers.map(({ answer }) => answer).join(", ");
   await updateQuestionCard(ctx, {
     card_status: "submitted",
     question_desc: `已选择：${selectedText}。`,
@@ -661,7 +663,10 @@ const AskUserQuestionSchema = {
           placeholder: { type: "string" },
           format: { type: "string" },
           defaultValue: {},
-          defautValue: {},
+          defautValue: {
+            description:
+              "Compatibility alias for DingTalk form protocol documentation typo; prefer defaultValue when possible.",
+          },
           options: {
             type: "array",
             items: {

--- a/src/card/ask-user-question-context.ts
+++ b/src/card/ask-user-question-context.ts
@@ -13,6 +13,7 @@ export type DingTalkQuestionContext = {
   sessionWebhook: string;
   log?: Logger;
   dingtalkConfig: DingTalkConfig;
+  questionScopeKey?: string;
   onQuestionCardSent?: (event: { questionId: string; outTrackId: string }) => void | Promise<void>;
 };
 

--- a/src/card/ask-user-question-context.ts
+++ b/src/card/ask-user-question-context.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type {
+  DingTalkConfig,
+  DingTalkInboundMessage,
+  HandleDingTalkMessageParams,
+  Logger,
+} from "../types";
+
+export type DingTalkQuestionContext = {
+  cfg: HandleDingTalkMessageParams["cfg"];
+  accountId: string;
+  data: DingTalkInboundMessage;
+  sessionWebhook: string;
+  log?: Logger;
+  dingtalkConfig: DingTalkConfig;
+  onQuestionCardSent?: (event: { questionId: string; outTrackId: string }) => void | Promise<void>;
+};
+
+const questionContextStorage = new AsyncLocalStorage<DingTalkQuestionContext>();
+
+export function withDingTalkQuestionContext<T>(
+  context: DingTalkQuestionContext,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return questionContextStorage.run(context, fn);
+}
+
+export function getDingTalkQuestionContext(): DingTalkQuestionContext | undefined {
+  return questionContextStorage.getStore();
+}

--- a/src/card/ask-user-question.ts
+++ b/src/card/ask-user-question.ts
@@ -421,7 +421,7 @@ function supersedePendingQuestionsInScope(ctx: PendingQuestion): void {
   if (!set) {
     return;
   }
-  for (const outTrackId of [...set]) {
+  for (const outTrackId of Array.from(set)) {
     if (outTrackId === ctx.outTrackId) {
       continue;
     }

--- a/src/card/ask-user-question.ts
+++ b/src/card/ask-user-question.ts
@@ -10,7 +10,6 @@ import { formatDingTalkErrorPayloadLog, getProxyBypassOption, parseBooleanLike }
 import {
   getDingTalkQuestionContext,
   type DingTalkQuestionContext,
-  withDingTalkQuestionContext,
 } from "./ask-user-question-context";
 import { DINGTALK_ASK_USER_CARD_TEMPLATE } from "./card-template";
 
@@ -622,6 +621,9 @@ async function injectAnswerSyntheticMessage(
   suffix: string,
 ): Promise<void> {
   const syntheticData: DingTalkInboundMessage = {
+    // Keep this origin-derived synthetic id stable and unique. If inbound
+    // dedup/self-filter/auth gates move here later, reinjected ask-user answers
+    // must still pass or the waiting session can hang.
     msgId: `${ctx.data.msgId || ctx.outTrackId}:ask-user-${suffix}:${ctx.questionId}`,
     msgtype: "text",
     createAt: Date.now(),
@@ -635,25 +637,14 @@ async function injectAnswerSyntheticMessage(
     chatbotUserId: ctx.data.chatbotUserId,
     sessionWebhook: ctx.data.sessionWebhook,
   };
-  await withDingTalkQuestionContext(
-    {
-      cfg: ctx.cfg,
-      accountId: ctx.accountId,
-      data: syntheticData,
-      sessionWebhook: ctx.sessionWebhook,
-      log: ctx.log,
-      dingtalkConfig: ctx.dingtalkConfig,
-    },
-    () =>
-      handleDingTalkMessage({
-        cfg: ctx.cfg,
-        accountId: ctx.accountId,
-        data: syntheticData,
-        sessionWebhook: ctx.sessionWebhook,
-        log: ctx.log,
-        dingtalkConfig: ctx.dingtalkConfig,
-      }),
-  );
+  await handleDingTalkMessage({
+    cfg: ctx.cfg,
+    accountId: ctx.accountId,
+    data: syntheticData,
+    sessionWebhook: ctx.sessionWebhook,
+    log: ctx.log,
+    dingtalkConfig: ctx.dingtalkConfig,
+  });
 }
 
 export async function handleDingTalkAskUserCardCallback(params: {

--- a/src/card/ask-user-question.ts
+++ b/src/card/ask-user-question.ts
@@ -1,19 +1,18 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
-import { getAccessToken } from "./auth";
-import { updateCardVariables } from "./card-callback-service";
-import { DINGTALK_ASK_USER_CARD_TEMPLATE } from "./card/card-template";
-import { resolveRobotCode } from "./config";
-import axios from "./http-client";
-import { handleDingTalkMessage } from "./inbound-handler";
-import type {
-  DingTalkConfig,
-  DingTalkInboundMessage,
-  HandleDingTalkMessageParams,
-  Logger,
-} from "./types";
-import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "./utils";
+import { getAccessToken } from "../auth";
+import { updateCardVariables } from "../card-callback-service";
+import { resolveRobotCode } from "../config";
+import axios from "../http-client";
+import { handleDingTalkMessage } from "../inbound-handler";
+import type { DingTalkConfig, DingTalkInboundMessage, Logger } from "../types";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "../utils";
+import {
+  getDingTalkQuestionContext,
+  type DingTalkQuestionContext,
+  withDingTalkQuestionContext,
+} from "./ask-user-question-context";
+import { DINGTALK_ASK_USER_CARD_TEMPLATE } from "./card-template";
 
 const DINGTALK_API = "https://api.dingtalk.com";
 const PENDING_QUESTION_TTL_MS = 5 * 60 * 1000;
@@ -53,15 +52,6 @@ type SelectValue = { index: number; value: RawValue };
 type MultiSelectValue = { index: number[]; value: RawValue[] };
 type AnswerEntry = { question: string; answer: string };
 
-type AskUserQuestionContext = {
-  cfg: HandleDingTalkMessageParams["cfg"];
-  accountId: string;
-  data: DingTalkInboundMessage;
-  sessionWebhook: string;
-  log?: Logger;
-  dingtalkConfig: DingTalkConfig;
-};
-
 type FormField = {
   name: string;
   label?: string;
@@ -81,7 +71,7 @@ type FormField = {
   addText?: string;
 };
 
-type PendingQuestion = AskUserQuestionContext & {
+type PendingQuestion = DingTalkQuestionContext & {
   questionId: string;
   outTrackId: string;
   title: string;
@@ -102,7 +92,6 @@ type ParsedCardCallback = {
   hasBusinessPayload: boolean;
 };
 
-const questionContextStorage = new AsyncLocalStorage<AskUserQuestionContext>();
 const pendingQuestionsByTrackId = new Map<string, PendingQuestion>();
 const pendingQuestionsByQuestionId = new Map<string, PendingQuestion>();
 
@@ -114,13 +103,6 @@ function jsonToolResult(payload: unknown): {
     content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
     details: payload,
   };
-}
-
-export function withDingTalkQuestionContext<T>(
-  context: AskUserQuestionContext,
-  fn: () => Promise<T>,
-): Promise<T> {
-  return questionContextStorage.run(context, fn);
 }
 
 function stringifyCardData(data: Record<string, unknown>): Record<string, string> {
@@ -322,6 +304,7 @@ function storePendingQuestion(ctx: PendingQuestion): void {
     if (!pendingQuestionsByTrackId.has(ctx.outTrackId) || ctx.submitted) {
       return;
     }
+    ctx.submitted = true;
     consumePendingQuestion(ctx);
     void updateQuestionCardBestEffort(ctx, {
       card_status: "expired",
@@ -329,13 +312,13 @@ function storePendingQuestion(ctx: PendingQuestion): void {
       form_btn_text: "已失效",
     });
     setImmediate(() => {
-      void injectAnswerSyntheticMessage(
-        ctx,
-        `问题已超时，请重新发起: ${ctx.title}`,
-        "expired",
-      ).catch((err) => {
-        ctx.log?.error?.(`[DingTalk][AskUser] Failed to inject expiration message: ${String(err)}`);
-      });
+      void injectAnswerSyntheticMessage(ctx, buildExpiredAnswerMessage(ctx), "expired").catch(
+        (err) => {
+          ctx.log?.error?.(
+            `[DingTalk][AskUser] Failed to inject expired answer message: ${String(err)}`,
+          );
+        },
+      );
     });
   }, PENDING_QUESTION_TTL_MS);
 }
@@ -455,6 +438,14 @@ function buildEmptyAnswerMessage(ctx: PendingQuestion): string {
   return `用户提交了空表单: ${ctx.title}`;
 }
 
+function buildCancelledAnswerMessage(ctx: PendingQuestion): string {
+  return `用户取消了问题: ${ctx.title}`;
+}
+
+function buildExpiredAnswerMessage(ctx: PendingQuestion): string {
+  return `问题已超时: ${ctx.title}`;
+}
+
 async function injectAnswerSyntheticMessage(
   ctx: PendingQuestion,
   text: string,
@@ -497,7 +488,7 @@ async function injectAnswerSyntheticMessage(
 
 export async function handleDingTalkAskUserCardCallback(params: {
   payload: unknown;
-  cfg: HandleDingTalkMessageParams["cfg"];
+  cfg: DingTalkQuestionContext["cfg"];
   accountId: string;
   config: DingTalkConfig;
   log?: Logger;
@@ -533,10 +524,10 @@ export async function handleDingTalkAskUserCardCallback(params: {
     });
     consumePendingQuestion(ctx);
     setImmediate(() => {
-      void injectAnswerSyntheticMessage(ctx, `用户取消了问题: ${ctx.title}`, "cancelled").catch(
+      void injectAnswerSyntheticMessage(ctx, buildCancelledAnswerMessage(ctx), "cancelled").catch(
         (err) => {
           params.log?.error?.(
-            `[DingTalk][AskUser] Failed to inject cancellation message: ${String(err)}`,
+            `[DingTalk][AskUser] Failed to inject cancelled answer message: ${String(err)}`,
           );
         },
       );
@@ -666,10 +657,11 @@ const AskUserQuestionSchema = {
     fields: {
       type: "array",
       description:
-        "Advanced DingTalk form fields. Use top-level fields when collecting multiple inputs " +
-        "or when you need field types beyond the simple questions DSL. The plugin will send " +
-        "these fields as the DingTalk card variable form.fields. Do not wrap fields inside form. " +
-        "For simple confirmation, single-select, or multi-select questions, prefer questions. " +
+        "Advanced DingTalk form fields. Use top-level fields when collecting multiple inputs, " +
+        "when the user asks to fill a form, or when you would otherwise list required parameters in markdown. " +
+        "Do not answer with a markdown checklist when these fields are needed. The plugin will send " +
+        "these fields as the DingTalk card variable form, shaped as { fields }. Do not wrap fields inside form. " +
+        "For simple confirmation, single-select, or multi-select questions, prefer questions. Do not mix fields with questions. " +
         "For choice fields (SELECT, MULTI_SELECT, CHECKBOX_GROUP, MULTI_CHECKBOX_GROUP), " +
         "provide options as { value, text }. Use TEXT for single-line text, TEXT_AREA for " +
         "multi-line text, NUMBER for numeric input, DATE/TIME/DATETIME for date or time inputs, " +
@@ -762,8 +754,11 @@ export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): voi
   const registerTool = (
     api as OpenClawPluginApi & { registerTool?: OpenClawPluginApi["registerTool"] }
   ).registerTool;
+  api.logger?.debug?.(
+    `${TOOL_NAME}: register hook invoked, mode=${api.registrationMode ?? "unknown"}, registerTool=${typeof registerTool}`,
+  );
   if (typeof registerTool !== "function") {
-    api.logger?.debug?.(`${TOOL_NAME}: registerTool unavailable, skipping tool registration`);
+    api.logger?.warn?.(`${TOOL_NAME}: registerTool unavailable, skipping tool registration`);
     return;
   }
 
@@ -771,16 +766,17 @@ export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): voi
     name: TOOL_NAME,
     label: "Ask User Question",
     description:
-      "Ask the user a blocking question via an interactive DingTalk card when the current task cannot continue without the user's answer. " +
+      "Ask the user a blocking question or collect structured input via an interactive DingTalk form card when the current task cannot continue without the user's answer. " +
       "Returns immediately after sending the card. " +
       "The user's answer will arrive as a new message in the conversation. " +
       "Do NOT poll or re-call this tool — just wait for the response message. " +
       "For selection questions, provide options. " +
       "For free-text input, set options to an empty array. " +
+      "When collecting multiple missing values, when the user asks for a form, or when you would otherwise list required parameters for the user to fill, call this tool with top-level fields instead of replying with a markdown checklist. " +
       "Do not call this tool for normal explanations, why/how questions, capability introductions, or cases where you can answer directly.",
     parameters: AskUserQuestionSchema as any,
     async execute(_toolCallId: string, params: unknown) {
-      const context = questionContextStorage.getStore();
+      const context = getDingTalkQuestionContext();
       if (!context) {
         return jsonToolResult({
           status: "failed",
@@ -842,15 +838,26 @@ export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): voi
           error: detail || (err instanceof Error ? err.message : String(err)),
         });
       }
-
-      storePendingQuestion({
+      const pendingContext: DingTalkQuestionContext = {
         ...context,
+        onQuestionCardSent: undefined,
+      };
+      storePendingQuestion({
+        ...pendingContext,
         questionId,
         outTrackId,
         title,
         questions: parsed,
         submitted: false,
       });
+
+      try {
+        await context.onQuestionCardSent?.({ questionId, outTrackId });
+      } catch (err) {
+        context.log?.warn?.(
+          `[DingTalk][AskUser] onQuestionCardSent hook failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
 
       context.log?.info?.(
         `[DingTalk][AskUser] question card sent question=${questionId} outTrackId=${outTrackId}`,

--- a/src/card/ask-user-question.ts
+++ b/src/card/ask-user-question.ts
@@ -16,6 +16,7 @@ import { DINGTALK_ASK_USER_CARD_TEMPLATE } from "./card-template";
 
 const DINGTALK_API = "https://api.dingtalk.com";
 const PENDING_QUESTION_TTL_MS = 5 * 60 * 1000;
+const HANDLED_CALLBACK_TOMBSTONE_TTL_MS = 30 * 60 * 1000;
 const TOOL_NAME = "dingtalk_ask_user_question";
 const ANSWER_FIELD_PREFIX = "answer";
 
@@ -82,7 +83,15 @@ type PendingQuestion = DingTalkQuestionContext & {
     multiSelect: boolean;
   }>;
   submitted: boolean;
+  ownerUserId?: string;
   ttlTimer?: ReturnType<typeof setTimeout>;
+};
+
+type HandledQuestionTombstone = {
+  outTrackId: string;
+  questionId: string;
+  reason: "superseded" | "expired" | "submitted" | "cancelled" | "empty";
+  timer?: ReturnType<typeof setTimeout>;
 };
 
 type ParsedCardCallback = {
@@ -94,6 +103,9 @@ type ParsedCardCallback = {
 
 const pendingQuestionsByTrackId = new Map<string, PendingQuestion>();
 const pendingQuestionsByQuestionId = new Map<string, PendingQuestion>();
+const pendingOutTrackIdsByScopeKey = new Map<string, Set<string>>();
+const handledQuestionTombstonesByTrackId = new Map<string, HandledQuestionTombstone>();
+const handledQuestionTombstonesByQuestionId = new Map<string, HandledQuestionTombstone>();
 
 function jsonToolResult(payload: unknown): {
   content: Array<{ type: "text"; text: string }>;
@@ -115,6 +127,33 @@ function stringifyCardData(data: Record<string, unknown>): Record<string, string
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeUserId(value: unknown): string | undefined {
+  return readString(value);
+}
+
+function resolvePendingQuestionOwner(ctx: PendingQuestion): string | undefined {
+  return (
+    normalizeUserId(ctx.ownerUserId) ??
+    normalizeUserId(ctx.data.senderStaffId) ??
+    normalizeUserId(ctx.data.senderId)
+  );
+}
+
+function isOwnerClick(ctx: PendingQuestion, clickerUserId?: string): boolean {
+  const ownerUserId = resolvePendingQuestionOwner(ctx);
+  if (!ownerUserId) {
+    return true;
+  }
+  const clicker = normalizeUserId(clickerUserId);
+  if (!clicker) {
+    return false;
+  }
+  const allowed = [ownerUserId, ctx.data.senderStaffId, ctx.data.senderId]
+    .map((value) => normalizeUserId(value)?.toLowerCase())
+    .filter((value): value is string => Boolean(value));
+  return allowed.includes(clicker.toLowerCase());
 }
 
 function normalizeOption(option: AskUserOption, index: number): { value: string; text: string } {
@@ -297,15 +336,123 @@ async function createAndDeliverQuestionCard(params: {
   }
 }
 
+function removeScopeIndex(ctx: PendingQuestion): void {
+  const scopeKey = readString(ctx.questionScopeKey);
+  if (!scopeKey) {
+    return;
+  }
+  const set = pendingOutTrackIdsByScopeKey.get(scopeKey);
+  if (!set) {
+    return;
+  }
+  set.delete(ctx.outTrackId);
+  if (set.size === 0) {
+    pendingOutTrackIdsByScopeKey.delete(scopeKey);
+  }
+}
+
+function addScopeIndex(ctx: PendingQuestion): void {
+  const scopeKey = readString(ctx.questionScopeKey);
+  if (!scopeKey) {
+    return;
+  }
+  let set = pendingOutTrackIdsByScopeKey.get(scopeKey);
+  if (!set) {
+    set = new Set();
+    pendingOutTrackIdsByScopeKey.set(scopeKey, set);
+  }
+  set.add(ctx.outTrackId);
+}
+
+function deleteHandledQuestionTombstone(tombstone: HandledQuestionTombstone): void {
+  if (handledQuestionTombstonesByTrackId.get(tombstone.outTrackId) === tombstone) {
+    handledQuestionTombstonesByTrackId.delete(tombstone.outTrackId);
+  }
+  if (handledQuestionTombstonesByQuestionId.get(tombstone.questionId) === tombstone) {
+    handledQuestionTombstonesByQuestionId.delete(tombstone.questionId);
+  }
+  if (tombstone.timer) {
+    clearTimeout(tombstone.timer);
+  }
+}
+
+function addHandledQuestionTombstone(
+  ctx: PendingQuestion,
+  reason: HandledQuestionTombstone["reason"],
+): void {
+  const existingByTrack = handledQuestionTombstonesByTrackId.get(ctx.outTrackId);
+  if (existingByTrack) {
+    deleteHandledQuestionTombstone(existingByTrack);
+  }
+  const existingByQuestion = handledQuestionTombstonesByQuestionId.get(ctx.questionId);
+  if (existingByQuestion && existingByQuestion !== existingByTrack) {
+    deleteHandledQuestionTombstone(existingByQuestion);
+  }
+  const tombstone: HandledQuestionTombstone = {
+    outTrackId: ctx.outTrackId,
+    questionId: ctx.questionId,
+    reason,
+  };
+  tombstone.timer = setTimeout(() => {
+    deleteHandledQuestionTombstone(tombstone);
+  }, HANDLED_CALLBACK_TOMBSTONE_TTL_MS);
+  if (typeof tombstone.timer === "object" && "unref" in tombstone.timer) {
+    tombstone.timer.unref();
+  }
+  handledQuestionTombstonesByTrackId.set(ctx.outTrackId, tombstone);
+  handledQuestionTombstonesByQuestionId.set(ctx.questionId, tombstone);
+}
+
+function findHandledQuestionTombstone(
+  parsed: ParsedCardCallback,
+): HandledQuestionTombstone | undefined {
+  return (
+    (parsed.outTrackId ? handledQuestionTombstonesByTrackId.get(parsed.outTrackId) : undefined) ??
+    (parsed.actionId ? handledQuestionTombstonesByQuestionId.get(parsed.actionId) : undefined)
+  );
+}
+
+function supersedePendingQuestionsInScope(ctx: PendingQuestion): void {
+  const scopeKey = readString(ctx.questionScopeKey);
+  if (!scopeKey) {
+    return;
+  }
+  const set = pendingOutTrackIdsByScopeKey.get(scopeKey);
+  if (!set) {
+    return;
+  }
+  for (const outTrackId of [...set]) {
+    if (outTrackId === ctx.outTrackId) {
+      continue;
+    }
+    const oldCtx = pendingQuestionsByTrackId.get(outTrackId);
+    if (!oldCtx || oldCtx.submitted) {
+      continue;
+    }
+    oldCtx.submitted = true;
+    consumePendingQuestion(oldCtx);
+    addHandledQuestionTombstone(oldCtx, "superseded");
+    void updateQuestionCardBestEffort(oldCtx, {
+      card_status: "expired",
+      question_desc: "已有新的问题卡片，请回答最新卡片。",
+      form_btn_text: "已失效",
+    });
+  }
+}
+
 function storePendingQuestion(ctx: PendingQuestion): void {
+  ctx.ownerUserId = resolvePendingQuestionOwner(ctx);
+  supersedePendingQuestionsInScope(ctx);
   pendingQuestionsByTrackId.set(ctx.outTrackId, ctx);
   pendingQuestionsByQuestionId.set(ctx.questionId, ctx);
+  addScopeIndex(ctx);
   ctx.ttlTimer = setTimeout(() => {
     if (!pendingQuestionsByTrackId.has(ctx.outTrackId) || ctx.submitted) {
       return;
     }
     ctx.submitted = true;
     consumePendingQuestion(ctx);
+    addHandledQuestionTombstone(ctx, "expired");
     void updateQuestionCardBestEffort(ctx, {
       card_status: "expired",
       question_desc: "问题已失效，请重新发起。",
@@ -326,6 +473,7 @@ function storePendingQuestion(ctx: PendingQuestion): void {
 function consumePendingQuestion(ctx: PendingQuestion): void {
   pendingQuestionsByTrackId.delete(ctx.outTrackId);
   pendingQuestionsByQuestionId.delete(ctx.questionId);
+  removeScopeIndex(ctx);
   if (ctx.ttlTimer) {
     clearTimeout(ctx.ttlTimer);
   }
@@ -431,19 +579,41 @@ function formatAnswerText(
 
 function buildAnswerMessage(ctx: PendingQuestion, answers: AnswerEntry[]): string {
   const lines = answers.map(({ question, answer }) => `- ${question}: ${answer}`);
-  return `用户回答了你的问题:\n${lines.join("\n")}`;
+  return [
+    "用户回答了交互卡片:",
+    `- question_id: ${ctx.questionId}`,
+    `- question_title: ${ctx.title}`,
+    "- status: submitted",
+    "- answers:",
+    ...lines.map((line) => `  ${line}`),
+  ].join("\n");
 }
 
 function buildEmptyAnswerMessage(ctx: PendingQuestion): string {
-  return `用户提交了空表单: ${ctx.title}`;
+  return [
+    "用户提交了空交互卡片:",
+    `- question_id: ${ctx.questionId}`,
+    `- question_title: ${ctx.title}`,
+    "- status: submitted",
+  ].join("\n");
 }
 
 function buildCancelledAnswerMessage(ctx: PendingQuestion): string {
-  return `用户取消了问题: ${ctx.title}`;
+  return [
+    "用户取消了交互卡片:",
+    `- question_id: ${ctx.questionId}`,
+    `- question_title: ${ctx.title}`,
+    "- status: cancelled",
+  ].join("\n");
 }
 
 function buildExpiredAnswerMessage(ctx: PendingQuestion): string {
-  return `问题已超时: ${ctx.title}`;
+  return [
+    "交互卡片已超时:",
+    `- question_id: ${ctx.questionId}`,
+    `- question_title: ${ctx.title}`,
+    "- status: expired",
+  ].join("\n");
 }
 
 async function injectAnswerSyntheticMessage(
@@ -491,14 +661,29 @@ export async function handleDingTalkAskUserCardCallback(params: {
   cfg: DingTalkQuestionContext["cfg"];
   accountId: string;
   config: DingTalkConfig;
+  clickerUserId?: string;
   log?: Logger;
 }): Promise<{ handled: boolean }> {
   const parsed = parseAskUserCardCallback(params.payload);
+  const tombstone = findHandledQuestionTombstone(parsed);
+  if (tombstone) {
+    params.log?.debug?.(
+      `[DingTalk][AskUser] Ignoring handled callback question=${tombstone.questionId} reason=${tombstone.reason}`,
+    );
+    return { handled: true };
+  }
   const ctx =
     (parsed.outTrackId ? pendingQuestionsByTrackId.get(parsed.outTrackId) : undefined) ??
     (parsed.actionId ? pendingQuestionsByQuestionId.get(parsed.actionId) : undefined);
   if (!ctx) {
     return { handled: false };
+  }
+
+  if (!isOwnerClick(ctx, params.clickerUserId)) {
+    params.log?.info?.(
+      `[DingTalk][AskUser] rejected: clicker=${params.clickerUserId ?? "unknown"} owner=${resolvePendingQuestionOwner(ctx) ?? "unknown"} question=${ctx.questionId}`,
+    );
+    return { handled: true };
   }
 
   if (!parsed.hasBusinessPayload) {
@@ -523,6 +708,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
       form_btn_text: "已取消",
     });
     consumePendingQuestion(ctx);
+    addHandledQuestionTombstone(ctx, "cancelled");
     setImmediate(() => {
       void injectAnswerSyntheticMessage(ctx, buildCancelledAnswerMessage(ctx), "cancelled").catch(
         (err) => {
@@ -567,6 +753,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
       form_btn_text: "已提交",
     });
     consumePendingQuestion(ctx);
+    addHandledQuestionTombstone(ctx, "empty");
     setImmediate(() => {
       void injectAnswerSyntheticMessage(ctx, buildEmptyAnswerMessage(ctx), "empty").catch((err) => {
         params.log?.error?.(
@@ -586,6 +773,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
     form_btn_text: "已提交",
   });
   consumePendingQuestion(ctx);
+  addHandledQuestionTombstone(ctx, "submitted");
 
   const message = buildAnswerMessage(ctx, answers);
   setImmediate(() => {
@@ -612,7 +800,8 @@ const AskUserQuestionSchema = {
     questions: {
       type: "array",
       description:
-        "Blocking question(s) that must be answered by the DingTalk user before the assistant can continue. Prefer exactly one question per card. " +
+        "Lightweight blocking question DSL for simple confirmation, single-select, multi-select, or simple free-text prompts. Prefer exactly one question per card. " +
+        "Do not use questions for complex forms, multiple structured fields, date/time inputs, numeric inputs, boolean switches, or mixed input collection; use top-level fields for those cases. " +
         "Do not use for explanations, status updates, capability introductions, or retrospective questions.",
       minItems: 1,
       maxItems: 6,
@@ -659,6 +848,7 @@ const AskUserQuestionSchema = {
       description:
         "Advanced DingTalk form fields. Use top-level fields when collecting multiple inputs, " +
         "when the user asks to fill a form, or when you would otherwise list required parameters in markdown. " +
+        "Use one fields card to collect all missing inputs for the current turn; do not split related fields into multiple cards. " +
         "Do not answer with a markdown checklist when these fields are needed. The plugin will send " +
         "these fields as the DingTalk card variable form, shaped as { fields }. Do not wrap fields inside form. " +
         "For simple confirmation, single-select, or multi-select questions, prefer questions. Do not mix fields with questions. " +
@@ -746,8 +936,20 @@ export function clearPendingQuestionsForTest(): void {
       clearTimeout(ctx.ttlTimer);
     }
   }
+  const tombstones = new Set([
+    ...handledQuestionTombstonesByTrackId.values(),
+    ...handledQuestionTombstonesByQuestionId.values(),
+  ]);
+  for (const tombstone of tombstones) {
+    if (tombstone.timer) {
+      clearTimeout(tombstone.timer);
+    }
+  }
   pendingQuestionsByTrackId.clear();
   pendingQuestionsByQuestionId.clear();
+  pendingOutTrackIdsByScopeKey.clear();
+  handledQuestionTombstonesByTrackId.clear();
+  handledQuestionTombstonesByQuestionId.clear();
 }
 
 export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): void {
@@ -770,8 +972,8 @@ export function registerDingTalkAskUserQuestionTool(api: OpenClawPluginApi): voi
       "Returns immediately after sending the card. " +
       "The user's answer will arrive as a new message in the conversation. " +
       "Do NOT poll or re-call this tool — just wait for the response message. " +
-      "For selection questions, provide options. " +
-      "For free-text input, set options to an empty array. " +
+      "Use questions only for simple confirmation, single-select, multi-select, or simple free-text prompts. " +
+      "For simple selection questions, provide options; for simple free-text input, set options to an empty array. " +
       "When collecting multiple missing values, when the user asks for a form, or when you would otherwise list required parameters for the user to fill, call this tool with top-level fields instead of replying with a markdown checklist. " +
       "Do not call this tool for normal explanations, why/how questions, capability introductions, or cases where you can answer directly.",
     parameters: AskUserQuestionSchema as any,

--- a/src/card/ask-user-question.ts
+++ b/src/card/ask-user-question.ts
@@ -6,7 +6,7 @@ import { resolveRobotCode } from "../config";
 import axios from "../http-client";
 import { handleDingTalkMessage } from "../inbound-handler";
 import type { DingTalkConfig, DingTalkInboundMessage, Logger } from "../types";
-import { formatDingTalkErrorPayloadLog, getProxyBypassOption } from "../utils";
+import { formatDingTalkErrorPayloadLog, getProxyBypassOption, parseBooleanLike } from "../utils";
 import {
   getDingTalkQuestionContext,
   type DingTalkQuestionContext,
@@ -392,7 +392,7 @@ export function parseAskUserCardCallback(payload: unknown): ParsedCardCallback {
     outTrackId,
     actionId,
     params,
-    hasBusinessPayload: Boolean(params.form || params.user_cancel || params.user_cacel),
+    hasBusinessPayload: Boolean(params.form || params.user_cancel),
   };
 }
 
@@ -513,7 +513,7 @@ export async function handleDingTalkAskUserCardCallback(params: {
     return { handled: true };
   }
 
-  const isCancel = parsed.params.user_cancel === "true" || parsed.params.user_cacel === "true";
+  const isCancel = parseBooleanLike(parsed.params.user_cancel) === true;
   ctx.submitted = true;
 
   if (isCancel) {

--- a/src/card/card-action-handler.ts
+++ b/src/card/card-action-handler.ts
@@ -22,6 +22,7 @@ export async function handleCardAction(params: {
     cfg: params.cfg,
     accountId: params.accountId,
     config: params.config,
+    clickerUserId: params.analysis.userId,
     log: params.log,
   });
   if (askUserResult.handled) {

--- a/src/card/card-action-handler.ts
+++ b/src/card/card-action-handler.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { CardCallbackAnalysis } from "../card-callback-service";
 import type { DingTalkConfig, Logger } from "../types";
+import { handleDingTalkAskUserCardCallback } from "./ask-user-question";
 import { resolveCardRun } from "./card-run-registry";
 import { stopCardRun } from "./card-stop-handler";
 
@@ -9,12 +10,24 @@ export interface CardActionResult {
 }
 
 export async function handleCardAction(params: {
+  payload: unknown;
   analysis: CardCallbackAnalysis;
   cfg: OpenClawConfig;
   accountId: string;
   config: DingTalkConfig;
   log?: Logger;
 }): Promise<CardActionResult> {
+  const askUserResult = await handleDingTalkAskUserCardCallback({
+    payload: params.payload,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    config: params.config,
+    log: params.log,
+  });
+  if (askUserResult.handled) {
+    return askUserResult;
+  }
+
   if (params.analysis.actionId !== "btn_stop") {
     return { handled: false };
   }

--- a/src/card/card-template.ts
+++ b/src/card/card-template.ts
@@ -8,6 +8,8 @@ export const BUILTIN_DINGTALK_CARD_TEMPLATE_ID =
 export const BUILTIN_DINGTALK_CARD_CONTENT_KEY = "content";
 export const BUILTIN_DINGTALK_CARD_BLOCK_LIST_KEY = "blockList";
 export const BUILTIN_DINGTALK_CARD_COPY_CONTENT_KEY = "copy_content";
+export const BUILTIN_DINGTALK_ASK_USER_CARD_TEMPLATE_ID =
+  "89d0c6fe-3822-44c8-950e-e950f562546d.schema";
 
 export interface DingTalkCardTemplateContract {
   templateId: string;
@@ -20,6 +22,10 @@ export interface DingTalkCardTemplateContract {
   copyContentKey: string;
 }
 
+export interface DingTalkAskUserCardTemplateContract {
+  templateId: string;
+}
+
 /** Frozen singleton — no allocation on every call. */
 export const DINGTALK_CARD_TEMPLATE: Readonly<DingTalkCardTemplateContract> = Object.freeze({
   templateId: BUILTIN_DINGTALK_CARD_TEMPLATE_ID,
@@ -29,3 +35,7 @@ export const DINGTALK_CARD_TEMPLATE: Readonly<DingTalkCardTemplateContract> = Ob
   copyContentKey: BUILTIN_DINGTALK_CARD_COPY_CONTENT_KEY,
 });
 
+export const DINGTALK_ASK_USER_CARD_TEMPLATE: Readonly<DingTalkAskUserCardTemplateContract> =
+  Object.freeze({
+    templateId: BUILTIN_DINGTALK_ASK_USER_CARD_TEMPLATE_ID,
+  });

--- a/src/gateway/channel-gateway.ts
+++ b/src/gateway/channel-gateway.ts
@@ -1,14 +1,7 @@
 import { DWClient, TOPIC_CARD, TOPIC_ROBOT } from "dingtalk-stream";
-import {
-  handleDingTalkAskUserCardCallback,
-  withDingTalkQuestionContext,
-} from "../ask-user-question";
 import { analyzeCardCallback } from "../card-callback-service";
+import { finalizeActiveCardsForAccount, recoverPendingCardsForAccount } from "../card-service";
 import { handleCardAction } from "../card/card-action-handler";
-import {
-  finalizeActiveCardsForAccount,
-  recoverPendingCardsForAccount,
-} from "../card-service";
 import { resolveRobotCode, resolveRuntimeConfig } from "../config";
 import { ConnectionManager } from "../connection-manager";
 import { isMessageProcessed, markMessageProcessed } from "../dedup";
@@ -264,25 +257,14 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               ctx.log?.warn?.(`[${account.accountId}] No message ID available for deduplication`);
               stats.noMessageId += 1;
               acknowledge();
-              await withDingTalkQuestionContext(
-                {
-                  cfg,
-                  accountId: account.accountId,
-                  data,
-                  sessionWebhook: data.sessionWebhook,
-                  log: pluginLog,
-                  dingtalkConfig: config,
-                },
-                () =>
-                  handleDingTalkMessage({
-                    cfg,
-                    accountId: account.accountId,
-                    data,
-                    sessionWebhook: data.sessionWebhook,
-                    log: pluginLog,
-                    dingtalkConfig: config,
-                  }),
-              );
+              await handleDingTalkMessage({
+                cfg,
+                accountId: account.accountId,
+                data,
+                sessionWebhook: data.sessionWebhook,
+                log: pluginLog,
+                dingtalkConfig: config,
+              });
               stats.processed += 1;
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
                 logInboundCounters(pluginLog, account.accountId, "periodic");
@@ -319,25 +301,14 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
             acknowledge();
             processingDedupKeys.set(dedupKey, Date.now());
             try {
-              await withDingTalkQuestionContext(
-                {
-                  cfg,
-                  accountId: account.accountId,
-                  data,
-                  sessionWebhook: data.sessionWebhook,
-                  log: pluginLog,
-                  dingtalkConfig: config,
-                },
-                () =>
-                  handleDingTalkMessage({
-                    cfg,
-                    accountId: account.accountId,
-                    data,
-                    sessionWebhook: data.sessionWebhook,
-                    log: pluginLog,
-                    dingtalkConfig: config,
-                  }),
-              );
+              await handleDingTalkMessage({
+                cfg,
+                accountId: account.accountId,
+                data,
+                sessionWebhook: data.sessionWebhook,
+                log: pluginLog,
+                dingtalkConfig: config,
+              });
               stats.processed += 1;
               markMessageProcessed(dedupKey);
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
@@ -375,17 +346,6 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               `[${account.accountId}] [DingTalk][CardCallback] action=${analysis.summary} raw=${JSON.stringify(payload)}`,
             );
 
-            const askUserResult = await handleDingTalkAskUserCardCallback({
-              payload,
-              cfg,
-              accountId: account.accountId,
-              config,
-              log: pluginLog,
-            });
-            if (askUserResult.handled) {
-              return;
-            }
-
             if (analysis.feedbackTarget && analysis.feedbackAckText) {
               recordExplicitFeedbackLearning({
                 enabled: isLearningEnabled(config),
@@ -418,6 +378,7 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               }
             }
             const actionResult = await handleCardAction({
+              payload,
               analysis,
               cfg,
               accountId: account.accountId,
@@ -537,7 +498,9 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               lastStartAt: getCurrentTimestamp(),
               lastError: null,
             });
-            pluginLog?.info?.(`[${account.accountId}] DingTalk Stream client connected successfully`);
+            pluginLog?.info?.(
+              `[${account.accountId}] DingTalk Stream client connected successfully`,
+            );
             await nativeStopPromise;
           }
         } catch (err: any) {

--- a/src/gateway/channel-gateway.ts
+++ b/src/gateway/channel-gateway.ts
@@ -1,4 +1,8 @@
 import { DWClient, TOPIC_CARD, TOPIC_ROBOT } from "dingtalk-stream";
+import {
+  handleDingTalkAskUserCardCallback,
+  withDingTalkQuestionContext,
+} from "../ask-user-question";
 import { analyzeCardCallback } from "../card-callback-service";
 import { handleCardAction } from "../card/card-action-handler";
 import {
@@ -260,14 +264,25 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
               ctx.log?.warn?.(`[${account.accountId}] No message ID available for deduplication`);
               stats.noMessageId += 1;
               acknowledge();
-              await handleDingTalkMessage({
-                cfg,
-                accountId: account.accountId,
-                data,
-                sessionWebhook: data.sessionWebhook,
-                log: pluginLog,
-                dingtalkConfig: config,
-              });
+              await withDingTalkQuestionContext(
+                {
+                  cfg,
+                  accountId: account.accountId,
+                  data,
+                  sessionWebhook: data.sessionWebhook,
+                  log: pluginLog,
+                  dingtalkConfig: config,
+                },
+                () =>
+                  handleDingTalkMessage({
+                    cfg,
+                    accountId: account.accountId,
+                    data,
+                    sessionWebhook: data.sessionWebhook,
+                    log: pluginLog,
+                    dingtalkConfig: config,
+                  }),
+              );
               stats.processed += 1;
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
                 logInboundCounters(pluginLog, account.accountId, "periodic");
@@ -304,14 +319,25 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
             acknowledge();
             processingDedupKeys.set(dedupKey, Date.now());
             try {
-              await handleDingTalkMessage({
-                cfg,
-                accountId: account.accountId,
-                data,
-                sessionWebhook: data.sessionWebhook,
-                log: pluginLog,
-                dingtalkConfig: config,
-              });
+              await withDingTalkQuestionContext(
+                {
+                  cfg,
+                  accountId: account.accountId,
+                  data,
+                  sessionWebhook: data.sessionWebhook,
+                  log: pluginLog,
+                  dingtalkConfig: config,
+                },
+                () =>
+                  handleDingTalkMessage({
+                    cfg,
+                    accountId: account.accountId,
+                    data,
+                    sessionWebhook: data.sessionWebhook,
+                    log: pluginLog,
+                    dingtalkConfig: config,
+                  }),
+              );
               stats.processed += 1;
               markMessageProcessed(dedupKey);
               if (stats.received % INBOUND_COUNTER_LOG_EVERY === 0) {
@@ -348,6 +374,17 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
             pluginLog?.info?.(
               `[${account.accountId}] [DingTalk][CardCallback] action=${analysis.summary} raw=${JSON.stringify(payload)}`,
             );
+
+            const askUserResult = await handleDingTalkAskUserCardCallback({
+              payload,
+              cfg,
+              accountId: account.accountId,
+              config,
+              log: pluginLog,
+            });
+            if (askUserResult.handled) {
+              return;
+            }
 
             if (analysis.feedbackTarget && analysis.feedbackAckText) {
               recordExplicitFeedbackLearning({

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -558,6 +558,9 @@ export async function downloadMedia(
 }
 
 export async function handleDingTalkMessage(params: HandleDingTalkMessageParams): Promise<void> {
+  // Keep context creation inside this public inbound entry. Ask-user synthetic
+  // reinjections call handleDingTalkMessage directly, so moving this wrapper to
+  // gateway callbacks would lose per-message isolation for reinjected answers.
   return withDingTalkQuestionContext(
     {
       cfg: params.cfg,

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -7,10 +7,19 @@ import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
 import { createDynamicAckReactionController } from "./ack-reaction/dynamic-ack-reaction-controller";
 import { getAccessToken } from "./auth";
-import { createAICard, commitAICardBlocks, isCardInTerminalState, recallAICardMessage } from "./card-service";
-import { getDingTalkQuestionContext, withDingTalkQuestionContext } from "./card/ask-user-question-context";
+import {
+  createAICard,
+  commitAICardBlocks,
+  isCardInTerminalState,
+  recallAICardMessage,
+} from "./card-service";
+import {
+  getDingTalkQuestionContext,
+  withDingTalkQuestionContext,
+} from "./card/ask-user-question-context";
 import { isCardRunStopRequested, registerCardRun, removeCardRun } from "./card/card-run-registry";
 import { renderStatusLine } from "./card/statusline-renderer";
+import { dispatchDingTalkCardStopCommand } from "./command/card-stop-command";
 import { handleInboundCommandDispatch } from "./command/inbound-command-dispatch-service";
 import {
   resolveAckReactionSetting,
@@ -824,6 +833,10 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
       peer: { kind: sessionPeer.kind, id: sessionPeer.peerId },
     });
   }
+  const questionContext = getDingTalkQuestionContext();
+  if (questionContext) {
+    questionContext.questionScopeKey = `${accountId}:${route.sessionKey}:${senderId}`;
+  }
 
   // @Sub-Agent routing: dispatch @mention-targeted messages to their agent(s).
   // Both content (`@agent <message>`) and commands (`@agent /new`) re-enter
@@ -948,28 +961,42 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
   let questionCardTookOver = false;
 
   let cardFlightKey: string | undefined;
-  const questionContext = getDingTalkQuestionContext();
   if (questionContext) {
     questionContext.onQuestionCardSent = async ({ questionId, outTrackId }) => {
+      questionCardTookOver = true;
+      if (cardFlightKey) {
+        cardCreationInFlight.delete(cardFlightKey);
+        cardFlightKey = undefined;
+      }
+      try {
+        await dispatchDingTalkCardStopCommand({
+          cfg,
+          accountId,
+          agentId: route.agentId,
+          targetSessionKey: route.sessionKey,
+          clickerUserId: senderId || "unknown",
+          log,
+        });
+        log?.info?.(
+          `[DingTalk][AskUser] Dispatched targeted stop after question card sent question=${questionId} outTrackId=${outTrackId} targetSessionKey=${route.sessionKey}`,
+        );
+      } catch (err) {
+        log?.warn?.(
+          `[DingTalk][AskUser] Question card sent, but targeted stop failed question=${questionId} outTrackId=${outTrackId} targetSessionKey=${route.sessionKey}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       if (!currentAICard) {
-        questionCardTookOver = true;
         return;
       }
       if (isCardInTerminalState(currentAICard.state)) {
-        questionCardTookOver = true;
         return;
       }
       const recalled = await recallAICardMessage(currentAICard, log);
       if (!recalled) {
         log?.warn?.(
-          `[DingTalk][AskUser] Question card sent, but AI card recall failed; keeping normal reply fallback question=${questionId} outTrackId=${outTrackId}`,
+          `[DingTalk][AskUser] Question card sent, but AI card recall failed; normal replies remain suppressed question=${questionId} outTrackId=${outTrackId}`,
         );
         return;
-      }
-      questionCardTookOver = true;
-      if (cardFlightKey) {
-        cardCreationInFlight.delete(cardFlightKey);
-        cardFlightKey = undefined;
       }
       log?.info?.(
         `[DingTalk][AskUser] Recalled empty AI card after question card sent question=${questionId} outTrackId=${outTrackId}`,
@@ -2265,7 +2292,9 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
             bufferedFinalPayload.text.trim().length > 0;
           if (hasBufferedText || mediaUrls.length > 0) {
             if (questionCardTookOver) {
-              log?.info?.("[DingTalk][AskUser] Suppressed buffered final after question card took over");
+              log?.info?.(
+                "[DingTalk][AskUser] Suppressed buffered final after question card took over",
+              );
             } else {
               await strategy.deliver({
                 text: inlineReplyPayload.text,
@@ -2285,7 +2314,9 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
       }
 
       if (questionCardTookOver) {
-        log?.info?.("[DingTalk][AskUser] Skipping normal AI card finalize after question card took over");
+        log?.info?.(
+          "[DingTalk][AskUser] Skipping normal AI card finalize after question card took over",
+        );
         return;
       }
       await strategy.finalize();

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -7,7 +7,8 @@ import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
 import { createDynamicAckReactionController } from "./ack-reaction/dynamic-ack-reaction-controller";
 import { getAccessToken } from "./auth";
-import { createAICard, commitAICardBlocks, isCardInTerminalState } from "./card-service";
+import { createAICard, commitAICardBlocks, isCardInTerminalState, recallAICardMessage } from "./card-service";
+import { getDingTalkQuestionContext, withDingTalkQuestionContext } from "./card/ask-user-question-context";
 import { isCardRunStopRequested, registerCardRun, removeCardRun } from "./card/card-run-registry";
 import { renderStatusLine } from "./card/statusline-renderer";
 import { handleInboundCommandDispatch } from "./command/inbound-command-dispatch-service";
@@ -548,6 +549,20 @@ export async function downloadMedia(
 }
 
 export async function handleDingTalkMessage(params: HandleDingTalkMessageParams): Promise<void> {
+  return withDingTalkQuestionContext(
+    {
+      cfg: params.cfg,
+      accountId: params.accountId,
+      data: params.data,
+      sessionWebhook: params.sessionWebhook,
+      log: params.log,
+      dingtalkConfig: params.dingtalkConfig,
+    },
+    () => handleDingTalkMessageInner(params),
+  );
+}
+
+async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): Promise<void> {
   const {
     cfg,
     accountId,
@@ -930,8 +945,38 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
   // sending a separate plain-text message.
   let useCardMode = dingtalkConfig.messageType === "card";
   let currentAICard: import("./types").AICardInstance | undefined;
+  let questionCardTookOver = false;
 
   let cardFlightKey: string | undefined;
+  const questionContext = getDingTalkQuestionContext();
+  if (questionContext) {
+    questionContext.onQuestionCardSent = async ({ questionId, outTrackId }) => {
+      if (!currentAICard) {
+        questionCardTookOver = true;
+        return;
+      }
+      if (isCardInTerminalState(currentAICard.state)) {
+        questionCardTookOver = true;
+        return;
+      }
+      const recalled = await recallAICardMessage(currentAICard, log);
+      if (!recalled) {
+        log?.warn?.(
+          `[DingTalk][AskUser] Question card sent, but AI card recall failed; keeping normal reply fallback question=${questionId} outTrackId=${outTrackId}`,
+        );
+        return;
+      }
+      questionCardTookOver = true;
+      if (cardFlightKey) {
+        cardCreationInFlight.delete(cardFlightKey);
+        cardFlightKey = undefined;
+      }
+      log?.info?.(
+        `[DingTalk][AskUser] Recalled empty AI card after question card sent question=${questionId} outTrackId=${outTrackId}`,
+      );
+    };
+  }
+
   if (useCardMode && !isBtwBypass) {
     const key = `${accountId}:${to}`;
     if (cardCreationInFlight.has(key)) {
@@ -2163,11 +2208,18 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
                 const inlineReplyPayload = parseInlineReplyPayloadText(payload.text);
                 const mediaUrls = extractMediaUrls(payload, inlineReplyPayload);
                 const richPayload = payload as ReplyStreamPayload & { isReasoning?: boolean };
+                const replyKind = (info?.kind as DeliverPayload["kind"]) || "block";
+                if (questionCardTookOver) {
+                  log?.info?.(
+                    `[DingTalk][AskUser] Suppressed ${replyKind} reply after question card took over`,
+                  );
+                  return;
+                }
                 await strategy.deliver({
                   text: inlineReplyPayload.text,
                   mediaUrls,
                   audioAsVoice: extractSharedAudioAsVoice(payload, inlineReplyPayload),
-                  kind: (info?.kind as DeliverPayload["kind"]) || "block",
+                  kind: replyKind,
                   isReasoning: richPayload.isReasoning === true,
                 });
               } catch (err: unknown) {
@@ -2212,13 +2264,17 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
             typeof bufferedFinalPayload.text === "string" &&
             bufferedFinalPayload.text.trim().length > 0;
           if (hasBufferedText || mediaUrls.length > 0) {
-            await strategy.deliver({
-              text: inlineReplyPayload.text,
-              mediaUrls,
-              audioAsVoice: extractSharedAudioAsVoice(bufferedFinalPayload, inlineReplyPayload),
-              kind: "final",
-              isReasoning: bufferedFinalPayload.isReasoning === true,
-            });
+            if (questionCardTookOver) {
+              log?.info?.("[DingTalk][AskUser] Suppressed buffered final after question card took over");
+            } else {
+              await strategy.deliver({
+                text: inlineReplyPayload.text,
+                mediaUrls,
+                audioAsVoice: extractSharedAudioAsVoice(bufferedFinalPayload, inlineReplyPayload),
+                kind: "final",
+                isReasoning: bufferedFinalPayload.isReasoning === true,
+              });
+            }
           }
         }
       } catch (dispatchErr: unknown) {
@@ -2228,6 +2284,10 @@ export async function handleDingTalkMessage(params: HandleDingTalkMessageParams)
         throw dispatchErr;
       }
 
+      if (questionCardTookOver) {
+        log?.info?.("[DingTalk][AskUser] Skipping normal AI card finalize after question card took over");
+        return;
+      }
       await strategy.finalize();
     } finally {
       // Only remove the registry entry if no stop was requested. When a stop is

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -34,10 +34,14 @@ describe("AskUserQuestionSchema", () => {
     const schema = getAskUserQuestionSchemaForTest();
     const questionSchema = schema.properties.questions.items.properties;
 
-    expect(schema.properties.questions.description).toContain("Blocking question");
+    expect(schema.properties.questions.description).toContain("Lightweight blocking question DSL");
+    expect(schema.properties.questions.description).toContain(
+      "Do not use questions for complex forms",
+    );
     expect(schema.properties.questions.description).toContain("Do not use for explanations");
     expect(schema.properties.fields.description).toContain("Advanced DingTalk form fields");
     expect(schema.properties.fields.description).toContain("top-level fields");
+    expect(schema.properties.fields.description).toContain("Use one fields card");
     expect(schema.properties.fields.description).toContain("shaped as { fields }");
     expect(schema.properties.fields.description).toContain("Do not wrap fields inside form");
     expect(schema.properties.fields.description).toContain("{ value, text }");
@@ -292,6 +296,264 @@ describe("parseAskUserCardCallback", () => {
 });
 
 describe("handleDingTalkAskUserCardCallback", () => {
+  it("supersedes all earlier pending questions in the same user scope", async () => {
+    const baseData = {
+      msgId: "msg_multi",
+      msgtype: "text",
+      createAt: Date.now(),
+      text: { content: "ask" },
+      conversationType: "1",
+      conversationId: "conv_1",
+      senderId: "sender_1",
+      senderStaffId: "staff_1",
+      chatbotUserId: "bot_1",
+      sessionWebhook: "https://example.com/webhook",
+    };
+    const questionScopeKey = "default:session_1:staff_1";
+    const otherUserQuestionScopeKey = "default:session_1:staff_2";
+
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: baseData,
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionScopeKey,
+      questionId: "q_old_1",
+      outTrackId: "ask_old_1",
+      title: "旧问题 1",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [{ value: "ok", text: "确定" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: {
+        ...baseData,
+        msgId: "msg_other_user",
+        senderId: "sender_2",
+        senderStaffId: "staff_2",
+      },
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionScopeKey: otherUserQuestionScopeKey,
+      questionId: "q_other_user",
+      outTrackId: "ask_other_user",
+      title: "其他用户的问题",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [{ value: "ok", text: "确定" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: baseData,
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionScopeKey,
+      questionId: "q_old_2",
+      outTrackId: "ask_old_2",
+      title: "旧问题 2",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [{ value: "ok", text: "确定" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: baseData,
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionScopeKey,
+      questionId: "q_new",
+      outTrackId: "ask_new",
+      title: "新问题",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [{ value: "ok", text: "确定" }],
+          multiSelect: false,
+        },
+      ],
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(updateCardVariables).toHaveBeenCalledWith(
+      "ask_old_1",
+      expect.objectContaining({
+        card_status: "expired",
+        question_desc: "已有新的问题卡片，请回答最新卡片。",
+        form_btn_text: "已失效",
+      }),
+      "access-token",
+      {},
+    );
+    expect(updateCardVariables).toHaveBeenCalledWith(
+      "ask_old_2",
+      expect.objectContaining({
+        card_status: "expired",
+        question_desc: "已有新的问题卡片，请回答最新卡片。",
+        form_btn_text: "已失效",
+      }),
+      "access-token",
+      {},
+    );
+    expect(updateCardVariables).not.toHaveBeenCalledWith(
+      "ask_other_user",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+    vi.clearAllMocks();
+
+    await expect(
+      handleDingTalkAskUserCardCallback({
+        payload: {
+          outTrackId: "ask_old_1",
+          content: JSON.stringify({
+            cardPrivateData: {
+              actionIds: ["q_old_1"],
+              params: { form: { answer_0: "ok" } },
+            },
+          }),
+        },
+        cfg: {} as any,
+        accountId: "default",
+        config: {} as any,
+        clickerUserId: "staff_1",
+      }),
+    ).resolves.toEqual({ handled: true });
+    await expect(
+      handleDingTalkAskUserCardCallback({
+        payload: {
+          outTrackId: "ask_old_2",
+          content: JSON.stringify({
+            cardPrivateData: {
+              actionIds: ["q_old_2"],
+              params: { form: { answer_0: "ok" } },
+            },
+          }),
+        },
+        cfg: {} as any,
+        accountId: "default",
+        config: {} as any,
+        clickerUserId: "staff_1",
+      }),
+    ).resolves.toEqual({ handled: true });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDingTalkMessage).not.toHaveBeenCalled();
+
+    await expect(
+      handleDingTalkAskUserCardCallback({
+        payload: {
+          outTrackId: "ask_new",
+          content: JSON.stringify({
+            cardPrivateData: {
+              actionIds: ["q_new"],
+              params: { form: { answer_0: "ok" } },
+            },
+          }),
+        },
+        cfg: {} as any,
+        accountId: "default",
+        config: {} as any,
+        clickerUserId: "staff_1",
+      }),
+    ).resolves.toEqual({ handled: true });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(handleDingTalkMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          msgId: "msg_multi:ask-user-submitted:q_new",
+          text: {
+            content: [
+              "用户回答了交互卡片:",
+              "- question_id: q_new",
+              "- question_title: 新问题",
+              "- status: submitted",
+              "- answers:",
+              "  - 确认: 确定",
+            ].join("\n"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("rejects submissions from users other than the card owner", async () => {
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: {
+        msgId: "msg_owner",
+        msgtype: "text",
+        createAt: Date.now(),
+        text: { content: "ask" },
+        conversationType: "2",
+        conversationId: "group_1",
+        senderId: "sender_1",
+        senderStaffId: "staff_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://example.com/webhook",
+      },
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionId: "q_owner",
+      outTrackId: "ask_owner",
+      title: "补充执行参数",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [{ value: "ok", text: "确定" }],
+          multiSelect: false,
+        },
+      ],
+    });
+
+    const result = await handleDingTalkAskUserCardCallback({
+      payload: {
+        outTrackId: "ask_owner",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["q_owner"],
+            params: {
+              form: {
+                answer_0: "ok",
+              },
+            },
+          },
+        }),
+      },
+      cfg: {} as any,
+      accountId: "default",
+      config: {} as any,
+      clickerUserId: "staff_2",
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(result).toEqual({ handled: true });
+    expect(updateCardVariables).not.toHaveBeenCalled();
+    expect(handleDingTalkMessage).not.toHaveBeenCalled();
+  });
+
   it("updates cancelled cards and injects a cancellation message", async () => {
     registerPendingQuestionForTest({
       cfg: {} as any,
@@ -338,6 +600,7 @@ describe("handleDingTalkAskUserCardCallback", () => {
       cfg: {} as any,
       accountId: "default",
       config: {} as any,
+      clickerUserId: "staff_1",
     });
     await new Promise((resolve) => setImmediate(resolve));
 
@@ -356,7 +619,14 @@ describe("handleDingTalkAskUserCardCallback", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           msgId: "msg_cancel:ask-user-cancelled:q_cancel",
-          text: { content: "用户取消了问题: 补充执行参数" },
+          text: {
+            content: [
+              "用户取消了交互卡片:",
+              "- question_id: q_cancel",
+              "- question_title: 补充执行参数",
+              "- status: cancelled",
+            ].join("\n"),
+          },
         }),
       }),
     );
@@ -411,7 +681,14 @@ describe("handleDingTalkAskUserCardCallback", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           msgId: "msg_expire:ask-user-expired:q_expire",
-          text: { content: "问题已超时: 补充执行参数" },
+          text: {
+            content: [
+              "交互卡片已超时:",
+              "- question_id: q_expire",
+              "- question_title: 补充执行参数",
+              "- status: expired",
+            ].join("\n"),
+          },
         }),
       }),
     );
@@ -431,7 +708,7 @@ describe("handleDingTalkAskUserCardCallback", () => {
         accountId: "default",
         config: {} as any,
       }),
-    ).resolves.toEqual({ handled: false });
+    ).resolves.toEqual({ handled: true });
   });
 
   it("consumes optional fields submissions even when every answer is empty", async () => {
@@ -482,6 +759,7 @@ describe("handleDingTalkAskUserCardCallback", () => {
       cfg: {} as any,
       accountId: "default",
       config: {} as any,
+      clickerUserId: "staff_1",
     });
     await new Promise((resolve) => setImmediate(resolve));
 
@@ -501,7 +779,14 @@ describe("handleDingTalkAskUserCardCallback", () => {
     expect(handleDingTalkMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          text: { content: "用户提交了空表单: 补充执行参数" },
+          text: {
+            content: [
+              "用户提交了空交互卡片:",
+              "- question_id: q_empty",
+              "- question_title: 补充执行参数",
+              "- status: submitted",
+            ].join("\n"),
+          },
         }),
       }),
     );
@@ -521,6 +806,6 @@ describe("handleDingTalkAskUserCardCallback", () => {
         accountId: "default",
         config: {} as any,
       }),
-    ).resolves.toEqual({ handled: false });
+    ).resolves.toEqual({ handled: true });
   });
 });

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -258,7 +258,7 @@ describe("parseAskUserCardCallback", () => {
         content: JSON.stringify({
           cardPrivateData: {
             params: {
-              user_cancel: "true",
+              user_cancel: true,
             },
           },
         }),
@@ -266,7 +266,7 @@ describe("parseAskUserCardCallback", () => {
     ).toMatchObject({
       outTrackId: "ask_2",
       params: {
-        user_cancel: "true",
+        user_cancel: true,
       },
       hasBusinessPayload: true,
     });

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -13,9 +13,16 @@ describe("AskUserQuestionSchema", () => {
 
     expect(schema.properties.questions.description).toContain("Blocking question");
     expect(schema.properties.questions.description).toContain("Do not use for explanations");
-    expect(schema.properties.fields.description).toContain("Advanced DingTalk form variable protocol");
+    expect(schema.properties.fields.description).toContain("Advanced DingTalk form fields");
+    expect(schema.properties.fields.description).toContain("form.fields");
+    expect(schema.properties.fields.description).toContain("Do not wrap fields inside form");
+    expect(schema.properties.fields.description).toContain("{ value, text }");
     expect(schema.properties.fields.items.properties.type.enum).toContain("DATETIME");
     expect(schema.properties.fields.items.properties.type.enum).toContain("MULTI_CHECKBOX_GROUP");
+    expect(schema.properties.fields.items.properties).not.toHaveProperty("format");
+    expect(schema.properties.fields.items.properties.options.description).toContain(
+      "Each option must be { value, text }",
+    );
     expect(schema.properties.fields.items.properties.defautValue.description).toContain(
       "Compatibility alias",
     );
@@ -100,6 +107,41 @@ describe("buildQuestionFormFromFields", () => {
         multiSelect: false,
       },
       { fieldName: "notify", title: "完成后通知", options: [], multiSelect: false },
+    ]);
+  });
+
+  it("preserves native date and time fields without requiring format", () => {
+    const form = buildQuestionFormFromFields({
+      title: "高级表单",
+      fields: [
+        {
+          name: "exec_time",
+          label: "执行时间",
+          type: "TIME",
+          required: true,
+        },
+        {
+          name: "run_date",
+          label: "执行日期",
+          type: "DATE",
+          required: true,
+        },
+      ],
+    });
+
+    expect(form.fields).toEqual([
+      {
+        name: "exec_time",
+        label: "执行时间",
+        type: "TIME",
+        required: true,
+      },
+      {
+        name: "run_date",
+        label: "执行日期",
+        type: "DATE",
+        required: true,
+      },
     ]);
   });
 });

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -665,7 +665,6 @@ describe("handleDingTalkAskUserCardCallback", () => {
     });
 
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
-    await vi.runOnlyPendingTimersAsync();
 
     expect(updateCardVariables).toHaveBeenCalledWith(
       "ask_expire",
@@ -676,21 +675,6 @@ describe("handleDingTalkAskUserCardCallback", () => {
       }),
       "access-token",
       {},
-    );
-    expect(handleDingTalkMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          msgId: "msg_expire:ask-user-expired:q_expire",
-          text: {
-            content: [
-              "交互卡片已超时:",
-              "- question_id: q_expire",
-              "- question_title: 补充执行参数",
-              "- status: expired",
-            ].join("\n"),
-          },
-        }),
-      }),
     );
 
     await expect(
@@ -709,6 +693,23 @@ describe("handleDingTalkAskUserCardCallback", () => {
         config: {} as any,
       }),
     ).resolves.toEqual({ handled: true });
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(handleDingTalkMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          msgId: "msg_expire:ask-user-expired:q_expire",
+          text: {
+            content: [
+              "交互卡片已超时:",
+              "- question_id: q_expire",
+              "- question_title: 补充执行参数",
+              "- status: expired",
+            ].join("\n"),
+          },
+        }),
+      }),
+    );
   });
 
   it("consumes optional fields submissions even when every answer is empty", async () => {

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { updateCardVariables } from "../../src/card-callback-service";
 import {
   clearPendingQuestionsForTest,
   buildQuestionFormFromFields,
@@ -7,8 +8,7 @@ import {
   handleDingTalkAskUserCardCallback,
   parseAskUserCardCallback,
   registerPendingQuestionForTest,
-} from "../../src/ask-user-question";
-import { updateCardVariables } from "../../src/card-callback-service";
+} from "../../src/card/ask-user-question";
 import { handleDingTalkMessage } from "../../src/inbound-handler";
 
 vi.mock("../../src/auth", () => ({
@@ -24,6 +24,7 @@ vi.mock("../../src/inbound-handler", () => ({
 }));
 
 afterEach(() => {
+  vi.useRealTimers();
   clearPendingQuestionsForTest();
   vi.clearAllMocks();
 });
@@ -36,7 +37,8 @@ describe("AskUserQuestionSchema", () => {
     expect(schema.properties.questions.description).toContain("Blocking question");
     expect(schema.properties.questions.description).toContain("Do not use for explanations");
     expect(schema.properties.fields.description).toContain("Advanced DingTalk form fields");
-    expect(schema.properties.fields.description).toContain("form.fields");
+    expect(schema.properties.fields.description).toContain("top-level fields");
+    expect(schema.properties.fields.description).toContain("shaped as { fields }");
     expect(schema.properties.fields.description).toContain("Do not wrap fields inside form");
     expect(schema.properties.fields.description).toContain("{ value, text }");
     expect(schema.properties.fields.items.properties.type.enum).toContain("DATETIME");
@@ -290,6 +292,148 @@ describe("parseAskUserCardCallback", () => {
 });
 
 describe("handleDingTalkAskUserCardCallback", () => {
+  it("updates cancelled cards and injects a cancellation message", async () => {
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: {
+        msgId: "msg_cancel",
+        msgtype: "text",
+        createAt: Date.now(),
+        text: { content: "ask" },
+        conversationType: "1",
+        conversationId: "conv_1",
+        senderId: "sender_1",
+        senderStaffId: "staff_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://example.com/webhook",
+      },
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionId: "q_cancel",
+      outTrackId: "ask_cancel",
+      title: "补充执行参数",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [],
+          multiSelect: false,
+        },
+      ],
+    });
+
+    const result = await handleDingTalkAskUserCardCallback({
+      payload: {
+        outTrackId: "ask_cancel",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["q_cancel"],
+            params: {
+              user_cancel: "true",
+            },
+          },
+        }),
+      },
+      cfg: {} as any,
+      accountId: "default",
+      config: {} as any,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(result).toEqual({ handled: true });
+    expect(updateCardVariables).toHaveBeenCalledWith(
+      "ask_cancel",
+      expect.objectContaining({
+        card_status: "cancelled",
+        question_desc: "已取消。",
+        form_btn_text: "已取消",
+      }),
+      "access-token",
+      {},
+    );
+    expect(handleDingTalkMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          msgId: "msg_cancel:ask-user-cancelled:q_cancel",
+          text: { content: "用户取消了问题: 补充执行参数" },
+        }),
+      }),
+    );
+  });
+
+  it("expires pending questions and injects a timeout message", async () => {
+    vi.useFakeTimers();
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: {
+        msgId: "msg_expire",
+        msgtype: "text",
+        createAt: Date.now(),
+        text: { content: "ask" },
+        conversationType: "1",
+        conversationId: "conv_1",
+        senderId: "sender_1",
+        senderStaffId: "staff_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://example.com/webhook",
+      },
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionId: "q_expire",
+      outTrackId: "ask_expire",
+      title: "补充执行参数",
+      questions: [
+        {
+          fieldName: "answer_0",
+          title: "确认",
+          options: [],
+          multiSelect: false,
+        },
+      ],
+    });
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(updateCardVariables).toHaveBeenCalledWith(
+      "ask_expire",
+      expect.objectContaining({
+        card_status: "expired",
+        question_desc: "问题已失效，请重新发起。",
+        form_btn_text: "已失效",
+      }),
+      "access-token",
+      {},
+    );
+    expect(handleDingTalkMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          msgId: "msg_expire:ask-user-expired:q_expire",
+          text: { content: "问题已超时: 补充执行参数" },
+        }),
+      }),
+    );
+
+    await expect(
+      handleDingTalkAskUserCardCallback({
+        payload: {
+          outTrackId: "ask_expire",
+          content: JSON.stringify({
+            cardPrivateData: {
+              actionIds: ["q_expire"],
+              params: { form: { answer_0: "late" } },
+            },
+          }),
+        },
+        cfg: {} as any,
+        accountId: "default",
+        config: {} as any,
+      }),
+    ).resolves.toEqual({ handled: false });
+  });
+
   it("consumes optional fields submissions even when every answer is empty", async () => {
     registerPendingQuestionForTest({
       cfg: {} as any,

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -16,6 +16,9 @@ describe("AskUserQuestionSchema", () => {
     expect(schema.properties.fields.description).toContain("Advanced DingTalk form variable protocol");
     expect(schema.properties.fields.items.properties.type.enum).toContain("DATETIME");
     expect(schema.properties.fields.items.properties.type.enum).toContain("MULTI_CHECKBOX_GROUP");
+    expect(schema.properties.fields.items.properties.defautValue.description).toContain(
+      "Compatibility alias",
+    );
     expect(questionSchema.question.description).toBe("The question to ask the user");
     expect(questionSchema.header.description).toContain("Short label");
     expect(questionSchema.options.description).toContain("Leave empty ([]) for free-text input");

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildQuestionFormFromFields,
+  buildQuestionForm,
+  getAskUserQuestionSchemaForTest,
+  parseAskUserCardCallback,
+} from "../../src/ask-user-question";
+
+describe("AskUserQuestionSchema", () => {
+  it("guides the assistant to provide a small question DSL instead of DingTalk form fields", () => {
+    const schema = getAskUserQuestionSchemaForTest();
+    const questionSchema = schema.properties.questions.items.properties;
+
+    expect(schema.properties.questions.description).toContain("Blocking question");
+    expect(schema.properties.questions.description).toContain("Do not use for explanations");
+    expect(schema.properties.fields.description).toContain("Advanced DingTalk form variable protocol");
+    expect(schema.properties.fields.items.properties.type.enum).toContain("DATETIME");
+    expect(schema.properties.fields.items.properties.type.enum).toContain("MULTI_CHECKBOX_GROUP");
+    expect(questionSchema.question.description).toBe("The question to ask the user");
+    expect(questionSchema.header.description).toContain("Short label");
+    expect(questionSchema.options.description).toContain("Leave empty ([]) for free-text input");
+    expect(questionSchema.options.description).toContain("Use two options for confirmation");
+    expect(questionSchema.multiSelect.description).toContain("ignored when options is empty");
+  });
+});
+
+describe("buildQuestionFormFromFields", () => {
+  it("accepts DingTalk form variable protocol fields", () => {
+    const form = buildQuestionFormFromFields({
+      title: "高级表单",
+      description: "请补充执行参数",
+      fields: [
+        {
+          name: "reason",
+          label: "执行原因",
+          type: "TEXT_AREA",
+          required: true,
+          minRows: 2,
+          maxRows: 4,
+        },
+        {
+          name: "priority",
+          label: "优先级",
+          type: "SELECT",
+          required: true,
+          options: [
+            { value: "p0", text: "P0" },
+            { value: "p1", text: "P1" },
+          ],
+        },
+        {
+          name: "notify",
+          label: "完成后通知",
+          type: "SWITCH",
+          defaultValue: true,
+        },
+      ],
+    });
+
+    expect(form.title).toBe("高级表单");
+    expect(form.desc).toBe("请补充执行参数");
+    expect(form.fields).toEqual([
+      {
+        name: "reason",
+        label: "执行原因",
+        type: "TEXT_AREA",
+        required: true,
+        minRows: 2,
+        maxRows: 4,
+      },
+      {
+        name: "priority",
+        label: "优先级",
+        type: "SELECT",
+        required: true,
+        options: [
+          { value: "p0", text: "P0" },
+          { value: "p1", text: "P1" },
+        ],
+      },
+      {
+        name: "notify",
+        label: "完成后通知",
+        type: "SWITCH",
+        defaultValue: true,
+      },
+    ]);
+    expect(form.parsed).toEqual([
+      { fieldName: "reason", title: "执行原因", options: [], multiSelect: false },
+      {
+        fieldName: "priority",
+        title: "优先级",
+        options: [
+          { value: "p0", text: "P0" },
+          { value: "p1", text: "P1" },
+        ],
+        multiSelect: false,
+      },
+      { fieldName: "notify", title: "完成后通知", options: [], multiSelect: false },
+    ]);
+  });
+});
+
+describe("buildQuestionForm", () => {
+  it("maps the assistant question DSL to supported DingTalk form field types", () => {
+    const form = buildQuestionForm([
+      {
+        question: "填写原因",
+        header: "原因",
+        options: [],
+      },
+      {
+        question: "选择实例",
+        header: "实例",
+        options: [{ label: "mysql_odps", value: "400291853741" }],
+      },
+      {
+        question: "选择多个实例",
+        header: "多实例",
+        multiSelect: true,
+        options: [
+          { label: "mysql_a", value: "1" },
+          { label: "mysql_b", value: "2" },
+        ],
+      },
+    ]);
+
+    expect(form.fields).toEqual([
+      {
+        name: "answer_0",
+        label: "原因",
+        type: "TEXT",
+        required: true,
+        placeholder: "请输入回答",
+      },
+      {
+        name: "answer_1",
+        label: "实例",
+        type: "CHECKBOX_GROUP",
+        required: true,
+        options: [{ value: "400291853741", text: "mysql_odps" }],
+      },
+      {
+        name: "answer_2",
+        label: "多实例",
+        type: "MULTI_CHECKBOX_GROUP",
+        required: true,
+        options: [
+          { value: "1", text: "mysql_a" },
+          { value: "2", text: "mysql_b" },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("parseAskUserCardCallback", () => {
+  it("extracts form payload from DingTalk card callback content", () => {
+    const parsed = parseAskUserCardCallback({
+      outTrackId: "ask_1",
+      content: JSON.stringify({
+        cardPrivateData: {
+          actionIds: ["q_single_001"],
+          params: {
+            form: {
+              answer_0: "400291853741",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(parsed).toEqual({
+      outTrackId: "ask_1",
+      actionId: "q_single_001",
+      params: {
+        form: {
+          answer_0: "400291853741",
+        },
+      },
+      hasBusinessPayload: true,
+    });
+  });
+
+  it("recognizes cancel callbacks and ignores local form-state noise", () => {
+    expect(
+      parseAskUserCardCallback({
+        outTrackId: "ask_2",
+        content: JSON.stringify({
+          cardPrivateData: {
+            params: {
+              user_cancel: "true",
+            },
+          },
+        }),
+      }),
+    ).toMatchObject({
+      outTrackId: "ask_2",
+      params: {
+        user_cancel: "true",
+      },
+      hasBusinessPayload: true,
+    });
+
+    expect(
+      parseAskUserCardCallback({
+        outTrackId: "ask_3",
+        content: JSON.stringify({
+          cardPrivateData: {
+            params: {
+              fromConfig: {
+                fields: [],
+              },
+            },
+          },
+        }),
+      }),
+    ).toMatchObject({
+      outTrackId: "ask_3",
+      hasBusinessPayload: false,
+    });
+  });
+});

--- a/tests/unit/ask-user-question.test.ts
+++ b/tests/unit/ask-user-question.test.ts
@@ -1,10 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  clearPendingQuestionsForTest,
   buildQuestionFormFromFields,
   buildQuestionForm,
   getAskUserQuestionSchemaForTest,
+  handleDingTalkAskUserCardCallback,
   parseAskUserCardCallback,
+  registerPendingQuestionForTest,
 } from "../../src/ask-user-question";
+import { updateCardVariables } from "../../src/card-callback-service";
+import { handleDingTalkMessage } from "../../src/inbound-handler";
+
+vi.mock("../../src/auth", () => ({
+  getAccessToken: vi.fn(async () => "access-token"),
+}));
+
+vi.mock("../../src/card-callback-service", () => ({
+  updateCardVariables: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/inbound-handler", () => ({
+  handleDingTalkMessage: vi.fn(async () => undefined),
+}));
+
+afterEach(() => {
+  clearPendingQuestionsForTest();
+  vi.clearAllMocks();
+});
 
 describe("AskUserQuestionSchema", () => {
   it("guides the assistant to provide a small question DSL instead of DingTalk form fields", () => {
@@ -264,5 +286,97 @@ describe("parseAskUserCardCallback", () => {
       outTrackId: "ask_3",
       hasBusinessPayload: false,
     });
+  });
+});
+
+describe("handleDingTalkAskUserCardCallback", () => {
+  it("consumes optional fields submissions even when every answer is empty", async () => {
+    registerPendingQuestionForTest({
+      cfg: {} as any,
+      accountId: "default",
+      data: {
+        msgId: "msg_1",
+        msgtype: "text",
+        createAt: Date.now(),
+        text: { content: "ask" },
+        conversationType: "1",
+        conversationId: "conv_1",
+        senderId: "sender_1",
+        senderStaffId: "staff_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://example.com/webhook",
+      },
+      sessionWebhook: "https://example.com/webhook",
+      dingtalkConfig: {} as any,
+      questionId: "q_empty",
+      outTrackId: "ask_empty",
+      title: "补充执行参数",
+      questions: [
+        {
+          fieldName: "optional_reason",
+          title: "执行原因",
+          options: [],
+          multiSelect: false,
+        },
+      ],
+    });
+
+    const result = await handleDingTalkAskUserCardCallback({
+      payload: {
+        outTrackId: "ask_empty",
+        content: JSON.stringify({
+          cardPrivateData: {
+            actionIds: ["q_empty"],
+            params: {
+              form: {
+                optional_reason: "",
+              },
+            },
+          },
+        }),
+      },
+      cfg: {} as any,
+      accountId: "default",
+      config: {} as any,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(result).toEqual({ handled: true });
+    expect(updateCardVariables).toHaveBeenCalledWith(
+      "ask_empty",
+      expect.objectContaining({
+        card_status: "submitted",
+        question_desc: "已提交，未填写任何内容。",
+        selected_text: "",
+        selected_values: "[]",
+        form_btn_text: "已提交",
+      }),
+      "access-token",
+      {},
+    );
+    expect(handleDingTalkMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          text: { content: "用户提交了空表单: 补充执行参数" },
+        }),
+      }),
+    );
+
+    await expect(
+      handleDingTalkAskUserCardCallback({
+        payload: {
+          outTrackId: "ask_empty",
+          content: JSON.stringify({
+            cardPrivateData: {
+              actionIds: ["q_empty"],
+              params: { form: { optional_reason: "" } },
+            },
+          }),
+        },
+        cfg: {} as any,
+        accountId: "default",
+        config: {} as any,
+      }),
+    ).resolves.toEqual({ handled: false });
   });
 });

--- a/tests/unit/card-action-handler.test.ts
+++ b/tests/unit/card-action-handler.test.ts
@@ -64,6 +64,7 @@ describe('card-action-handler', () => {
         attachCardRunController('track_1', controller);
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',
@@ -114,6 +115,7 @@ describe('card-action-handler', () => {
         });
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',
@@ -150,6 +152,7 @@ describe('card-action-handler', () => {
         });
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',
@@ -171,6 +174,7 @@ describe('card-action-handler', () => {
 
     it('returns handled=false for non-stop action ids', async () => {
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'feedback_up',
                 actionId: 'feedback_up',
@@ -201,6 +205,7 @@ describe('card-action-handler', () => {
         });
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',
@@ -236,6 +241,7 @@ describe('card-action-handler', () => {
         });
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',
@@ -277,6 +283,7 @@ describe('card-action-handler', () => {
         attachCardRunController('track_err', controller);
 
         const result = await handleCardAction({
+            payload: {},
             analysis: {
                 summary: 'btn_stop',
                 actionId: 'btn_stop',

--- a/tests/unit/inbound-handler-card.test.ts
+++ b/tests/unit/inbound-handler-card.test.ts
@@ -10,6 +10,7 @@ const shared = vi.hoisted(() => ({
   createAICardMock: vi.fn(),
   finishAICardMock: vi.fn(),
   commitAICardBlocksMock: vi.fn(),
+  recallAICardMessageMock: vi.fn(),
   isCardInTerminalStateMock: vi.fn(),
   updateAICardBlockListMock: vi.fn(),
   streamAICardMock: vi.fn(),
@@ -39,6 +40,7 @@ vi.mock("../../src/card-service", () => ({
   createAICard: shared.createAICardMock,
   finishAICard: shared.finishAICardMock,
   commitAICardBlocks: shared.commitAICardBlocksMock,
+  recallAICardMessage: shared.recallAICardMessageMock,
   formatContentForCard: shared.formatContentForCardMock,
   isCardInTerminalState: shared.isCardInTerminalStateMock,
   streamAICard: shared.streamAICardMock,
@@ -94,6 +96,7 @@ import * as messageContextStore from "../../src/message-context-store";
 import * as sendService from "../../src/send-service";
 import * as mediaUtils from "../../src/media-utils";
 import { clearCardRunRegistryForTest } from "../../src/card/card-run-registry";
+import { getDingTalkQuestionContext } from "../../src/card/ask-user-question-context";
 import {
   clearTargetDirectoryStateCache,
 } from "../../src/targeting/target-directory-store";
@@ -163,6 +166,10 @@ describe("inbound-handler card lifecycle", () => {
     shared.createAICardMock.mockReset();
     shared.finishAICardMock.mockReset();
     shared.commitAICardBlocksMock.mockReset();
+    shared.recallAICardMessageMock.mockReset().mockImplementation(async (card: { state?: string }) => {
+      card.state = "3";
+      return true;
+    });
     shared.isCardInTerminalStateMock.mockReset();
     shared.updateAICardBlockListMock.mockReset().mockResolvedValue(undefined);
     shared.streamAICardMock.mockReset();
@@ -402,6 +409,150 @@ describe("inbound-handler card lifecycle", () => {
     } as unknown as { data: unknown; dingtalkConfig: unknown });
 
     expect(shared.commitAICardBlocksMock).not.toHaveBeenCalled();
+  });
+
+  it("suppresses normal AI replies after a DingTalk question card successfully takes over the turn", async () => {
+    const card = {
+      cardInstanceId: "card_question_takeover",
+      state: "1",
+      lastUpdated: Date.now(),
+    } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
+    shared.createAICardMock.mockResolvedValueOnce(card);
+    shared.isCardInTerminalStateMock.mockImplementation((state: string) => state === "3" || state === "5");
+
+    const runtime = buildRuntime();
+    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "intro before question" }, { kind: "tool" });
+        await getDingTalkQuestionContext()?.onQuestionCardSent?.({
+          questionId: "q_takeover",
+          outTrackId: "ask_takeover",
+        });
+        await dispatcherOptions.deliver({ text: "do not send this final" }, { kind: "final" });
+        return { queuedFinal: "do not send queued final" };
+      },
+    );
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: { dmPolicy: "open", messageType: "card", ackReaction: "" } as unknown as DingTalkConfig,
+      data: {
+        msgId: "question_takeover",
+        msgtype: "text",
+        text: { content: "ask me" },
+        conversationType: "1",
+        conversationId: "cid_ok",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as unknown as { data: unknown; dingtalkConfig: unknown });
+
+    expect(shared.recallAICardMessageMock).toHaveBeenCalledTimes(1);
+    expect(shared.commitAICardBlocksMock).not.toHaveBeenCalled();
+    const markdownFallbackCalls = shared.sendMessageMock.mock.calls.filter(
+      (call: unknown[]) => (call as unknown[])?.[3]?.forceMarkdown === true,
+    );
+    expect(markdownFallbackCalls).toHaveLength(0);
+  });
+
+  it("keeps the normal AI reply path when question card takeover cannot recall the existing AI card", async () => {
+    const card = {
+      cardInstanceId: "card_question_recall_failed",
+      state: "1",
+      lastUpdated: Date.now(),
+    } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
+    shared.createAICardMock.mockResolvedValueOnce(card);
+    shared.recallAICardMessageMock.mockResolvedValueOnce(false);
+    shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+    const runtime = buildRuntime();
+    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await getDingTalkQuestionContext()?.onQuestionCardSent?.({
+          questionId: "q_recall_failed",
+          outTrackId: "ask_recall_failed",
+        });
+        await dispatcherOptions.deliver({ text: "normal final after recall failed" }, { kind: "final" });
+        return { queuedFinal: "normal queued final after recall failed" };
+      },
+    );
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: { dmPolicy: "open", messageType: "card", ackReaction: "" } as unknown as DingTalkConfig,
+      data: {
+        msgId: "question_recall_failed",
+        msgtype: "text",
+        text: { content: "ask me" },
+        conversationType: "1",
+        conversationId: "cid_ok",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as unknown as { data: unknown; dingtalkConfig: unknown });
+
+    expect(shared.recallAICardMessageMock).toHaveBeenCalledTimes(1);
+    expect(shared.commitAICardBlocksMock).toHaveBeenCalledTimes(1);
+    expect(shared.commitAICardBlocksMock.mock.calls[0][1]?.content).toContain(
+      "normal final after recall failed",
+    );
+  });
+
+  it("keeps the normal AI reply path when a DingTalk question card is not sent successfully", async () => {
+    const card = {
+      cardInstanceId: "card_question_failed",
+      state: "1",
+      lastUpdated: Date.now(),
+    } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
+    shared.createAICardMock.mockResolvedValueOnce(card);
+    shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+    const runtime = buildRuntime();
+    runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "question card send failed, continue normally" }, { kind: "tool" });
+        await dispatcherOptions.deliver({ text: "normal fallback after failed question card" }, { kind: "final" });
+        return { queuedFinal: "normal fallback after failed question card" };
+      },
+    );
+    shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+    await handleDingTalkMessage({
+      cfg: {},
+      accountId: "main",
+      sessionWebhook: "https://session.webhook",
+      log: undefined,
+      dingtalkConfig: { dmPolicy: "open", messageType: "card", ackReaction: "" } as unknown as DingTalkConfig,
+      data: {
+        msgId: "question_failed",
+        msgtype: "text",
+        text: { content: "ask me" },
+        conversationType: "1",
+        conversationId: "cid_ok",
+        senderId: "user_1",
+        chatbotUserId: "bot_1",
+        sessionWebhook: "https://session.webhook",
+        createAt: Date.now(),
+      },
+    } as unknown as { data: unknown; dingtalkConfig: unknown });
+
+    expect(shared.recallAICardMessageMock).not.toHaveBeenCalled();
+    expect(shared.commitAICardBlocksMock).toHaveBeenCalledTimes(1);
+    expect(shared.commitAICardBlocksMock.mock.calls[0][1]?.content).toContain(
+      "normal fallback after failed question card",
+    );
   });
 
   it("concurrent messages: second message skips card creation when first card is still active", async () => {

--- a/tests/unit/inbound-handler-card.test.ts
+++ b/tests/unit/inbound-handler-card.test.ts
@@ -11,6 +11,7 @@ const shared = vi.hoisted(() => ({
   finishAICardMock: vi.fn(),
   commitAICardBlocksMock: vi.fn(),
   recallAICardMessageMock: vi.fn(),
+  dispatchDingTalkCardStopCommandMock: vi.fn(),
   isCardInTerminalStateMock: vi.fn(),
   updateAICardBlockListMock: vi.fn(),
   streamAICardMock: vi.fn(),
@@ -47,6 +48,10 @@ vi.mock("../../src/card-service", () => ({
   updateAICardBlockList: shared.updateAICardBlockListMock,
   streamAICardContent: vi.fn(),
   clearAICardStreamingContent: vi.fn(),
+}));
+
+vi.mock("../../src/command/card-stop-command", () => ({
+  dispatchDingTalkCardStopCommand: shared.dispatchDingTalkCardStopCommandMock,
 }));
 
 vi.mock("../../src/session-lock", () => ({
@@ -166,6 +171,8 @@ describe("inbound-handler card lifecycle", () => {
     shared.createAICardMock.mockReset();
     shared.finishAICardMock.mockReset();
     shared.commitAICardBlocksMock.mockReset();
+    shared.dispatchDingTalkCardStopCommandMock.mockReset();
+    shared.dispatchDingTalkCardStopCommandMock.mockResolvedValue({ ok: true });
     shared.recallAICardMessageMock.mockReset().mockImplementation(async (card: { state?: string }) => {
       card.state = "3";
       return true;
@@ -454,6 +461,14 @@ describe("inbound-handler card lifecycle", () => {
     } as unknown as { data: unknown; dingtalkConfig: unknown });
 
     expect(shared.recallAICardMessageMock).toHaveBeenCalledTimes(1);
+    expect(shared.dispatchDingTalkCardStopCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        agentId: "main",
+        targetSessionKey: "s1",
+        clickerUserId: "user_1",
+      }),
+    );
     expect(shared.commitAICardBlocksMock).not.toHaveBeenCalled();
     const markdownFallbackCalls = shared.sendMessageMock.mock.calls.filter(
       (call: unknown[]) => (call as unknown[])?.[3]?.forceMarkdown === true,
@@ -461,7 +476,7 @@ describe("inbound-handler card lifecycle", () => {
     expect(markdownFallbackCalls).toHaveLength(0);
   });
 
-  it("keeps the normal AI reply path when question card takeover cannot recall the existing AI card", async () => {
+  it("still suppresses normal AI replies when question card takeover cannot recall the existing AI card", async () => {
     const card = {
       cardInstanceId: "card_question_recall_failed",
       state: "1",
@@ -504,10 +519,15 @@ describe("inbound-handler card lifecycle", () => {
     } as unknown as { data: unknown; dingtalkConfig: unknown });
 
     expect(shared.recallAICardMessageMock).toHaveBeenCalledTimes(1);
-    expect(shared.commitAICardBlocksMock).toHaveBeenCalledTimes(1);
-    expect(shared.commitAICardBlocksMock.mock.calls[0][1]?.content).toContain(
-      "normal final after recall failed",
+    expect(shared.dispatchDingTalkCardStopCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        agentId: "main",
+        targetSessionKey: "s1",
+        clickerUserId: "user_1",
+      }),
     );
+    expect(shared.commitAICardBlocksMock).not.toHaveBeenCalled();
   });
 
   it("keeps the normal AI reply path when a DingTalk question card is not sent successfully", async () => {

--- a/tests/unit/runtime-peer-index.test.ts
+++ b/tests/unit/runtime-peer-index.test.ts
@@ -220,7 +220,7 @@ describe("runtime + peer registry + index plugin", () => {
       "dingtalk-connector.probe",
       expect.any(Function),
     );
-  });
+  }, 10_000);
 
   it("skips docs gateway registration outside full registration mode", async () => {
     const plugin = (await import("../../index")).default;


### PR DESCRIPTION
## 概要

- 新增 `dingtalk_ask_user_question` 工具，支持在钉钉会话中发送原生交互表单卡片。
- 支持两种提问方式：轻量 `questions` DSL，以及钉钉原生 `fields` 表单变量协议。
- 支持用户提交、取消和超时失效后的卡片状态更新，并将用户答案或取消结果作为新的会话消息注入，驱动原任务继续执行。
- 兼容旧 OpenClaw 运行时：当宿主不支持 `registerTool` 时跳过工具注册，不影响既有钉钉消息、AI 卡片和反馈学习能力。
- README 已补充该能力说明、入参形态和无需额外配置模板 ID 的说明。

## 验证 TODO

- 本地验证：
  - `tsc -p tsconfig.json --noEmit`
  - `vitest run tests/unit/ask-user-question.test.ts tests/unit/llm-output-hook.test.ts tests/unit/runtime-peer-index.test.ts --pool=threads --poolOptions.threads.singleThread=true --run`
  - `ESBUILD_BINARY_PATH=node_modules/.pnpm/@esbuild+darwin-arm64@0.21.5/node_modules/@esbuild/darwin-arm64/bin/esbuild ./node_modules/.bin/vitepress build docs`
- GitHub CI Tests 已通过：
  - `pnpm run type-check`
  - `pnpm run lint`
  - `pnpm test`
  - `pnpm test:coverage`
- 真机验证：
  - 已按当前开发分支构建并在本地 沙箱中加载当前钉钉插件代码。
  - 已真机验证钉钉 Stream 交互卡片投递。
  - 已真机验证表单提交后卡片状态更新，并将用户答案作为后续会话消息注入，原任务可继续。
  - 已真机验证取消操作后卡片状态更新，并将取消结果作为后续会话消息注入。
- 结果：与本 PR 目标一致，未发现新增异常；端到端验证视频见下方。
- 收尾：本次 PR 使用内置 ask-user 卡片模板 ID，无需新增用户配置；本地 沙箱和临时调试配置不属于本 PR 提交内容。

## 验证视频

https://github.com/user-attachments/assets/54c60ee7-8465-41ee-82fe-c58904414786
