### PR TITLE
fix(card): preserve final answer after non-terminal tool error

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -428,6 +428,7 @@ function buildGroupTurnContextPrompt(params: {
 
 type ReplyStreamPayload = {
   text?: string;
+  isError?: boolean;
   isReasoning?: boolean;
   mediaUrl?: string;
   mediaUrls?: string[];
@@ -2250,6 +2251,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
                   mediaUrls,
                   audioAsVoice: extractSharedAudioAsVoice(payload, inlineReplyPayload),
                   kind: replyKind,
+                  isError: payload.isError === true,
                   isReasoning: richPayload.isReasoning === true,
                 });
               } catch (err: unknown) {

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -472,7 +472,15 @@ export function createCardReplyStrategy(
       if (payload.kind === "final") {
         // OpenClaw can append a non-terminal tool warning after a valid final.
         // Do not let that plain-text warning replace the answer already captured by the card.
-        if (payload.isError === true && sawFinalDelivery && payload.mediaUrls.length === 0) {
+        const hasPreservableReply = Boolean(
+          finalTextForFallback?.trim() || controller.getFinalAnswerContent().trim(),
+        ) || processedMediaUrls.size > 0 || pendingNonImageMedia.length > 0;
+        if (
+          payload.isError === true
+          && sawFinalDelivery
+          && payload.mediaUrls.length === 0
+          && hasPreservableReply
+        ) {
           log?.debug?.("[DingTalk][Finalize] Ignoring late error final after answer delivery");
           return;
         }

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -470,6 +470,12 @@ export function createCardReplyStrategy(
 
       // ---- final: defer to finalize, just save text ----
       if (payload.kind === "final") {
+        // OpenClaw can append a non-terminal tool warning after a valid final.
+        // Do not let that plain-text warning replace the answer already captured by the card.
+        if (payload.isError === true && sawFinalDelivery && payload.mediaUrls.length === 0) {
+          log?.debug?.("[DingTalk][Finalize] Ignoring late error final after answer delivery");
+          return;
+        }
         const isFirstFinalDelivery = !sawFinalDelivery;
         lifecycleState = "final_seen";
         await flushPendingReasoning();

--- a/src/reply-strategy-types.ts
+++ b/src/reply-strategy-types.ts
@@ -30,6 +30,7 @@ export interface DeliverPayload {
    */
   audioAsVoice?: boolean;
   kind: "block" | "final" | "tool";
+  isError?: boolean;
   isReasoning?: boolean;
 }
 

--- a/tests/unit/inbound-handler-card-streaming.test.ts
+++ b/tests/unit/inbound-handler-card-streaming.test.ts
@@ -816,8 +816,60 @@ describe("inbound-handler card streaming", () => {
       const content = shared.commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
       // The last final overwrites earlier ones
       expect(content).toContain("晚到 final 覆盖答案");
+      expect(content).not.toContain("首个最终答案");
       // Tool output should be in the block list
       expect(blockListJson).toContain("late tool output");
+    });
+
+    it("card flow preserves a normal final when a later error final arrives", async () => {
+      const runtime = buildRuntime();
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+        .fn()
+        .mockImplementation(async ({ dispatcherOptions }) => {
+          await dispatcherOptions.deliver({ text: "正常最终答案" }, { kind: "final" });
+          await dispatcherOptions.deliver(
+            { text: "⚠️ 🛠️ Exec failed: ledger", isError: true },
+            { kind: "final" },
+          );
+          return { queuedFinal: false };
+        });
+      shared.getRuntimeMock.mockReturnValueOnce(runtime);
+
+      const card = {
+        cardInstanceId: "card_error_final_after_answer",
+        state: "1",
+        lastUpdated: Date.now(),
+      } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
+      shared.createAICardMock.mockResolvedValueOnce(card);
+      shared.isCardInTerminalStateMock.mockReturnValue(false);
+
+      await handleDingTalkMessage({
+        cfg: {},
+        accountId: "main",
+        sessionWebhook: "https://session.webhook",
+        log: undefined,
+        dingtalkConfig: {
+          dmPolicy: "open",
+          messageType: "card",
+          ackReaction: "",
+          cardStreamingMode: "off",
+        } as unknown as DingTalkConfig,
+        data: {
+          msgId: "m_card_error_final_after_answer",
+          msgtype: "text",
+          text: { content: "hello" },
+          conversationType: "1",
+          conversationId: "cid_ok",
+          senderId: "user_1",
+          chatbotUserId: "bot_1",
+          sessionWebhook: "https://session.webhook",
+          createAt: Date.now(),
+        },
+      } as unknown as { data: unknown });
+
+      const content = shared.commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
+      expect(content).toContain("正常最终答案");
+      expect(content).not.toContain("Exec failed");
     });
 
     it("card flow inserts late tool before frozen final answer when the answer turn was sealed before first final", async () => {

--- a/tests/unit/inbound-handler-card-streaming.test.ts
+++ b/tests/unit/inbound-handler-card-streaming.test.ts
@@ -821,56 +821,59 @@ describe("inbound-handler card streaming", () => {
       expect(blockListJson).toContain("late tool output");
     });
 
-    it("card flow preserves a normal final when a later error final arrives", async () => {
-      const runtime = buildRuntime();
-      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
-        .fn()
-        .mockImplementation(async ({ dispatcherOptions }) => {
-          await dispatcherOptions.deliver({ text: "正常最终答案" }, { kind: "final" });
-          await dispatcherOptions.deliver(
-            { text: "⚠️ 🛠️ Exec failed: ledger", isError: true },
-            { kind: "final" },
-          );
-          return { queuedFinal: false };
-        });
-      shared.getRuntimeMock.mockReturnValueOnce(runtime);
+    it.each(["off", "answer"] as const)(
+      "card flow preserves a normal final when a later error final arrives in %s mode",
+      async (cardStreamingMode) => {
+        const runtime = buildRuntime();
+        runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+          .fn()
+          .mockImplementation(async ({ dispatcherOptions }) => {
+            await dispatcherOptions.deliver({ text: "正常最终答案" }, { kind: "final" });
+            await dispatcherOptions.deliver(
+              { text: "⚠️ 🛠️ Exec failed: ledger", isError: true },
+              { kind: "final" },
+            );
+            return { queuedFinal: false };
+          });
+        shared.getRuntimeMock.mockReturnValueOnce(runtime);
 
-      const card = {
-        cardInstanceId: "card_error_final_after_answer",
-        state: "1",
-        lastUpdated: Date.now(),
-      } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
-      shared.createAICardMock.mockResolvedValueOnce(card);
-      shared.isCardInTerminalStateMock.mockReturnValue(false);
+        const card = {
+          cardInstanceId: "card_error_final_after_answer",
+          state: "1",
+          lastUpdated: Date.now(),
+        } as unknown as { cardInstanceId: string; state: string; lastUpdated: number };
+        shared.createAICardMock.mockResolvedValueOnce(card);
+        shared.isCardInTerminalStateMock.mockReturnValue(false);
 
-      await handleDingTalkMessage({
-        cfg: {},
-        accountId: "main",
-        sessionWebhook: "https://session.webhook",
-        log: undefined,
-        dingtalkConfig: {
-          dmPolicy: "open",
-          messageType: "card",
-          ackReaction: "",
-          cardStreamingMode: "off",
-        } as unknown as DingTalkConfig,
-        data: {
-          msgId: "m_card_error_final_after_answer",
-          msgtype: "text",
-          text: { content: "hello" },
-          conversationType: "1",
-          conversationId: "cid_ok",
-          senderId: "user_1",
-          chatbotUserId: "bot_1",
+        await handleDingTalkMessage({
+          cfg: {},
+          accountId: "main",
           sessionWebhook: "https://session.webhook",
-          createAt: Date.now(),
-        },
-      } as unknown as { data: unknown });
+          log: undefined,
+          dingtalkConfig: {
+            dmPolicy: "open",
+            messageType: "card",
+            ackReaction: "",
+            cardStreamingMode,
+          } as unknown as DingTalkConfig,
+          data: {
+            msgId: "m_card_error_final_after_answer",
+            msgtype: "text",
+            text: { content: "hello" },
+            conversationType: "1",
+            conversationId: "cid_ok",
+            senderId: "user_1",
+            chatbotUserId: "bot_1",
+            sessionWebhook: "https://session.webhook",
+            createAt: Date.now(),
+          },
+        } as unknown as { data: unknown });
 
-      const content = shared.commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
-      expect(content).toContain("正常最终答案");
-      expect(content).not.toContain("Exec failed");
-    });
+        const content = shared.commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
+        expect(content).toContain("正常最终答案");
+        expect(content).not.toContain("Exec failed");
+      },
+    );
 
     it("card flow inserts late tool before frozen final answer when the answer turn was sealed before first final", async () => {
       const runtime = buildRuntime();

--- a/tests/unit/reply-strategy-card.test.ts
+++ b/tests/unit/reply-strategy-card.test.ts
@@ -736,6 +736,21 @@ describe("reply-strategy-card", () => {
             expect(strategy.getFinalText()).toBe("✅ Done");
         });
 
+        it.each(["off", "answer"] as const)("shows a late error after an empty final in %s mode", async (cardStreamingMode) => {
+            const card = makeCard();
+            const strategy = createCardReplyStrategy(buildCtx(card, {
+                config: { clientId: "id", clientSecret: "s", messageType: "card", cardStreamingMode } as any,
+            }));
+
+            await strategy.deliver({ text: "", mediaUrls: [], kind: "final" });
+            await strategy.deliver({ text: "⚠️ Exec failed", mediaUrls: [], kind: "final", isError: true });
+            await strategy.finalize();
+
+            const rendered = commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
+            expect(rendered).toContain("⚠️ Exec failed");
+            expect(rendered).not.toContain("✅ Done");
+        });
+
         it("ignores all callbacks and deliveries after finalize seals the card lifecycle", async () => {
             const card = makeCard();
             const strategy = createCardReplyStrategy(buildCtx(card));
@@ -972,12 +987,15 @@ describe("reply-strategy-card", () => {
             }));
 
             await strategy.deliver({ text: "最终答案", mediaUrls: [], kind: "block" });
+            await strategy.deliver({ text: "", mediaUrls: [], kind: "final" });
+            await strategy.deliver({ text: "⚠️ Exec failed", mediaUrls: [], kind: "final", isError: true });
             await strategy.finalize();
 
             expect(commitAICardBlocksMock).toHaveBeenCalledTimes(1);
             const rendered = commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content ?? "";
             expect(rendered).toContain("最终答案");
             expect(rendered).not.toContain("✅ Done");
+            expect(rendered).not.toContain("Exec failed");
         });
 
         it("finalize prefers the final answer snapshot over an earlier partial answer", async () => {


### PR DESCRIPTION
通过钉钉 AI 卡片与 OpenClaw 对话时，OpenClaw 可能在正常最终答案之后，再发送一条带有 `isError: true` 的非终止性工具调用错误，例如：
<img width="1444" height="566" alt="image" src="https://github.com/user-attachments/assets/32612ce3-65df-4f97-8817-05cea6f2202c" />


  ```text
  ⚠️ 🛠️ Exec failed

  此前钉钉插件会将这条错误消息当作新的最终回复，覆盖已经生成的正常答案，导致用户最终只能看到工具调用错误。
```
  ## 修改内容

  - 将 OpenClaw 回复中的 isError 标记传递给卡片回复策略。
  - 已经收到正常最终答案时，忽略随后到达的纯文本错误 final。
  - 保持原有行为：
      - 普通的后续 final 仍可覆盖之前的答案。
      - 第一条回复本身是错误时，仍会正常显示。

  ## 单元测试

  已补充回归单测，覆盖以下完整消息顺序：

  1. 先收到正常最终答案。
  2. 随后收到带有 isError: true 的工具调用错误。
  3. 验证卡片仍保留正常最终答案。
  4. 验证卡片内容不会被 Exec failed 覆盖。

  测试结果：

  - 定向单测：14 个全部通过
  - 全量单测：1126 个全部通过
  - TypeScript 类型检查通过
  - Runtime 构建及 npm 包校验通过

  ## 本地部署验证

  已将修改后的插件链接部署到本地 OpenClaw 2026.7.1-beta.6 环境，并完成以下验证：

  - Gateway 重启成功，深度连通性检查正常。
  - OpenClaw 已从本地仓库的 dist/index.js 加载钉钉插件。
  - DingTalk Stream 连接成功。
  - 实际钉钉入站消息能够正常接收和处理。

## 本地钉钉验证

  修改后的插件已链接部署到本地 OpenClaw `2026.7.1-beta.6`，Gateway 连通性正常，DingTalk Stream 连接成功。

  真实钉钉会话日志中捕获到两次“正常答案后紧接工具错误”的场景：

  - `14:07:22.550` 收到正常 final（`textLen=488`）；
  - `14:07:22.551` 紧接着出现 `Exec failed`；
  - `14:07:22.588` 最终卡片仍以正常答案提交（`contentLen=488`）。

  另一组日志中：

  - `14:16:45.192–198` 收到多个正常 final，最后一个 `textLen=82`；
  - `14:16:45.199` 紧接着出现 `Exec failed`；
  - `14:16:45.220` 最终卡片仍保留最后一个正常答案（`contentLen=82`）。

  以上日志表明，真实钉钉会话中的晚到工具错误不会再覆盖已经生成的正常最终答案。

  “空 final → 错误 final”边界在部署后的真实日志中尚未再次触发，目前已通过 `off` 和 `answer` 双模式回归单测验证。


  Fixes #586 
