### PR TITLE
chore(release): prepare v3.6.7

### DIFF
--- a/docs/releases/latest.md
+++ b/docs/releases/latest.md
@@ -1,2 +1,2 @@
 <!-- Latest release alias: update this include target when a new release note is added. -->
-<!--@include: ./v3.6.6.md-->
+<!--@include: ./v3.6.7.md-->

--- a/docs/releases/v3.6.7.md
+++ b/docs/releases/v3.6.7.md
@@ -1,0 +1,32 @@
+# v3.6.7 发布说明
+
+本次 patch 版本聚焦 **DingTalk Ask User 卡片生命周期、回答路由与重启恢复的可靠性**。
+
+**最新版本入口**：[`latest.md`](./latest.md)
+
+## 🛠 修复与稳定性
+
+* **强化 Ask User 卡片生命周期**
+  * [`PR #589`](https://github.com/soimy/openclaw-channel-dingtalk/pull/589)（by @BenGuanRan）新增 account-scoped 持久化状态机，统一处理卡片预留、激活、回答派发与终态 tombstone。
+  * 用户发送新真实消息后，同 scope 的待回答卡片会立即失效；卡面更新以 best-effort 异步执行，不再阻塞普通消息回复。
+  * Gateway 重启后，未完成卡片会 fail-closed 进入明确终态，避免旧卡继续提交或伪造回答。
+
+* **绑定回答到发卡时的 Agent 与 Session**
+  * Ask User 回答会使用发卡时解析并持久化的路由快照重新入栈，避免后续路由变化把回答送入错误上下文。
+  * 回调按 `outTrackId` 优先原子 claim；重复、过期或晚到回调不会再次派发。
+
+* **修复暂停与投放竞态**
+  * 定向 `/stop` 成功后才由问题卡接管本轮回复；暂停失败时会终止卡片接管并保留当前 Agent run 的正常输出。
+  * 卡片投放成功后的激活会重新检查 reservation，避免已失效卡片被晚到的投放结果重新激活。
+
+## 🤝 鸣谢
+
+感谢本版本周期的所有贡献者：
+
+* @BenGuanRan
+
+---
+
+**发布页面**：<https://github.com/soimy/openclaw-channel-dingtalk/releases/tag/v3.6.7>
+
+**Full Changelog**: <https://github.com/soimy/openclaw-channel-dingtalk/compare/v3.6.6...v3.6.7>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@soimy/dingtalk",
-  "version": "3.6.6",
+  "version": "3.6.7",
   "description": "DingTalk (钉钉) channel plugin for OpenClaw",
   "keywords": [
     "bot",


### PR DESCRIPTION
## 背景

官方 npm `@soimy/dingtalk@3.6.6` 对应 2026-07-16 的 `v3.6.6` tag；PR #589 于 2026-07-19 合入 `main`，因此当前 `latest` 尚未包含 Ask User 生命周期修复。

## 目标

发布 `v3.6.7` patch，使官方 npm / ClawHub 包包含 PR #589。

## 实现

- 将 `package.json` 版本从 `3.6.6` 更新为 `3.6.7`。
- 新增 `docs/releases/v3.6.7.md`，记录 PR #589 的生命周期、路由和竞态修复。
- 将 `docs/releases/latest.md` 指向 `v3.6.7`。

## 实现 TODO

- [x] 基于包含 PR #589 的官方 `main`（merge commit `0b5e546`）准备版本。
- [x] 更新官方包版本号。
- [x] 补充发布说明和 latest 入口。
- [ ] 合并后由维护者创建并推送 `v3.6.7` tag，触发 npm / ClawHub 发布工作流。

## 验证 TODO

- [x] `pnpm run type-check`
- [x] `pnpm run lint`：0 errors（91 warnings 为现有告警）
- [x] `pnpm test`：117 files / 1171 tests passed
- [x] `pnpm run build`
- [x] `pnpm run pack:check`
- [x] `npm pack --dry-run --json`：确认发布内容包含 PR #589 新增的 Ask User lifecycle store 源码、类型声明及 runtime bundle
- [x] GitHub Actions：CI Tests（type-check、lint、tests、coverage）通过

本机 `pnpm docs:build` 在 Node 25 + VitePress 内置 esbuild 0.21 下触发环境性 `The service was stopped`；直接调用同版本 esbuild JS API可稳定复现。官方 `main` 对应 merge commit 的 Docs Vercel workflow 已通过；fork PR 的 Docs Vercel job 按 workflow 条件跳过。
