### PR TITLE
fix(onboarding): own DingTalk setup password type

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -20,6 +20,10 @@ import type { DingTalkConfig, DingTalkChannelConfig } from "./types.js";
 
 const channel = "dingtalk" as const;
 
+type DingTalkSetupInput = ChannelSetupInput & {
+  password?: string;
+};
+
 function isConfigured(account: DingTalkConfig): boolean {
   return Boolean(account.clientId && hasConfiguredSecretInput(account.clientSecret));
 }
@@ -349,7 +353,7 @@ function applyAccountConfig(params: {
 function applyGenericSetupInput(params: {
   cfg: OpenClawConfig;
   accountId: string;
-  input: ChannelSetupInput;
+  input: DingTalkSetupInput;
 }): OpenClawConfig {
   return applyAccountConfig({
     cfg: params.cfg,
@@ -547,7 +551,7 @@ export const dingtalkSetupAdapter: ChannelSetupAdapter = {
     applyGenericSetupInput({
       cfg,
       accountId,
-      input,
+      input: input as DingTalkSetupInput,
     }),
 };
 


### PR DESCRIPTION
## 背景

OpenClaw 将 `ChannelSetupInput.password` 标记为插件兼容字段，DingTalk onboarding 仍直接读取该字段。

## 目标

将 DingTalk setup 输入字段声明迁移到插件本地类型，保持当前 SDK 和运行时行为兼容。

## 实现

- 新增 `DingTalkSetupInput` 本地类型并声明 `password`。
- 在 onboarding adapter 边界完成类型收窄。
- 保持 `token -> clientId` 和 `password -> clientSecret` 行为不变。
- 未升级 OpenClaw 依赖。

## 实现 TODO

- [x] 完成插件本地 setup 类型迁移
- [x] 验证当前最低 SDK 兼容性

## 验证 TODO

- [x] `npm run type-check`
- [x] onboarding 单元测试（17/17）
- [x] `npm run lint`（0 errors；91 个既有 warnings）
- [x] `pnpm run build:runtime`
- [x] `pnpm test`（117/117 files，1174/1174 tests）
- [ ] DingTalk 真机联调：本次仅涉及 TypeScript 类型边界，未改变运行时消息路径，因此未执行

未来 SDK 删除共享 `password` 后的兼容性基于交叉类型结构推断；当前尚无包含该删除的已发布 SDK 版本可供实证。

Closes #591
