### PR TITLE
fix: restore compatibility with OpenClaw 2026.8 SDK

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import * as path from "node:path";
+import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
-import { parseInlineDirectives } from "openclaw/plugin-sdk/text-runtime";
+import { parseInlineDirectives } from "./inline-directives";
 import { normalizeAllowFrom, isSenderAllowed, resolveGroupAccess } from "./access-control";
 import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
@@ -1792,7 +1793,10 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
     const groupMembers = !isDirect ? formatGroupMembers(storePath, groupId) : undefined;
 
     const fromLabel = isDirect ? `${senderName} (${senderId})` : `${groupName} - ${senderName}`;
-    const body = rt.channel.reply.formatInboundEnvelope({
+    // `rt.channel.reply.formatInboundEnvelope` was removed from the runtime
+    // facade in OpenClaw 2026.8.x; the helper is still exported from the
+    // `channel-inbound` SDK subpath.
+    const body = formatInboundEnvelope({
       channel: "DingTalk",
       from: fromLabel,
       timestamp: data.createAt,

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import * as path from "node:path";
 import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
-import { parseInlineDirectives } from "./inline-directives";
+import { parseInlineDirectives } from "./messaging/inline-directives";
 import { normalizeAllowFrom, isSenderAllowed, resolveGroupAccess } from "./access-control";
 import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";

--- a/src/inline-directives.ts
+++ b/src/inline-directives.ts
@@ -1,0 +1,228 @@
+/**
+ * Inline directive parsing (local implementation).
+ *
+ * OpenClaw retired the `openclaw/plugin-sdk/text-runtime` subpath in
+ * 2026.8.x (docs/plugins/sdk-migration.md: "The August 15 compatibility
+ * subpaths ... `text-runtime` ... were retired early"). Its replacement
+ * `openclaw/plugin-sdk/text-chunking` only re-exports the directive-tag
+ * *stripping* helpers and the `InlineDirectiveParseResult` type - not
+ * `parseInlineDirectives` itself.
+ *
+ * This module reproduces the previous host behaviour inside the plugin so no
+ * removed SDK internals are imported.
+ */
+
+const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
+const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
+const BLOCK_SENTINEL_SEED = "\u0000";
+
+export type ParseInlineDirectivesOptions = {
+  currentMessageId?: string;
+  stripAudioTag?: boolean;
+  stripReplyTags?: boolean;
+};
+
+export type InlineDirectiveParseResult = {
+  text: string;
+  audioAsVoice: boolean;
+  replyToId?: string;
+  replyToExplicitId?: string;
+  replyToCurrent: boolean;
+  hasAudioTag: boolean;
+  hasReplyTag: boolean;
+};
+
+type FenceSpan = { start: number; end: number };
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Collects ``` / ~~~ fenced regions so whitespace normalization never
+ * rewrites code blocks.
+ */
+function parseFenceSpans(text: string): FenceSpan[] {
+  const spans: FenceSpan[] = [];
+  const fenceRe = /^([ \t]*)(`{3,}|~{3,})[^\n]*$/gm;
+  let match: RegExpExecArray | null;
+  let openStart: number | undefined;
+  let openMarker: string | undefined;
+
+  while ((match = fenceRe.exec(text)) !== null) {
+    const marker = match[2] ?? "";
+    if (openStart === undefined) {
+      openStart = match.index;
+      openMarker = marker;
+      continue;
+    }
+    const sameKind = openMarker?.[0] === marker[0] && marker.length >= (openMarker?.length ?? 0);
+    if (!sameKind) {
+      continue;
+    }
+    const lineEnd = match.index + match[0].length;
+    spans.push({ start: openStart, end: Math.min(lineEnd + 1, text.length) });
+    openStart = undefined;
+    openMarker = undefined;
+  }
+
+  if (openStart !== undefined) {
+    spans.push({ start: openStart, end: text.length });
+  }
+  return spans;
+}
+
+function createBlockSentinel(text: string): string {
+  let sentinel = BLOCK_SENTINEL_SEED;
+  while (text.includes(sentinel)) {
+    sentinel += BLOCK_SENTINEL_SEED;
+  }
+  return sentinel;
+}
+
+function normalizeDirectiveWhitespace(text: string): string {
+  const blockSentinel = createBlockSentinel(text);
+  const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
+  const blocks: string[] = [];
+  const fenceSpans =
+    text.includes("```") || text.includes("~~~") ? parseFenceSpans(text) : ([] as FenceSpan[]);
+
+  let masked = "";
+  let cursor = 0;
+  for (const span of fenceSpans) {
+    blocks.push(text.slice(span.start, span.end));
+    masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+    cursor = span.end;
+  }
+  masked = `${masked}${text.slice(cursor)}`.replace(/(?:(?:^|\n)(?: {4}|\t)[^\n]*)+/gm, (block) => {
+    blocks.push(block);
+    return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+  });
+
+  return masked
+    .replace(/\r\n/g, "\n")
+    .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
+    .replace(/^\n+/, "")
+    .replace(/^[ \t](?=\S)/, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd()
+    .replace(blockPlaceholderRe, (_full, index: string) => blocks[Number(index)] ?? "");
+}
+
+function replacementPreservesWordBoundary(source: string, offset: number, length: number): string {
+  const before = source[offset - 1];
+  const after = source[offset + length];
+  return before && after && !/\s/u.test(before) && !/\s/u.test(after) ? " " : "";
+}
+
+function stripUnsafeReplyDirectiveChars(value: string): string {
+  const chars: string[] = [];
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (
+      (code >= 0 && code <= 31) ||
+      code === 127 ||
+      (code >= 128 && code <= 159) ||
+      ch === "[" ||
+      ch === "]"
+    ) {
+      continue;
+    }
+    chars.push(ch);
+  }
+  return chars.join("");
+}
+
+export function sanitizeReplyDirectiveId(rawReplyToId: string | undefined): string | undefined {
+  const trimmed = rawReplyToId?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const sanitized = stripUnsafeReplyDirectiveChars(trimmed).trim();
+  if (!sanitized) {
+    return undefined;
+  }
+  const chars = Array.from(sanitized);
+  if (chars.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
+    return chars.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
+  }
+  return sanitized;
+}
+
+export function parseInlineDirectives(
+  text: string | undefined,
+  options: ParseInlineDirectivesOptions = {},
+): InlineDirectiveParseResult {
+  const { currentMessageId, stripAudioTag = true, stripReplyTags = true } = options;
+
+  if (!text) {
+    return {
+      text: "",
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
+
+  if (!text.includes("[[")) {
+    return {
+      text: normalizeDirectiveWhitespace(text),
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
+
+  let cleaned = text;
+  let audioAsVoice = false;
+  let hasAudioTag = false;
+  let hasReplyTag = false;
+  let sawCurrent = false;
+  let lastExplicitId: string | undefined;
+
+  cleaned = cleaned.replace(AUDIO_TAG_RE, (match: string, offset: number, source: string) => {
+    audioAsVoice = true;
+    hasAudioTag = true;
+    return stripAudioTag ? replacementPreservesWordBoundary(source, offset, match.length) : match;
+  });
+
+  cleaned = cleaned.replace(
+    REPLY_TAG_RE,
+    (match: string, idRaw: string | undefined, offset: number, source: string) => {
+      hasReplyTag = true;
+      if (idRaw === undefined) {
+        sawCurrent = true;
+      } else {
+        const id = sanitizeReplyDirectiveId(idRaw);
+        if (id) {
+          lastExplicitId = id;
+        }
+      }
+      return stripReplyTags
+        ? replacementPreservesWordBoundary(source, offset, match.length)
+        : match;
+    },
+  );
+
+  cleaned = normalizeDirectiveWhitespace(cleaned);
+  const replyToId =
+    lastExplicitId ?? (sawCurrent ? normalizeOptionalString(currentMessageId) : undefined);
+
+  return {
+    text: cleaned,
+    audioAsVoice,
+    replyToId,
+    replyToExplicitId: lastExplicitId,
+    replyToCurrent: sawCurrent,
+    hasAudioTag,
+    hasReplyTag,
+  };
+}

--- a/src/messaging/inline-directives.ts
+++ b/src/messaging/inline-directives.ts
@@ -1,0 +1,252 @@
+/**
+ * Inline directive parsing (local implementation).
+ *
+ * OpenClaw retired the `openclaw/plugin-sdk/text-runtime` subpath in
+ * 2026.8.x (docs/plugins/sdk-migration.md: "The August 15 compatibility
+ * subpaths ... `text-runtime` ... were retired early"). Its replacement
+ * `openclaw/plugin-sdk/text-chunking` only re-exports the directive-tag
+ * *stripping* helpers and the `InlineDirectiveParseResult` type - not
+ * `parseInlineDirectives` itself.
+ *
+ * This module reproduces the previous host behaviour inside the plugin so no
+ * removed SDK internals are imported. Code-region awareness (fenced,
+ * indented, and inline code) is sourced from the public SDK helpers
+ * `findCodeRegions` / `isInsideCode` (available since 2026.7.1-2), plus a
+ * lenient indented-block fallback matching the host whitespace normalizer so
+ * directives inside code are never treated as real voice/reply commands.
+ */
+
+import {
+  findCodeRegions,
+  isInsideCode,
+  type CodeRegion,
+} from "openclaw/plugin-sdk/text-chunking";
+
+const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
+const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
+const BLOCK_SENTINEL_SEED = "\uE000";
+/** Lenient indented-code-block lines (4 spaces or tab), same rule as the host whitespace normalizer. */
+const INDENTED_CODE_LINE_RE = /(?:^|\n)((?: {4}|\t)[^\n]*)(?:\n(?: {4}|\t)[^\n]*)*/g;
+
+export type ParseInlineDirectivesOptions = {
+  currentMessageId?: string;
+  stripAudioTag?: boolean;
+  stripReplyTags?: boolean;
+};
+
+export type InlineDirectiveParseResult = {
+  text: string;
+  audioAsVoice: boolean;
+  replyToId?: string;
+  replyToExplicitId?: string;
+  replyToCurrent: boolean;
+  hasAudioTag: boolean;
+  hasReplyTag: boolean;
+};
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * CommonMark code regions (fenced / indented / inline) from the SDK, extended
+ * with a lenient indented-block fallback for lines indented by 4 spaces or a
+ * tab that follow a paragraph without a blank separator (the host normalizer
+ * protects those too).
+ */
+function resolveCodeRegions(text: string): CodeRegion[] {
+  const regions: CodeRegion[] = [...findCodeRegions(text)];
+  const indentRe = new RegExp(INDENTED_CODE_LINE_RE.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = indentRe.exec(text)) !== null) {
+    const start = match.index + (match[0].charCodeAt(0) === 10 ? 1 : 0);
+    regions.push({ start, end: match.index + match[0].length });
+  }
+  return mergeCodeRegions(regions);
+}
+
+function mergeCodeRegions(regions: CodeRegion[]): CodeRegion[] {
+  if (regions.length <= 1) return regions;
+  const sorted = [...regions].sort((a, b) => a.start - b.start || a.end - b.end);
+  const merged: CodeRegion[] = [];
+  for (const region of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && region.start <= last.end) {
+      last.end = Math.max(last.end, region.end);
+    } else {
+      merged.push({ start: region.start, end: region.end });
+    }
+  }
+  return merged;
+}
+
+function createBlockSentinel(text: string): string {
+  let sentinel = BLOCK_SENTINEL_SEED;
+  while (text.includes(sentinel)) {
+    sentinel += BLOCK_SENTINEL_SEED;
+  }
+  return sentinel;
+}
+
+function normalizeDirectiveWhitespace(text: string, codeRegions: CodeRegion[] = []): string {
+  const blockSentinel = createBlockSentinel(text);
+  const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
+  const blocks: string[] = [];
+
+  let masked = "";
+  let cursor = 0;
+  for (const region of codeRegions) {
+    if (region.start < cursor) continue;
+    blocks.push(text.slice(region.start, region.end));
+    masked += `${text.slice(cursor, region.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
+    cursor = region.end;
+  }
+  masked += text.slice(cursor);
+
+  return masked
+    .replace(/\r\n/g, "\n")
+    .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
+    .replace(/^\n+/, "")
+    .replace(/^[ \t](?=\S)/, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd()
+    .replace(blockPlaceholderRe, (_full, index: string) => blocks[Number(index)] ?? "");
+}
+
+function replacementPreservesWordBoundary(source: string, offset: number, length: number): string {
+  const before = source[offset - 1];
+  const after = source[offset + length];
+  return before && after && !/\s/u.test(before) && !/\s/u.test(after) ? " " : "";
+}
+
+function stripUnsafeReplyDirectiveChars(value: string): string {
+  const chars: string[] = [];
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (
+      (code >= 0 && code <= 31) ||
+      code === 127 ||
+      (code >= 128 && code <= 159) ||
+      ch === "[" ||
+      ch === "]"
+    ) {
+      continue;
+    }
+    chars.push(ch);
+  }
+  return chars.join("");
+}
+
+export function sanitizeReplyDirectiveId(rawReplyToId: string | undefined): string | undefined {
+  const trimmed = rawReplyToId?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const sanitized = stripUnsafeReplyDirectiveChars(trimmed).trim();
+  if (!sanitized) {
+    return undefined;
+  }
+  const chars = Array.from(sanitized);
+  if (chars.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
+    return chars.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
+  }
+  return sanitized;
+}
+
+export function parseInlineDirectives(
+  text: string | undefined,
+  options: ParseInlineDirectivesOptions = {},
+): InlineDirectiveParseResult {
+  const { currentMessageId, stripAudioTag = true, stripReplyTags = true } = options;
+
+  if (!text) {
+    return {
+      text: "",
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
+
+  if (!text.includes("[[")) {
+    return {
+      text: normalizeDirectiveWhitespace(text, resolveCodeRegions(text)),
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
+
+  // Directives inside code regions are literal text: never voice/reply semantics.
+  const codeRegions = resolveCodeRegions(text);
+  let cleaned = text;
+  let audioAsVoice = false;
+  let hasAudioTag = false;
+  let hasReplyTag = false;
+  let sawCurrent = false;
+  let lastExplicitId: string | undefined;
+
+  cleaned = cleaned.replace(AUDIO_TAG_RE, (match: string, offset: number, source: string) => {
+    if (isInsideCode(offset, codeRegions)) {
+      return match;
+    }
+    audioAsVoice = true;
+    hasAudioTag = true;
+    return stripAudioTag ? replacementPreservesWordBoundary(source, offset, match.length) : match;
+  });
+
+  cleaned = cleaned.replace(
+    REPLY_TAG_RE,
+    (match: string, idRaw: string | undefined, offset: number, source: string) => {
+      if (isInsideCode(offset, codeRegions)) {
+        return match;
+      }
+      hasReplyTag = true;
+      if (idRaw === undefined) {
+        sawCurrent = true;
+      } else {
+        const id = sanitizeReplyDirectiveId(idRaw);
+        if (id) {
+          lastExplicitId = id;
+        }
+      }
+      return stripReplyTags
+        ? replacementPreservesWordBoundary(source, offset, match.length)
+        : match;
+    },
+  );
+
+  // Early return when `[[...]]` matched no known directive: keep the original
+  // text untouched instead of running whitespace normalization.
+  if (!hasAudioTag && !hasReplyTag) {
+    return {
+      text,
+      audioAsVoice: false,
+      replyToCurrent: false,
+      hasAudioTag: false,
+      hasReplyTag: false,
+    };
+  }
+
+  cleaned = normalizeDirectiveWhitespace(cleaned, codeRegions);
+  const replyToId =
+    lastExplicitId ?? (sawCurrent ? normalizeOptionalString(currentMessageId) : undefined);
+
+  return {
+    text: cleaned,
+    audioAsVoice,
+    replyToId,
+    replyToExplicitId: lastExplicitId,
+    replyToCurrent: sawCurrent,
+    hasAudioTag,
+    hasReplyTag,
+  };
+}

--- a/src/messaging/inline-directives.ts
+++ b/src/messaging/inline-directives.ts
@@ -71,8 +71,10 @@ function resolveCodeRegions(text: string): CodeRegion[] {
 }
 
 function mergeCodeRegions(regions: CodeRegion[]): CodeRegion[] {
-  if (regions.length <= 1) return regions;
-  const sorted = [...regions].sort((a, b) => a.start - b.start || a.end - b.end);
+  if (regions.length <= 1) {
+    return regions;
+  }
+  const sorted = [...regions].toSorted((a, b) => a.start - b.start || a.end - b.end);
   const merged: CodeRegion[] = [];
   for (const region of sorted) {
     const last = merged[merged.length - 1];
@@ -101,7 +103,9 @@ function normalizeDirectiveWhitespace(text: string, codeRegions: CodeRegion[] = 
   let masked = "";
   let cursor = 0;
   for (const region of codeRegions) {
-    if (region.start < cursor) continue;
+    if (region.start < cursor) {
+      continue;
+    }
     blocks.push(text.slice(region.start, region.end));
     masked += `${text.slice(cursor, region.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
     cursor = region.end;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ import type {
   ChannelAccountSnapshot as SDKChannelAccountSnapshot,
   ChannelGatewayContext as SDKChannelGatewayContext,
   ChannelLogSink as SDKChannelLogSink,
-} from "openclaw/plugin-sdk/channel-runtime";
+} from "openclaw/plugin-sdk/channel-contract";
 import type { ChannelPlugin as SDKChannelPlugin, OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
 import type { SecretInput } from "./secret-input";

--- a/tests/unit/inbound-handler-quote.test.ts
+++ b/tests/unit/inbound-handler-quote.test.ts
@@ -27,6 +27,7 @@ const shared = vi.hoisted(() => ({
   formatContentForCardMock: vi.fn((s: string) => s),
   sendProactiveMediaMock: vi.fn(),
   uploadMediaMock: vi.fn(),
+  formatInboundEnvelopeMock: vi.fn().mockReturnValue("body"),
 }));
 
 vi.mock("../../src/runtime", () => ({
@@ -81,6 +82,12 @@ vi.mock("../../src/media-utils", async () => {
 vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   isAbortRequestText: shared.isAbortRequestTextMock,
   isBtwRequestText: vi.fn().mockReturnValue(false),
+}));
+
+// `formatInboundEnvelope` moved out of the runtime facade into the
+// `channel-inbound` SDK subpath (OpenClaw 2026.8.x).
+vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+  formatInboundEnvelope: shared.formatInboundEnvelopeMock,
 }));
 
 vi.mock("../../src/message-context-store", async () => {
@@ -166,6 +173,8 @@ describe("inbound-handler quote handling", () => {
       }
     }
     shared.getRuntimeMock.mockReset();
+    shared.formatInboundEnvelopeMock.mockReset();
+    shared.formatInboundEnvelopeMock.mockReturnValue("body");
     shared.extractMessageContentMock.mockReset();
     shared.downloadGroupFileMock.mockReset();
     shared.downloadGroupFileMock.mockResolvedValue(null);
@@ -442,7 +451,7 @@ describe("inbound-handler quote handling", () => {
         },
       } as unknown as { data: unknown });
 
-      const envelopeArg = (runtime.channel.reply.formatInboundEnvelope as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const envelopeArg = shared.formatInboundEnvelopeMock.mock.calls[0]?.[0];
       expect(envelopeArg.body).toContain("我在讨论字符串 [引用消息:] 本身");
       expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/tests/unit/inline-directives.test.ts
+++ b/tests/unit/inline-directives.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import { parseInlineDirectives, sanitizeReplyDirectiveId } from "../../src/messaging/inline-directives";
+
+describe("parseInlineDirectives", () => {
+  describe("audio tag handling", () => {
+    it("detects and strips [[audio_as_voice]] by default", () => {
+      const result = parseInlineDirectives("[[audio_as_voice]]讲个故事", {});
+      expect(result.audioAsVoice).toBe(true);
+      expect(result.hasAudioTag).toBe(true);
+      expect(result.text).toBe("讲个故事");
+    });
+
+    it("keeps the audio tag when stripAudioTag is false", () => {
+      const result = parseInlineDirectives("[[audio_as_voice]]hi", { stripAudioTag: false });
+      expect(result.audioAsVoice).toBe(true);
+      expect(result.hasAudioTag).toBe(true);
+      expect(result.text).toContain("[[audio_as_voice]]");
+    });
+
+    it("preserves word boundaries when stripping between words", () => {
+      const result = parseInlineDirectives("a[[audio_as_voice]]b", {});
+      expect(result.text).toBe("a b");
+    });
+
+    it("matches tags with surrounding whitespace", () => {
+      const result = parseInlineDirectives("[[ audio_as_voice ]]x", {});
+      expect(result.audioAsVoice).toBe(true);
+      expect(result.text).toBe("x");
+    });
+  });
+
+  describe("reply tag handling", () => {
+    it("detects [[reply_to_current]] and resolves currentMessageId", () => {
+      const result = parseInlineDirectives("答案[[reply_to_current]]", {
+        currentMessageId: "m123",
+      });
+      expect(result.hasReplyTag).toBe(true);
+      expect(result.replyToCurrent).toBe(true);
+      expect(result.replyToId).toBe("m123");
+    });
+
+    it("resolves an explicit [[reply_to:id]]", () => {
+      const result = parseInlineDirectives("[[reply_to:abc123]]x", {});
+      expect(result.hasReplyTag).toBe(true);
+      expect(result.replyToId).toBe("abc123");
+      expect(result.replyToExplicitId).toBe("abc123");
+      expect(result.text).toBe("x");
+    });
+
+    it("keeps the reply tag when stripReplyTags is false", () => {
+      const result = parseInlineDirectives("[[reply_to:abc]]x", { stripReplyTags: false });
+      expect(result.replyToId).toBe("abc");
+      expect(result.text).toContain("[[reply_to:abc]]");
+    });
+
+    it("explicit id wins over reply_to_current", () => {
+      const result = parseInlineDirectives("[[reply_to_current]][[reply_to:z9]]x", {
+        currentMessageId: "m1",
+      });
+      expect(result.replyToCurrent).toBe(true);
+      expect(result.replyToId).toBe("z9");
+    });
+  });
+
+  describe("reply id sanitization", () => {
+    it("does not match malformed reply tags with interior brackets", () => {
+      const text = "[[reply_to:bad]id]]x";
+      const result = parseInlineDirectives(text, {});
+      expect(result.hasReplyTag).toBe(false);
+      expect(result.replyToId).toBeUndefined();
+      expect(result.text).toBe(text);
+    });
+
+    it("drops empty or unsafe-only reply ids", () => {
+      const result = parseInlineDirectives("[[reply_to:  ]]x", {});
+      expect(result.hasReplyTag).toBe(true);
+      expect(result.replyToId).toBeUndefined();
+    });
+
+    it("truncates overlong reply ids to 256 chars", () => {
+      const long = "a".repeat(300);
+      const result = parseInlineDirectives(`[[reply_to:${long}]]x`, {});
+      expect(result.replyToId).toBe("a".repeat(256));
+    });
+
+    it("sanitizeReplyDirectiveId trims and validates", () => {
+      expect(sanitizeReplyDirectiveId("  ab  ")).toBe("ab");
+      expect(sanitizeReplyDirectiveId("")).toBeUndefined();
+      expect(sanitizeReplyDirectiveId("[]")).toBeUndefined();
+      expect(sanitizeReplyDirectiveId("x".repeat(300))).toBe("x".repeat(256));
+    });
+  });
+
+  describe("code regions protect directive tags", () => {
+    it("keeps tags inside inline code as literal text", () => {
+      const result = parseInlineDirectives("run `[[audio_as_voice]]` please", {});
+      expect(result.audioAsVoice).toBe(false);
+      expect(result.hasAudioTag).toBe(false);
+      expect(result.text).toBe("run `[[audio_as_voice]]` please");
+    });
+
+    it("keeps tags inside fenced code blocks", () => {
+      const text = "```\n[[audio_as_voice]]\n```";
+      const result = parseInlineDirectives(text, {});
+      expect(result.audioAsVoice).toBe(false);
+      expect(result.hasAudioTag).toBe(false);
+      expect(result.text).toBe(text);
+    });
+
+    it("keeps tags inside indented code blocks (blank-line separated)", () => {
+      const text = "code:\n\n    [[reply_to:abc123]]";
+      const result = parseInlineDirectives(text, {});
+      expect(result.hasReplyTag).toBe(false);
+      expect(result.replyToId).toBeUndefined();
+      expect(result.text).toBe(text);
+    });
+
+    it("keeps tags inside lenient indented blocks right after a paragraph", () => {
+      const text = "code:\n    [[reply_to:abc123]]";
+      const result = parseInlineDirectives(text, {});
+      expect(result.hasReplyTag).toBe(false);
+      expect(result.replyToId).toBeUndefined();
+      expect(result.text).toBe(text);
+    });
+
+    it("keeps tags inside tab-indented code blocks", () => {
+      const text = "code:\n\n\t[[reply_to:abc123]]";
+      const result = parseInlineDirectives(text, {});
+      expect(result.hasReplyTag).toBe(false);
+      expect(result.replyToId).toBeUndefined();
+      expect(result.text).toBe(text);
+    });
+
+    it("still parses real directives outside code regions", () => {
+      const text = "```\n[[audio_as_voice]]\n```\n说完[[audio_as_voice]]";
+      const result = parseInlineDirectives(text, {});
+      expect(result.audioAsVoice).toBe(true);
+      expect(result.hasAudioTag).toBe(true);
+      expect(result.text).not.toContain("说完[[audio_as_voice]]");
+      expect(result.text).toContain("```\n[[audio_as_voice]]\n```");
+    });
+  });
+
+  describe("early return for unknown [[tags]]", () => {
+    it("returns the original text untouched for unknown tags", () => {
+      const text = "hello\n\n\n[[custom]]\nworld";
+      const result = parseInlineDirectives(text, {});
+      expect(result.text).toBe(text);
+      expect(result.audioAsVoice).toBe(false);
+      expect(result.hasAudioTag).toBe(false);
+      expect(result.hasReplyTag).toBe(false);
+    });
+
+    it("does not normalize bracket markdown / LaTeX", () => {
+      const text = "x\n\n\n[[a b]]\n\ny";
+      const result = parseInlineDirectives(text, {});
+      expect(result.text).toBe(text);
+    });
+
+    it("returns empty result for empty input", () => {
+      expect(parseInlineDirectives("", {})).toEqual({
+        text: "",
+        audioAsVoice: false,
+        replyToCurrent: false,
+        hasAudioTag: false,
+        hasReplyTag: false,
+      });
+    });
+
+    it("returns empty result for undefined input", () => {
+      const result = parseInlineDirectives(undefined, {});
+      expect(result.text).toBe("");
+      expect(result.hasAudioTag).toBe(false);
+    });
+  });
+
+  describe("whitespace normalization", () => {
+    it("collapses multiple blank lines when no brackets present", () => {
+      const result = parseInlineDirectives("line1\n\n\n\nline2", {});
+      expect(result.text).toBe("line1\n\nline2");
+    });
+
+    it("preserves fenced code blocks during normalization", () => {
+      const text = "```\ncode   keep\n```\ntext   squash";
+      const result = parseInlineDirectives(text, {});
+      expect(result.text).toContain("```\ncode   keep\n```");
+      expect(result.text).toContain("text squash");
+    });
+
+    it("normalizes after stripping a real directive", () => {
+      const result = parseInlineDirectives("a\n\n\n\nb[[audio_as_voice]]", {});
+      expect(result.text).toBe("a\n\nb");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

OpenClaw **2026.8.x** retired several plugin SDK surfaces that this plugin still imports, breaking the channel in two stages:

1. **Plugin fails to load** (`ERR_PACKAGE_PATH_NOT_EXPORTED`) because `openclaw/plugin-sdk/text-runtime` was removed (per [sdk-migration.md](https://github.com/openclaw/openclaw/blob/main/docs/plugins/sdk-migration.md): *"The August 15 compatibility subpaths ... `text-runtime` ... were retired early"*). Its replacement `openclaw/plugin-sdk/text-chunking` only re-exports the directive-tag **stripping** helpers and the `InlineDirectiveParseResult` type — not `parseInlineDirectives`.
2. **Inbound messages error** (`rt.channel.reply.formatInboundEnvelope is not a function`) because that member was dropped from the plugin runtime facade in 2026.8.x, while the helper itself is still exported from `openclaw/plugin-sdk/channel-inbound`.

Also `openclaw/plugin-sdk/channel-runtime` (type-only imports for `ChannelAccountSnapshot`, `ChannelGatewayContext`, `ChannelLogSink`) was removed; those types now live in `openclaw/plugin-sdk/channel-contract`.

## Changes

- **`src/inline-directives.ts`** (new): local implementation of `parseInlineDirectives` with behaviour equivalent to the retired host helper — inline directive tag stripping (`[[audio_as_voice]]`, `[[reply_to_current]]`, `[[reply_to:...]]`), reply id sanitization, and code-fence / indented-code-block-aware whitespace normalization.
- **`src/inbound-handler.ts`**: import `parseInlineDirectives` from the new local module; import `formatInboundEnvelope` directly from `openclaw/plugin-sdk/channel-inbound` instead of the removed `rt.channel.reply.formatInboundEnvelope` facade member.
- **`src/types.ts`**: type-only import moved from `openclaw/plugin-sdk/channel-runtime` to `openclaw/plugin-sdk/channel-contract`.
- **`tests/unit/inbound-handler-quote.test.ts`**: mock the new `channel-inbound` import site instead of the removed facade member.

## Verification

- `pnpm type-check`, `pnpm build:types`, `pnpm build:runtime` all pass.
- Full unit suite passes (2 pre-existing timeout flakiness cases pass in isolation).
- `parseInlineDirectives` output was compared field-by-field against the retired OpenClaw 2026.8.1 host implementation across 12 behavioural cases (audio/reply tags, fenced + indented code blocks, multi-blank-line collapse, invalid reply ids, empty/undefined input) — all match.
- The built bundle imports only SDK subpaths that resolve against OpenClaw 2026.8.1, and `import()` of `dist/index.js` succeeds.
- Runtime facade paths used by the plugin were probed against the real 2026.8.1 facade; `formatInboundEnvelope` was the only missing member and is now sourced from the SDK subpath.
- Live-tested: channel loads, connects, and sends/receives messages on OpenClaw 2026.8.1.

This fix is plugin-side only; no OpenClaw source changes required.