### PR TITLE
fix(messaging): extract quoted text from real repliedMsg payload shapes

### DIFF
--- a/src/message-utils.ts
+++ b/src/message-utils.ts
@@ -106,6 +106,35 @@ function extractRichTextQuoteParts(
   };
 }
 
+function extractCardContentText(cardContent: unknown): string | undefined {
+  if (!Array.isArray(cardContent)) {
+    return undefined;
+  }
+  const collected: string[] = [];
+  const walk = (nodes: unknown): void => {
+    if (!Array.isArray(nodes)) {
+      return;
+    }
+    for (const node of nodes) {
+      if (node === null || typeof node !== "object" || Array.isArray(node)) {
+        continue;
+      }
+      const element = node as { elementType?: unknown; value?: unknown; children?: unknown };
+      if (element.elementType === "TEXT" && typeof element.value === "string") {
+        collected.push(element.value);
+      }
+      walk(element.children);
+    }
+  };
+  walk(cardContent);
+  const text = collected
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text.length > 0 ? text : undefined;
+}
+
 function extractAtMentionsFromText(text: string): AtMention[] {
   const mentions: AtMention[] = [];
   const matches = text.matchAll(/(?<!\w)@([^\s@.]+)(?!\.\w)/g);
@@ -321,7 +350,9 @@ function buildRepliedMessagePreview(params: {
         cardCreatedAt: repliedMsg.createdAt,
         processQueryKey: trimString(data.originalProcessQueryKey),
         previewText:
-          trimString(content?.text) || buildQuotedMessageTypePlaceholder("interactiveCard"),
+          trimString(content?.text) ||
+          extractCardContentText(content?.cardContent) ||
+          buildQuotedMessageTypePlaceholder("interactiveCard"),
         previewMessageType: "interactiveCard",
         previewSenderId: trimString(repliedMsg.senderId),
       };
@@ -332,6 +363,7 @@ function buildRepliedMessagePreview(params: {
       fileCreatedAt: repliedMsg.createdAt,
       previewText:
         trimString(content?.text) ||
+        extractCardContentText(content?.cardContent) ||
         buildQuotedMessageTypePlaceholder(docMeta ? "interactiveCardFile" : "interactiveCard"),
       previewMessageType: docMeta ? "interactiveCardFile" : "interactiveCard",
       previewSenderId: trimString(repliedMsg.senderId),
@@ -351,6 +383,7 @@ function buildRepliedMessagePreview(params: {
 
   const textPreview =
     trimString(content?.text) ||
+    trimString(content?.content) ||
     trimString(richTextQuote?.summary) ||
     buildQuotedMessageTypePlaceholder(repliedMsgType, fileName);
 
@@ -636,7 +669,7 @@ export function extractMessageContent(data: DingTalkInboundMessage): MessageCont
       }
 
       // No msgType — backward compat: extract text or richText from content.
-      if (content?.text?.trim()) {
+      if (trimString(content?.text) || trimString(content?.content)) {
         return repliedMsgId ? { msgId: repliedMsgId, ...repliedPreview } : null;
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,17 @@ export interface DocInfo {
 }
 
 /**
+ * Recursive element node of an interactiveCard `cardContent` payload.
+ * Real DingTalk quote callbacks carry card text as nested element trees
+ * (e.g. LIST -> RICHTEXT -> TEXT nodes) rather than a flat `text` field.
+ */
+export interface DingTalkCardContentNode {
+  elementType?: string;
+  value?: string;
+  children?: DingTalkCardContentNode[];
+}
+
+/**
  * DingTalk incoming message (Stream mode)
  */
 export interface DingTalkInboundMessage {
@@ -252,9 +263,13 @@ export interface DingTalkInboundMessage {
       createdAt?: number;
       content?: {
         text?: string;
+        /** Quoted text message body in real payloads (`msgType: "text"`). */
+        content?: string;
         downloadCode?: string;
         fileName?: string;
         biz_custom_action_url?: string;
+        /** interactiveCard quoted content as nested element tree. */
+        cardContent?: DingTalkCardContentNode[];
         richText?: Array<{
           msgType?: string;
           type?: string;

--- a/tests/unit/message-utils-quoted-preview.test.ts
+++ b/tests/unit/message-utils-quoted-preview.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { extractMessageContent } from '../../src/message-utils';
+import { buildInboundQuotedRef } from '../../src/messaging/quoted-ref';
+import { resolveQuotedRuntimeContext } from '../../src/messaging/quoted-context';
+
+// Payload shapes below mirror real DingTalk Stream callbacks captured during
+// device verification (quoted text lives under repliedMsg.content.content and
+// interactiveCard text under repliedMsg.content.cardContent element trees).
+
+function buildTextMessage(repliedMsg: Record<string, unknown>): any {
+    return {
+        msgId: 'current_msg',
+        createAt: 1787128600000,
+        conversationType: '2',
+        conversationId: 'cid_quote',
+        senderId: 'sender_a',
+        senderStaffId: 'staff_a',
+        chatbotUserId: 'bot_user',
+        sessionWebhook: 'https://example.com/session',
+        msgtype: 'text',
+        text: {
+            content: '看下这是啥',
+            isReplyMsg: true,
+            repliedMsg,
+        },
+    };
+}
+
+describe('message-utils quoted preview (real payload shapes)', () => {
+    it('text quote: extracts body from content.content', () => {
+        const message = buildTextMessage({
+            msgType: 'text',
+            msgId: 'quoted_text_real',
+            createdAt: 1787128548524,
+            senderId: 'sender_b',
+            content: { content: '被引用的真实文本' },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.msgId).toBe('quoted_text_real');
+        expect(content.quoted?.previewText).toBe('被引用的真实文本');
+        expect(content.quoted?.previewMessageType).toBe('text');
+    });
+
+    it('text quote: keeps legacy content.text shape working', () => {
+        const message = buildTextMessage({
+            msgType: 'text',
+            msgId: 'quoted_text_legacy',
+            createdAt: 1787128548524,
+            senderId: 'sender_b',
+            content: { text: '旧形态引用文本' },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.previewText).toBe('旧形态引用文本');
+    });
+
+    it('markdown quote: still extracts body from content.text', () => {
+        const message = buildTextMessage({
+            msgType: 'markdown',
+            msgId: 'quoted_markdown',
+            createdAt: 1787128548524,
+            senderId: 'sender_b',
+            content: { text: '# 引用标题\n引用正文' },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.previewText).toBe('# 引用标题\n引用正文');
+        expect(content.quoted?.previewMessageType).toBe('markdown');
+    });
+
+    it('interactiveCard quote from another bot: extracts cardContent TEXT nodes', () => {
+        const message = buildTextMessage({
+            msgType: 'interactiveCard',
+            msgId: 'quoted_card_real',
+            createdAt: 1787128374370,
+            senderId: 'other_bot',
+            content: {
+                cardContent: [
+                    {
+                        elementType: 'LIST',
+                        children: [
+                            {
+                                elementType: 'RICHTEXT',
+                                children: [{ elementType: 'TEXT', value: 'Hi! How can I help you today?' }],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.previewText).toBe('Hi! How can I help you today?');
+        expect(content.quoted?.isQuotedDocCard).toBe(true);
+    });
+
+    it('interactiveCard quote of bot reply: extracts cardContent TEXT nodes', () => {
+        const message = buildTextMessage({
+            msgType: 'interactiveCard',
+            msgId: 'quoted_bot_card',
+            createdAt: 1787128374370,
+            senderId: 'bot_user',
+            content: {
+                cardContent: [
+                    {
+                        elementType: 'RICHTEXT',
+                        children: [
+                            { elementType: 'TEXT', value: '第一行' },
+                            { elementType: 'TEXT', value: '第二行' },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.isQuotedCard).toBe(true);
+        expect(content.quoted?.previewText).toBe('第一行\n第二行');
+    });
+
+    it('interactiveCard quote: keeps content.text fallback when cardContent missing', () => {
+        const message = buildTextMessage({
+            msgType: 'interactiveCard',
+            msgId: 'quoted_card_flat',
+            createdAt: 1787128374370,
+            senderId: 'other_bot',
+            content: { text: '扁平卡片文本' },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.previewText).toBe('扁平卡片文本');
+    });
+
+    it('no-msgType quote: accepts content.content in backward-compat path', () => {
+        const message = buildTextMessage({
+            msgId: 'quoted_no_type',
+            createdAt: 1787128548524,
+            senderId: 'sender_b',
+            content: { content: '无类型引用文本' },
+        });
+
+        const content = extractMessageContent(message);
+
+        expect(content.quoted?.msgId).toBe('quoted_no_type');
+        expect(content.quoted?.previewText).toBe('无类型引用文本');
+    });
+
+    it('group quote with store miss feeds real text into runtime context', () => {
+        const message = buildTextMessage({
+            msgType: 'text',
+            msgId: 'quoted_unseen',
+            createdAt: 1787128548524,
+            senderId: 'sender_b',
+            content: { content: '群里别人发的消息' },
+        });
+
+        const content = extractMessageContent(message);
+        const quotedRef = buildInboundQuotedRef(message, content);
+        const context = resolveQuotedRuntimeContext({
+            accountId: 'main',
+            conversationId: 'cid_quote',
+            quotedRef,
+            firstRecord: null,
+            firstPreview: content.quoted?.previewText
+                ? {
+                      text: content.quoted.previewText,
+                      messageType: content.quoted.previewMessageType,
+                      senderId: content.quoted.previewSenderId,
+                  }
+                : undefined,
+        });
+
+        expect(context?.replyToBody).toBe('群里别人发的消息');
+        expect(context?.replyToIsQuote).toBe(true);
+    });
+});


### PR DESCRIPTION
## 背景

关联 Issue：Fixes #598

引用消息为**文本**或 **interactiveCard** 时，一旦 `message-context-store` 未命中（群聊引用他人消息、超 7 天 TTL、插件安装前的消息），agent 只能拿到占位符，引用上下文丢失。

真实回调中，文本正文位于 `content.content`，interactiveCard 文本位于 `content.cardContent` 的嵌套 TEXT 节点。

## 目标

store 未命中时，从真实 `repliedMsg` 报文恢复引用正文，同时保持 legacy `content.text` 等形态兼容。

## 实现

- `src/message-utils.ts`：支持 `content.content`；递归提取 `cardContent` TEXT 节点；保留旧字段回退。
- `src/types.ts`：补充 payload 类型定义。
- `tests/unit/message-utils-quoted-preview.test.ts`：新增 8 个真实 payload、兼容和端到端测试。
- `docs/user/features/message-types.md`：补充引用正文恢复和回退顺序说明。

## 实现 TODO

- [x] 提取逻辑修复与类型补齐
- [x] 真实报文形态测试
- [x] 用户文档同步
- [x] 已 rebase 到最新 `origin/main`，无冲突

## 验证 TODO

- [x] 新增引用测试 8/8 通过
- [x] type-check 通过
- [x] `build:runtime` 通过
- [x] 真机验证：群聊发送 `PR599 Smoking test`，引用并 `@bot` 发送“请复述我引用的原文”，机器人准确回复“你引用的原文是：PR599 Smoking test”。
- [x] 验证时 DingTalk 状态为 `running=true`、`connected=true`，无错误
- [ ] CI 全量测试与 `oxfmt` 检查，以 GitHub CI 结果为准

## 合并前说明

真机截图已确认用户可见结果正确。当前分支已推送至 PR，等待 CI 完成后即可进行合并审核。