### PR TITLE
fix(messaging): preserve structured mention IDs in context

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -427,18 +427,28 @@ function sanitizeGroupPromptName(value?: string): string {
     .trim();
 }
 
-function buildGroupTurnContextPrompt(params: {
+export function buildGroupTurnContextPrompt(params: {
   conversationId: string;
   senderDingtalkId: string;
   senderName?: string;
+  mentionedDingtalkIds?: readonly string[];
 }): string {
   const sanitizedSenderName = sanitizeGroupPromptName(params.senderName) || "Unknown";
+  const mentionedDingtalkIds = [
+    ...new Set(
+      (params.mentionedDingtalkIds || [])
+        .map((value) => value.replace(/[\r\n,=]/g, " ").trim())
+        .filter(Boolean),
+    ),
+  ];
   return [
     "Current DingTalk group turn context:",
     `- conversationId: ${params.conversationId}`,
     `- senderDingtalkId: ${params.senderDingtalkId}`,
     `- senderName: ${sanitizedSenderName}`,
+    `- mentionedDingtalkIds: ${mentionedDingtalkIds.length > 0 ? mentionedDingtalkIds.join(", ") : "(none provided)"}`,
     "Treat senderDingtalkId and senderName as the authoritative sender for this turn. Do not guess the current sender from GroupMembers.",
+    "Treat mentionedDingtalkIds as raw structured IDs only; do not infer a display name or map them to text mentions without payload evidence.",
   ].join("\n");
 }
 
@@ -1007,6 +1017,17 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
   const quotedRef = buildInboundQuotedRef(data, extractedContent);
   const replyQuotedRef = createReplyQuotedRef(data.msgId);
   const content = extractedContent;
+  const mentionUserIds = [
+    ...new Set(
+      [
+        ...(content.atUserDingtalkIds || []),
+        ...(content.atMentions || []).map((mention) => mention.userId),
+      ]
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ];
   // Decide control-message bypasses once from the user-authored text.  Reusing
   // the result below keeps /stop out of the FIFO queue without calling the SDK
   // classifier a second time after attachment/OCR enrichment.
@@ -1247,6 +1268,9 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
         quotedRef,
         senderId,
         senderName,
+        mentions: content.atMentions?.map((mention) => mention.name),
+        mentionUserIds,
+        chatType: isDirect ? "direct" : "group",
         createdAt: data.createAt,
         ttlMs: ttlDaysToMs(journalTTLDays),
         ttlReferenceMs: data.createAt,
@@ -1779,6 +1803,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
             conversationId: groupId,
             senderDingtalkId: senderId,
             senderName,
+            mentionedDingtalkIds: mentionUserIds,
           }),
           groupConfig?.systemPrompt?.trim(),
         ]

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -427,7 +427,7 @@ function sanitizeGroupPromptName(value?: string): string {
     .trim();
 }
 
-export function buildGroupTurnContextPrompt(params: {
+function buildGroupTurnContextPrompt(params: {
   conversationId: string;
   senderDingtalkId: string;
   senderName?: string;
@@ -449,6 +449,7 @@ export function buildGroupTurnContextPrompt(params: {
     `- mentionedDingtalkIds: ${mentionedDingtalkIds.length > 0 ? mentionedDingtalkIds.join(", ") : "(none provided)"}`,
     "Treat senderDingtalkId and senderName as the authoritative sender for this turn. Do not guess the current sender from GroupMembers.",
     "Treat mentionedDingtalkIds as raw structured IDs only; do not infer a display name or map them to text mentions without payload evidence.",
+    "mentionedDingtalkIds are webhook atUsers/richText IDs (for example $:LWCP_v1:$...), not staff IDs; they are not comparable with senderDingtalkId or GroupMembers ids and must not be used as send targets.",
   ].join("\n");
 }
 

--- a/src/message-context-store.ts
+++ b/src/message-context-store.ts
@@ -51,6 +51,8 @@ export interface MessageRecord {
   senderId?: string;
   senderName?: string;
   mentions?: string[];
+  /** Raw DingTalk user IDs from structured @mention payloads. */
+  mentionUserIds?: string[];
   chatType?: "direct" | "group";
   /** Flat quoted target for summary/history lookups; quotedRef remains the authoritative structured link. */
   quotedMessageId?: string;
@@ -102,6 +104,8 @@ interface BaseUpsertParams {
   senderId?: string;
   senderName?: string;
   mentions?: string[];
+  /** Raw DingTalk user IDs from structured @mention payloads. */
+  mentionUserIds?: string[];
   chatType?: "direct" | "group";
   quotedMessageId?: string;
   media?: {
@@ -340,6 +344,7 @@ function normalizeMessageRecord(value: unknown): MessageRecord | null {
         ? candidate.senderName.trim()
         : undefined,
     mentions: normalizeMentions(candidate.mentions),
+    mentionUserIds: normalizeMentions(candidate.mentionUserIds),
     chatType:
       candidate.chatType === "direct" || candidate.chatType === "group"
         ? candidate.chatType
@@ -703,6 +708,7 @@ function upsertRecord(
     senderId?: string;
     senderName?: string;
     mentions?: string[];
+    mentionUserIds?: string[];
     chatType?: "direct" | "group";
     quotedMessageId?: string;
     media?: MessageRecord["media"];
@@ -765,6 +771,7 @@ function upsertRecord(
     senderId: mergeStringField(existing?.senderId, params.senderId),
     senderName: mergeStringField(existing?.senderName, params.senderName),
     mentions: mergeMentions(existing?.mentions, params.mentions),
+    mentionUserIds: mergeMentions(existing?.mentionUserIds, params.mentionUserIds),
     chatType: params.chatType || existing?.chatType,
     quotedMessageId: mergeStringField(existing?.quotedMessageId, params.quotedMessageId),
     media: mergeMedia(existing?.media, params.media),

--- a/src/message-context-store.ts
+++ b/src/message-context-store.ts
@@ -50,8 +50,9 @@ export interface MessageRecord {
   quotedRef?: QuotedRef;
   senderId?: string;
   senderName?: string;
+  /** Display names parsed from mentions; not positionally aligned with mentionUserIds. */
   mentions?: string[];
-  /** Raw DingTalk user IDs from structured @mention payloads. */
+  /** Raw DingTalk user IDs from structured @mention payloads (atUsers / richText atUserId). Not positionally aligned with mentions. */
   mentionUserIds?: string[];
   chatType?: "direct" | "group";
   /** Flat quoted target for summary/history lookups; quotedRef remains the authoritative structured link. */
@@ -103,8 +104,9 @@ interface BaseUpsertParams {
   quotedRef?: QuotedRef;
   senderId?: string;
   senderName?: string;
+  /** Display names parsed from mentions; not positionally aligned with mentionUserIds. */
   mentions?: string[];
-  /** Raw DingTalk user IDs from structured @mention payloads. */
+  /** Raw DingTalk user IDs from structured @mention payloads (atUsers / richText atUserId). Not positionally aligned with mentions. */
   mentionUserIds?: string[];
   chatType?: "direct" | "group";
   quotedMessageId?: string;

--- a/tests/unit/inbound-handler-subagent.test.ts
+++ b/tests/unit/inbound-handler-subagent.test.ts
@@ -83,7 +83,21 @@ vi.mock("../../src/media-utils", async () => {
   };
 });
 
-import { handleDingTalkMessage } from "../../src/inbound-handler";
+import { buildGroupTurnContextPrompt, handleDingTalkMessage } from "../../src/inbound-handler";
+
+describe("group mention runtime context", () => {
+  it("preserves raw structured DingTalk IDs without guessing names", () => {
+    const prompt = buildGroupTurnContextPrompt({
+      conversationId: "cid_1",
+      senderDingtalkId: "sender_1",
+      senderName: "Alice",
+      mentionedDingtalkIds: ["$:user_a", "$:user_a", "user,bad"],
+    });
+
+    expect(prompt).toContain("mentionedDingtalkIds: $:user_a, user bad");
+    expect(prompt).toContain("do not infer a display name");
+  });
+});
 
 function buildRuntime() {
   return {

--- a/tests/unit/inbound-handler-subagent.test.ts
+++ b/tests/unit/inbound-handler-subagent.test.ts
@@ -83,21 +83,7 @@ vi.mock("../../src/media-utils", async () => {
   };
 });
 
-import { buildGroupTurnContextPrompt, handleDingTalkMessage } from "../../src/inbound-handler";
-
-describe("group mention runtime context", () => {
-  it("preserves raw structured DingTalk IDs without guessing names", () => {
-    const prompt = buildGroupTurnContextPrompt({
-      conversationId: "cid_1",
-      senderDingtalkId: "sender_1",
-      senderName: "Alice",
-      mentionedDingtalkIds: ["$:user_a", "$:user_a", "user,bad"],
-    });
-
-    expect(prompt).toContain("mentionedDingtalkIds: $:user_a, user bad");
-    expect(prompt).toContain("do not infer a display name");
-  });
-});
+import { handleDingTalkMessage } from "../../src/inbound-handler";
 
 function buildRuntime() {
   return {

--- a/tests/unit/inbound-handler.test.ts
+++ b/tests/unit/inbound-handler.test.ts
@@ -822,6 +822,12 @@ describe("inbound-handler", () => {
   it("injects group turn context prompt with authoritative sender metadata", async () => {
     const runtime = buildRuntime();
     shared.getRuntimeMock.mockReturnValueOnce(runtime);
+    shared.extractMessageContentMock.mockReturnValueOnce({
+      text: "hello group",
+      messageType: "text",
+      atUserDingtalkIds: ["$:user_a", "$:user_a", "user,bad"],
+      atMentions: [{ name: "Alpha助手", userId: "$:agent-a" }],
+    });
 
     await handleDingTalkMessage({
       cfg: {},
@@ -858,6 +864,18 @@ describe("inbound-handler", () => {
     expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
         GroupSystemPrompt: expect.stringContaining("senderName: Alice"),
+      }),
+    );
+    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSystemPrompt: expect.stringContaining(
+          "mentionedDingtalkIds: $:user_a, user bad, $:agent-a",
+        ),
+      }),
+    );
+    expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSystemPrompt: expect.stringContaining("not staff IDs"),
       }),
     );
   });

--- a/tests/unit/message-context-store.test.ts
+++ b/tests/unit/message-context-store.test.ts
@@ -175,6 +175,33 @@ describe('message-context-store', () => {
         expect(listed[1]?.chatType).toBe('group');
     });
 
+    it('hydrates mentionUserIds from persisted state after clearing the cache', () => {
+        upsertInboundMessageContext({
+            storePath,
+            accountId: 'main',
+            conversationId: 'cid_meta_reload',
+            msgId: 'msg_meta_reload_1',
+            createdAt: 1000,
+            messageType: 'text',
+            text: 'first',
+            mentionUserIds: ['dingtalk_bob', 'dingtalk_bob', ''],
+            ttlMs: 60_000,
+            topic: null,
+        });
+
+        // Drop the in-memory cache so the next resolve must rehydrate from disk.
+        clearMessageContextCacheForTest();
+
+        const reloaded = resolveByMsgId({
+            storePath,
+            accountId: 'main',
+            conversationId: 'cid_meta_reload',
+            msgId: 'msg_meta_reload_1',
+        });
+
+        expect(reloaded?.mentionUserIds).toEqual(['dingtalk_bob']);
+    });
+
     it('persists quotedRef on records and resolves inbound/outbound references', () => {
         const now = Date.now();
 

--- a/tests/unit/message-context-store.test.ts
+++ b/tests/unit/message-context-store.test.ts
@@ -126,6 +126,7 @@ describe('message-context-store', () => {
             senderId: 'user_1',
             senderName: 'Alice',
             mentions: ['Bob', 'Bob', ''],
+            mentionUserIds: ['dingtalk_bob', 'dingtalk_bob', ''],
             chatType: 'group',
             quotedMessageId: 'quoted_1',
             ttlMs: 60_000,
@@ -159,6 +160,7 @@ describe('message-context-store', () => {
         expect(inbound?.senderId).toBe('user_1');
         expect(inbound?.senderName).toBe('Alice');
         expect(inbound?.mentions).toEqual(['Bob']);
+        expect(inbound?.mentionUserIds).toEqual(['dingtalk_bob']);
         expect(inbound?.chatType).toBe('group');
         expect(inbound?.quotedMessageId).toBe('quoted_1');
 

--- a/tests/unit/message-utils-mentions.test.ts
+++ b/tests/unit/message-utils-mentions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { extractMessageContent } from "../../src/message-utils";
+import { resolveAtAgents } from "../../src/targeting/agent-name-matcher";
+import type { DingTalkInboundMessage } from "../../src/types";
+
+function message(overrides: Partial<DingTalkInboundMessage>): DingTalkInboundMessage {
+  return {
+    msgId: "msg-mention-1",
+    msgtype: "text",
+    createAt: 1,
+    conversationType: "2",
+    conversationId: "cid-mention-1",
+    senderId: "sender-1",
+    chatbotUserId: "bot-1",
+    sessionWebhook: "https://example.invalid/session",
+    ...overrides,
+  } as DingTalkInboundMessage;
+}
+
+describe("structured DingTalk mention payloads", () => {
+  it("preserves top-level atUsers IDs without mapping them to text names", () => {
+    const result = extractMessageContent(
+      message({
+        atUsers: [{ dingtalkId: "$:user-a" }, { dingtalkId: "$:user-b" }],
+        text: { content: "@Alice @Bob 请确认" },
+      }),
+    );
+
+    expect(result.atUserDingtalkIds).toEqual(["$:user-a", "$:user-b"]);
+    expect(result.atMentions?.map((mention) => mention.name)).toEqual(["Alice", "Bob"]);
+  });
+
+  it("keeps richText atUserId attached to the corresponding structured mention", () => {
+    const result = extractMessageContent(
+      message({
+        msgtype: "richText",
+        atUsers: [{ dingtalkId: "$:person-a" }],
+        content: {
+          richText: [
+            { type: "at", atName: "Alpha助手", atUserId: "$:agent-a" },
+            { type: "text", text: " 请处理" },
+          ],
+        },
+      }),
+    );
+
+    expect(result.atUserDingtalkIds).toEqual(["$:person-a"]);
+    expect(result.atMentions).toEqual([{ name: "Alpha助手", userId: "$:agent-a" }]);
+  });
+
+  it("routes an Agent mention while excluding a richText real-user mention", () => {
+    const result = extractMessageContent(
+      message({
+        msgtype: "richText",
+        atUsers: [{ dingtalkId: "$:person-a" }],
+        content: {
+          richText: [
+            { type: "at", atName: "Alpha助手", atUserId: "$:agent-a" },
+            { type: "at", atName: "Alice", atUserId: "$:person-a" },
+          ],
+        },
+      }),
+    );
+
+    const routing = resolveAtAgents(
+      result.atMentions || [],
+      { agents: { list: [{ id: "agent-a", name: "Alpha助手" }] } },
+      result.atUserDingtalkIds,
+    );
+
+    expect(routing.matchedAgents).toEqual([
+      { agentId: "agent-a", matchSource: "name", matchedName: "Alpha助手" },
+    ]);
+    expect(routing.unmatchedNames).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 背景

关联 Issue：#580。DingTalk 的顶层 `atUsers` 只提供原始 `dingtalkId`，richText 的 `atUserId` 则附着在具体 mention 节点上。现有代码能做路由判断，但没有把这些结构化 ID 记录进 `message-context-store`，群聊 runtime 也看不到原始 mention ID。

## 目标

保留可证实的原始 DingTalk ID，并明确禁止从文本显示名反推 ID；覆盖顶层多用户、richText 及 Agent/真人混合 mention。

## 实现

- `message-context-store` 新增 `mentionUserIds` 字段，并在规范化、合并、持久化路径中保留去重后的原始 ID。
- 入站消息把 `atUsers` 与 richText `atUserId` 合并写入消息上下文，同时记录 mention 名称和 chat type。
- 群聊 `GroupSystemPrompt` 增加脱敏后的 `mentionedDingtalkIds`，并明确不进行显示名推断。
- 新增脱敏 fixture 测试：text 顶层 `atUsers`、richText `atUserId`、多用户与 Agent/真人混合路由。

## 实现 TODO

- [x] 保持现有文本 mention 与 richText 路由行为
- [x] 不建立未经 payload 证实的名字到 ID 映射

## 验证 TODO

- [x] `vitest run tests/unit/message-utils-mentions.test.ts tests/unit/message-context-store.test.ts`（13/13）
- [x] `oxlint --type-aware src/inbound-handler.ts src/message-context-store.ts`（0 errors；保留仓库既有 10 warnings）
- [x] `git diff --check`
- [ ] 完整 `type-check`：本地安装的 OpenClaw 依赖为旧版本，缺少 `plugin-sdk/secret-input-runtime` 等导出，无法代表当前仓库 CI

PR #599 只处理 quoted preview 的 `message-utils.ts`/`types.ts`，不包含本 PR 的 structured mention context 变更。