### PR TITLE
feat: stream concise task progress to AI cards

### DIFF
--- a/docs/plans/2026-09-01-live-task-progress-card.md
+++ b/docs/plans/2026-09-01-live-task-progress-card.md
@@ -1,0 +1,59 @@
+# Live Task Progress Card Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep one DingTalk AI card visibly updated during long OpenClaw tasks with a concise, sanitized progress summary.
+
+**Architecture:** Extend the card draft timeline with one replaceable progress block. A card-scoped progress controller subscribes to correlated OpenClaw lifecycle/tool events, converts tool names to safe user-facing stages, updates elapsed/completed-step metadata, emits a 30-second heartbeat, and removes the progress block before the final answer is committed.
+
+**Tech Stack:** TypeScript, OpenClaw runtime agent events, Soimy DingTalk AI Card APIs, Vitest.
+
+---
+
+### Task 1: Add a replaceable progress block to the card timeline
+
+**Files:**
+- Modify: `src/card-draft-controller.ts`
+- Test: `tests/unit/card-draft-controller.test.ts`
+
+1. Write a failing test proving repeated progress updates replace one block and clearing removes it.
+2. Run the focused test and confirm it fails because the API is missing.
+3. Add `updateProgress` and `clearProgress` with a dedicated timeline entry.
+4. Run the focused test and the full controller test file.
+
+### Task 2: Convert runtime events into safe concise progress
+
+**Files:**
+- Create: `src/card/card-task-progress.ts`
+- Create: `tests/unit/card-task-progress.test.ts`
+
+1. Write failing tests for safe stage labels, correlated tool events, completed-step counts, elapsed time, and a 30-second heartbeat.
+2. Confirm failures before implementation.
+3. Implement a controller that never renders raw command arguments or tool output.
+4. Run the focused tests.
+
+### Task 3: Wire progress into card reply lifecycle
+
+**Files:**
+- Modify: `src/reply-strategy-types.ts`
+- Modify: `src/inbound-handler.ts`
+- Modify: `src/reply-strategy-card.ts`
+- Test: `tests/unit/inbound-handler-card-streaming.test.ts`
+
+1. Write a failing integration test that emits runtime tool events and observes updates to the same card.
+2. Pass the runtime event surface into the card strategy.
+3. Start progress tracking with the card and dispose/clear it on finalization or abort.
+4. Run card streaming and inbound handler regression tests.
+
+### Task 4: Build, deploy, and verify
+
+**Files:**
+- Build output: `dist/index.js`, `dist/index.d.ts`
+- Installed plugin: `/home/claw/.openclaw/npm/projects/soimy-dingtalk-07d9447d75/node_modules/@soimy/dingtalk`
+
+1. Run formatting, type checking, focused tests, full tests, and build.
+2. Back up the installed plugin.
+3. Copy the verified build and source into the managed plugin location.
+4. Restart the OpenClaw gateway.
+5. Verify gateway health, DingTalk channel health, plugin load source, and absence of new startup errors.
+

--- a/src/ack-reaction/dynamic-ack-reaction-events.ts
+++ b/src/ack-reaction/dynamic-ack-reaction-events.ts
@@ -28,6 +28,36 @@ export type RuntimeEventsSurface = {
   onAgentEvent?: (listener: (event: unknown) => void) => (() => void);
 };
 
+export function createRuntimeEventsFanout(upstream: RuntimeEventsSurface | undefined): RuntimeEventsSurface {
+  const listeners = new Set<(event: unknown) => void>();
+  let unsubscribeUpstream: (() => void) | undefined;
+
+  const ensureUpstreamSubscription = () => {
+    if (unsubscribeUpstream || !upstream?.onAgentEvent) {
+      return;
+    }
+    unsubscribeUpstream = upstream.onAgentEvent((event: unknown) => {
+      for (const listener of [...listeners]) {
+        listener(event);
+      }
+    });
+  };
+
+  return {
+    onAgentEvent(listener: (event: unknown) => void) {
+      listeners.add(listener);
+      ensureUpstreamSubscription();
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0 && unsubscribeUpstream) {
+          unsubscribeUpstream();
+          unsubscribeUpstream = undefined;
+        }
+      };
+    },
+  };
+}
+
 function firstTrimmedString(...values: unknown[]): string | undefined {
   for (const value of values) {
     if (typeof value === "string" && value.trim()) {

--- a/src/ack-reaction/dynamic-ack-reaction-events.ts
+++ b/src/ack-reaction/dynamic-ack-reaction-events.ts
@@ -25,10 +25,12 @@ export type RuntimeAgentEvent = {
 };
 
 export type RuntimeEventsSurface = {
-  onAgentEvent?: (listener: (event: unknown) => void) => (() => void);
+  onAgentEvent?: (listener: (event: unknown) => void) => () => void;
 };
 
-export function createRuntimeEventsFanout(upstream: RuntimeEventsSurface | undefined): RuntimeEventsSurface {
+export function createRuntimeEventsFanout(
+  upstream: RuntimeEventsSurface | undefined,
+): RuntimeEventsSurface {
   const listeners = new Set<(event: unknown) => void>();
   let unsubscribeUpstream: (() => void) | undefined;
 
@@ -37,7 +39,8 @@ export function createRuntimeEventsFanout(upstream: RuntimeEventsSurface | undef
       return;
     }
     unsubscribeUpstream = upstream.onAgentEvent((event: unknown) => {
-      for (const listener of [...listeners]) {
+      const currentListeners = Array.from(listeners);
+      for (const listener of currentListeners) {
         listener(event);
       }
     });
@@ -72,7 +75,11 @@ export function getEventRunId(event: RuntimeAgentEvent | undefined): string | un
 }
 
 export function getEventSessionKey(event: RuntimeAgentEvent | undefined): string | undefined {
-  return firstTrimmedString(event?.sessionKey, event?.data?.sessionKey, event?.data?.meta?.sessionKey);
+  return firstTrimmedString(
+    event?.sessionKey,
+    event?.data?.sessionKey,
+    event?.data?.meta?.sessionKey,
+  );
 }
 
 export function describeEvent(event: RuntimeAgentEvent | undefined): string {
@@ -80,8 +87,10 @@ export function describeEvent(event: RuntimeAgentEvent | undefined): string {
   const phase = firstTrimmedString(event?.data?.phase) || "-";
   const toolName = firstTrimmedString(event?.data?.name) || "-";
   const toolCallId = firstTrimmedString(event?.data?.toolCallId) || "-";
-  return `stream=${stream} phase=${phase} runId=${getEventRunId(event) || "-"} ` +
-    `sessionKey=${getEventSessionKey(event) || "-"} toolCallId=${toolCallId} toolName=${toolName}`;
+  return (
+    `stream=${stream} phase=${phase} runId=${getEventRunId(event) || "-"} ` +
+    `sessionKey=${getEventSessionKey(event) || "-"} toolCallId=${toolCallId} toolName=${toolName}`
+  );
 }
 
 export function createDynamicAckReactionCorrelator(params: {
@@ -105,7 +114,7 @@ export function createDynamicAckReactionCorrelator(params: {
       const matched = eventRunId === activeRunId;
       params.log?.debug?.(
         `[DingTalk] Dynamic reaction correlation by runId matched=${matched} activeRunId=${activeRunId} ` +
-        `eventRunId=${eventRunId || "-"} eventSessionKey=${eventSessionKey || "-"}`,
+          `eventRunId=${eventRunId || "-"} eventSessionKey=${eventSessionKey || "-"}`,
       );
       return matched;
     }
@@ -125,18 +134,18 @@ export function createDynamicAckReactionCorrelator(params: {
     }
 
     if (
-      optimisticCaptureCount === 0
-      && eventStream === "lifecycle"
-      && eventPhase === "start"
-      && eventRunId
-      && !eventSessionKey
-      && Date.now() - params.createdAt <= params.optimisticCaptureWindowMs
+      optimisticCaptureCount === 0 &&
+      eventStream === "lifecycle" &&
+      eventPhase === "start" &&
+      eventRunId &&
+      !eventSessionKey &&
+      Date.now() - params.createdAt <= params.optimisticCaptureWindowMs
     ) {
       optimisticCaptureCount += 1;
       activeRunId = eventRunId;
       params.log?.debug?.(
         `[DingTalk] Dynamic reaction optimistically captured active runId=${activeRunId} ` +
-        `from first lifecycle event without sessionKey windowMs=${params.optimisticCaptureWindowMs}`,
+          `from first lifecycle event without sessionKey windowMs=${params.optimisticCaptureWindowMs}`,
       );
       return true;
     }
@@ -145,7 +154,7 @@ export function createDynamicAckReactionCorrelator(params: {
       correlationUnavailableLogged = true;
       params.log?.debug?.(
         `[DingTalk] Dynamic reaction ignored uncorrelated agent events; ` +
-        `reason=${getErrorMessage(eventRunId || eventSessionKey || "waiting for sessionKey/runId match")}`,
+          `reason=${getErrorMessage(eventRunId || eventSessionKey || "waiting for sessionKey/runId match")}`,
       );
     }
     return false;

--- a/src/card-draft-controller.ts
+++ b/src/card-draft-controller.ts
@@ -18,7 +18,7 @@ import {
 import { createDraftStreamLoop } from "./draft-stream-loop";
 import type { AICardInstance, CardBlock, Logger } from "./types";
 
-type TimelineEntryKind = "thinking" | "tool" | "answer" | "image";
+type TimelineEntryKind = "progress" | "thinking" | "tool" | "answer" | "image";
 
 type TimelineEntry = {
     kind: TimelineEntryKind;
@@ -34,6 +34,8 @@ const PROCESS_BLOCK_FONT_SIZE_TOKEN = "common_footnote_text_style__font_size";
 const PROCESS_BLOCK_FONT_COLOR_TOKEN_V2 = "common_level2_base_color";
 
 export interface CardDraftController {
+    updateProgress: (text: string) => Promise<void>;
+    clearProgress: () => Promise<void>;
     updateAnswer: (text: string, options?: { stream?: boolean; renderBlocks?: boolean }) => Promise<void>;
     updateReasoning: (text: string) => Promise<void>;
     updateThinking: (text: string) => Promise<void>;
@@ -201,6 +203,43 @@ export function createCardDraftController(params: {
         return timelineEntries.length - 1;
     };
 
+    const updateProgress = async (text: string) => {
+        await waitForPendingBoundary();
+        if (stopped || failed) {
+            return;
+        }
+        const normalized = normalizeProcessText(text);
+        if (!normalized) {
+            return;
+        }
+        const progressIndex = timelineEntries.findIndex((entry) => entry.kind === "progress");
+        if (progressIndex >= 0) {
+            timelineEntries[progressIndex] = { kind: "progress", text: normalized };
+        } else {
+            timelineEntries.unshift({ kind: "progress", text: normalized });
+            if (activeThinkingIndex !== null) {
+                activeThinkingIndex += 1;
+            }
+            if (activeAnswerIndex !== null) {
+                activeAnswerIndex += 1;
+            }
+        }
+        queueRender();
+    };
+
+    const clearProgress = async () => {
+        await waitForPendingBoundary();
+        if (stopped || failed) {
+            return;
+        }
+        const progressIndex = timelineEntries.findIndex((entry) => entry.kind === "progress");
+        if (progressIndex < 0) {
+            return;
+        }
+        removeTimelineEntry(progressIndex);
+        queueRender();
+    };
+
     const findCurrentSegmentAnswerIndex = (): number | null => {
         return activeAnswerIndex;
     };
@@ -251,6 +290,11 @@ export function createCardDraftController(params: {
         for (const entry of entries) {
             if (!entry) { continue; }
             switch (entry.kind) {
+                case "progress":
+                    if (entry.text?.trim()) {
+                        blocks.push({ type: 2, markdown: wrapProcessBlockMarkdown(entry.text) });
+                    }
+                    break;
                 case "answer":
                     if (entry.text?.trim()) {
                         blocks.push({ type: 0, markdown: entry.text });
@@ -575,6 +619,8 @@ export function createCardDraftController(params: {
     };
 
     return {
+        updateProgress,
+        clearProgress,
         updateAnswer,
         updateReasoning,
         updateThinking: updateReasoning,

--- a/src/card/card-task-progress.ts
+++ b/src/card/card-task-progress.ts
@@ -105,7 +105,9 @@ export function createCardTaskProgressController(params: {
     updatePromise = updatePromise
       .then(() => params.updateProgress(render()))
       .catch((error: unknown) => {
-        params.log?.warn?.(`[DingTalk][TaskProgress] Card update failed: ${getErrorMessage(error)}`);
+        params.log?.warn?.(
+          `[DingTalk][TaskProgress] Card update failed: ${getErrorMessage(error)}`,
+        );
       });
     return updatePromise;
   };

--- a/src/card/card-task-progress.ts
+++ b/src/card/card-task-progress.ts
@@ -1,0 +1,168 @@
+import {
+  createDynamicAckReactionCorrelator,
+  type DynamicAckReactionLogger,
+  type RuntimeAgentEvent,
+  type RuntimeEventsSurface,
+} from "../ack-reaction/dynamic-ack-reaction-events";
+import { getErrorMessage } from "../utils";
+
+const DEFAULT_START_DELAY_MS = 10_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const OPTIMISTIC_RUN_ID_CAPTURE_WINDOW_MS = 5_000;
+
+function resolveSafeStage(toolName: unknown): string {
+  const name = typeof toolName === "string" ? toolName.trim().toLowerCase() : "";
+  if (["read", "view", "find", "list", "glob"].includes(name)) {
+    return "正在检查文件";
+  }
+  if (["write", "edit", "patch", "apply_patch"].includes(name)) {
+    return "正在应用修改";
+  }
+  if (["web_search", "search", "fetch", "open", "open_url"].includes(name)) {
+    return "正在查询资料";
+  }
+  if (name.includes("browser")) {
+    return "正在验证页面";
+  }
+  if (["bash", "exec", "process", "exec_command"].includes(name)) {
+    return "正在执行检查";
+  }
+  if (name.includes("database") || name.includes("sql") || name.includes("query")) {
+    return "正在查询数据";
+  }
+  return "正在处理任务";
+}
+
+function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes} 分 ${seconds} 秒` : `${seconds} 秒`;
+}
+
+function formatUpdatedAt(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString("zh-CN", {
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function createCardTaskProgressController(params: {
+  sessionKey: string;
+  runtimeEvents?: RuntimeEventsSurface;
+  updateProgress: (text: string) => Promise<void>;
+  clearProgress: () => Promise<void>;
+  startDelayMs?: number;
+  heartbeatIntervalMs?: number;
+  log?: DynamicAckReactionLogger;
+}) {
+  const startedAt = Date.now();
+  let currentStage = "正在处理任务";
+  let completedSteps = 0;
+  let visible = false;
+  let disposed = false;
+  let updatePromise: Promise<void> = Promise.resolve();
+  let heartbeatTimer: NodeJS.Timeout | undefined;
+  const completedToolCalls = new Set<string>();
+  const isCorrelatedEvent = createDynamicAckReactionCorrelator({
+    sessionKey: params.sessionKey,
+    enabled: true,
+    createdAt: startedAt,
+    optimisticCaptureWindowMs: OPTIMISTIC_RUN_ID_CAPTURE_WINDOW_MS,
+    log: params.log,
+  });
+
+  const render = (): string => {
+    const now = Date.now();
+    return [
+      "⏳ 任务处理中",
+      `当前阶段：${currentStage}`,
+      `已完成：${completedSteps} 步`,
+      `已耗时：${formatElapsed(now - startedAt)}`,
+      `更新：${formatUpdatedAt(now)}`,
+    ].join("\n");
+  };
+
+  const ensureHeartbeat = () => {
+    if (heartbeatTimer || disposed) {
+      return;
+    }
+    heartbeatTimer = setInterval(() => {
+      if (visible) {
+        void queueUpdate();
+      }
+    }, params.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS);
+  };
+
+  const queueUpdate = () => {
+    if (disposed) {
+      return updatePromise;
+    }
+    visible = true;
+    ensureHeartbeat();
+    updatePromise = updatePromise
+      .then(() => params.updateProgress(render()))
+      .catch((error: unknown) => {
+        params.log?.warn?.(`[DingTalk][TaskProgress] Card update failed: ${getErrorMessage(error)}`);
+      });
+    return updatePromise;
+  };
+
+  const handleAgentEvent = (event: unknown) => {
+    if (disposed) {
+      return;
+    }
+    const agentEvent = event as RuntimeAgentEvent | undefined;
+    if (agentEvent?.stream === "lifecycle" && agentEvent.data?.phase === "start") {
+      void isCorrelatedEvent(agentEvent);
+      return;
+    }
+    if (agentEvent?.stream !== "tool" || !isCorrelatedEvent(agentEvent)) {
+      return;
+    }
+
+    if (agentEvent.data?.phase === "start") {
+      currentStage = resolveSafeStage(agentEvent.data?.name);
+      void queueUpdate();
+      return;
+    }
+    if (agentEvent.data?.phase === "end") {
+      const toolCallId = agentEvent.data?.toolCallId?.trim();
+      if (!toolCallId || !completedToolCalls.has(toolCallId)) {
+        if (toolCallId) {
+          completedToolCalls.add(toolCallId);
+        }
+        completedSteps += 1;
+      }
+      void queueUpdate();
+    }
+  };
+
+  const unsubscribe = params.runtimeEvents?.onAgentEvent?.(handleAgentEvent) ?? (() => {});
+  const startTimer = setTimeout(() => {
+    void queueUpdate();
+  }, params.startDelayMs ?? DEFAULT_START_DELAY_MS);
+
+  return {
+    async awaitDrain(): Promise<void> {
+      await updatePromise.catch(() => undefined);
+    },
+    async dispose(): Promise<void> {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      clearTimeout(startTimer);
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+      }
+      unsubscribe();
+      await this.awaitDrain();
+      if (visible) {
+        await params.clearProgress();
+      }
+    },
+  };
+}

--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -7,6 +7,7 @@ import { normalizeAllowFrom, isSenderAllowed, resolveGroupAccess } from "./acces
 import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
 import { createDynamicAckReactionController } from "./ack-reaction/dynamic-ack-reaction-controller";
+import { createRuntimeEventsFanout } from "./ack-reaction/dynamic-ack-reaction-events";
 import { getAccessToken } from "./auth";
 import {
   createAICard,
@@ -2264,6 +2265,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
         };
       }
     ).events;
+    const replyRuntimeEvents = createRuntimeEventsFanout(runtimeEvents);
     const releaseSessionLock = await acquireSessionLock(route.sessionKey);
     const dynamicAckReactionController = createDynamicAckReactionController({
       enabled: shouldTrackDynamicAckReaction,
@@ -2275,7 +2277,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
       conversationId: groupId,
       sessionKey: route.sessionKey,
       log,
-      runtimeEvents,
+      runtimeEvents: replyRuntimeEvents,
       onReactionDisposed: () => {
         ackReactionAttached = false;
       },
@@ -2350,6 +2352,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
         isStopRequested: isCurrentCardStopRequested,
         inboundText: rawInboundText,
         taskMeta,
+        runtimeEvents: replyRuntimeEvents,
       });
 
       let deliveredFinalCount = 0;

--- a/src/reply-strategy-card.ts
+++ b/src/reply-strategy-card.ts
@@ -34,6 +34,7 @@ import { sendBySession, sendMessage, sendProactiveMedia, uploadMedia } from "./s
 import type { AICardInstance } from "./types";
 import { AICardStatus } from "./types";
 import { formatDingTalkErrorPayloadLog } from "./utils";
+import { createCardTaskProgressController } from "./card/card-task-progress";
 
 const EMPTY_FINAL_REPLY = "✅ Done";
 const DEFAULT_CARD_FAILED_MESSAGE = "回复生成失败，请重试";
@@ -130,6 +131,13 @@ export function createCardReplyStrategy(
     realTimeStreamEnabled: streamAnswerLive,
     throttleMs: config.cardStreamInterval ?? 1000,
     getStatusLine: buildStatusLine,
+  });
+  const taskProgressController = createCardTaskProgressController({
+    sessionKey: ctx.sessionKey || "",
+    runtimeEvents: ctx.runtimeEvents,
+    updateProgress: controller.updateProgress,
+    clearProgress: controller.clearProgress,
+    log,
   });
   const reasoningAssembler = createReasoningBlockAssembler();
   if (card.outTrackId) {
@@ -621,6 +629,7 @@ export function createCardReplyStrategy(
     },
 
     async finalize(): Promise<void> {
+      await taskProgressController.dispose();
       log?.info?.(
         `[DingTalk][Finalize] Step 5 entry — ` +
         `cardState=${card.state ?? "N/A"} ` +
@@ -832,6 +841,7 @@ export function createCardReplyStrategy(
     },
 
     async abort(_error: Error): Promise<void> {
+      await taskProgressController.dispose();
       lifecycleState = "sealed";
       if (card.accountId && card.conversationId) {
         clearRuns(ctx.taskMeta?.runIds);

--- a/src/reply-strategy-types.ts
+++ b/src/reply-strategy-types.ts
@@ -8,6 +8,7 @@
 
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
 import type { DingTalkConfig, Logger, QuotedRef } from "./types";
+import type { RuntimeEventsSurface } from "./ack-reaction/dynamic-ack-reaction-events";
 
 // ---- Internal helper type ----
 
@@ -94,4 +95,5 @@ export interface ReplyStrategyContext {
   isStopRequested?: () => boolean;
   inboundText?: string;
   taskMeta?: TaskMeta;
+  runtimeEvents?: RuntimeEventsSurface;
 }

--- a/tests/unit/card-draft-controller.test.ts
+++ b/tests/unit/card-draft-controller.test.ts
@@ -168,6 +168,27 @@ describe("card-draft-controller", () => {
         });
     });
 
+    it("replaces and clears a single live task progress block", async () => {
+        const card = makeCard();
+        const ctrl = createCardDraftController({ card, throttleMs: 0 });
+
+        await ctrl.updateProgress("⏳ 任务处理中\n当前阶段：正在检查配置");
+        await vi.advanceTimersByTimeAsync(0);
+        await ctrl.updateProgress("⏳ 任务处理中\n当前阶段：正在验证服务");
+        await vi.advanceTimersByTimeAsync(0);
+
+        let blocks = parseBlocks(ctrl.getRenderedBlocks());
+        expect(blocks).toHaveLength(1);
+        expect(getBlockText(blocks, 0)).toContain("正在验证服务");
+        expect(getBlockText(blocks, 0)).not.toContain("正在检查配置");
+
+        await ctrl.clearProgress();
+        await vi.advanceTimersByTimeAsync(0);
+
+        blocks = parseBlocks(ctrl.getRenderedBlocks());
+        expect(blocks).toHaveLength(0);
+    });
+
     it("answer rendering keeps the latest thinking block in the same timeline", async () => {
         const card = makeCard();
         const ctrl = createCardDraftController({ card, throttleMs: 0 });

--- a/tests/unit/card-task-progress.test.ts
+++ b/tests/unit/card-task-progress.test.ts
@@ -63,9 +63,21 @@ describe("card task progress", () => {
     });
 
     listener?.({ stream: "lifecycle", runId: "run-1", sessionKey: "s1", data: { phase: "start" } });
-    listener?.({ stream: "tool", runId: "run-1", data: { phase: "start", name: "read", toolCallId: "tool-1" } });
-    listener?.({ stream: "tool", runId: "run-1", data: { phase: "end", name: "read", toolCallId: "tool-1" } });
-    listener?.({ stream: "tool", runId: "run-1", data: { phase: "start", name: "web_search", toolCallId: "tool-2" } });
+    listener?.({
+      stream: "tool",
+      runId: "run-1",
+      data: { phase: "start", name: "read", toolCallId: "tool-1" },
+    });
+    listener?.({
+      stream: "tool",
+      runId: "run-1",
+      data: { phase: "end", name: "read", toolCallId: "tool-1" },
+    });
+    listener?.({
+      stream: "tool",
+      runId: "run-1",
+      data: { phase: "start", name: "web_search", toolCallId: "tool-2" },
+    });
     await controller.awaitDrain();
 
     const rendered = String(updateProgress.mock.calls.at(-1)?.[0] ?? "");

--- a/tests/unit/card-task-progress.test.ts
+++ b/tests/unit/card-task-progress.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCardTaskProgressController } from "../../src/card/card-task-progress";
+
+describe("card task progress", () => {
+  let listener: ((event: unknown) => void) | undefined;
+  const updateProgress = vi.fn().mockResolvedValue(undefined);
+  const clearProgress = vi.fn().mockResolvedValue(undefined);
+  const runtimeEvents = {
+    onAgentEvent: vi.fn((nextListener: (event: unknown) => void) => {
+      listener = nextListener;
+      return vi.fn();
+    }),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T04:00:00.000Z"));
+    listener = undefined;
+    updateProgress.mockClear();
+    clearProgress.mockClear();
+    runtimeEvents.onAgentEvent.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a safe stage for a correlated tool without rendering raw arguments", async () => {
+    const controller = createCardTaskProgressController({
+      sessionKey: "s1",
+      runtimeEvents,
+      updateProgress,
+      clearProgress,
+    });
+
+    listener?.({ stream: "lifecycle", runId: "run-1", sessionKey: "s1", data: { phase: "start" } });
+    listener?.({
+      stream: "tool",
+      runId: "run-1",
+      sessionKey: "s1",
+      data: {
+        phase: "start",
+        name: "exec",
+        toolCallId: "tool-1",
+        args: { cmd: "curl -H 'Authorization: Bearer secret-token' https://example.com" },
+      },
+    });
+    await controller.awaitDrain();
+
+    const rendered = String(updateProgress.mock.calls.at(-1)?.[0] ?? "");
+    expect(rendered).toContain("当前阶段：正在执行检查");
+    expect(rendered).toContain("已完成：0 步");
+    expect(rendered).not.toContain("curl");
+    expect(rendered).not.toContain("secret-token");
+  });
+
+  it("counts completed tools and changes to the next concise stage", async () => {
+    const controller = createCardTaskProgressController({
+      sessionKey: "s1",
+      runtimeEvents,
+      updateProgress,
+      clearProgress,
+    });
+
+    listener?.({ stream: "lifecycle", runId: "run-1", sessionKey: "s1", data: { phase: "start" } });
+    listener?.({ stream: "tool", runId: "run-1", data: { phase: "start", name: "read", toolCallId: "tool-1" } });
+    listener?.({ stream: "tool", runId: "run-1", data: { phase: "end", name: "read", toolCallId: "tool-1" } });
+    listener?.({ stream: "tool", runId: "run-1", data: { phase: "start", name: "web_search", toolCallId: "tool-2" } });
+    await controller.awaitDrain();
+
+    const rendered = String(updateProgress.mock.calls.at(-1)?.[0] ?? "");
+    expect(rendered).toContain("当前阶段：正在查询资料");
+    expect(rendered).toContain("已完成：1 步");
+  });
+
+  it("starts after ten seconds and refreshes a heartbeat every thirty seconds", async () => {
+    const controller = createCardTaskProgressController({
+      sessionKey: "s1",
+      runtimeEvents,
+      updateProgress,
+      clearProgress,
+    });
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(updateProgress).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await controller.awaitDrain();
+    expect(updateProgress).toHaveBeenCalledTimes(1);
+    expect(String(updateProgress.mock.calls[0]?.[0])).toContain("当前阶段：正在处理任务");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await controller.awaitDrain();
+    expect(updateProgress).toHaveBeenCalledTimes(2);
+    expect(String(updateProgress.mock.calls[1]?.[0])).toContain("已耗时：40 秒");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await controller.awaitDrain();
+    expect(updateProgress).toHaveBeenCalledTimes(3);
+    expect(String(updateProgress.mock.calls[2]?.[0])).toContain("已耗时：1 分 10 秒");
+  });
+
+  it("unsubscribes and clears progress when disposed", async () => {
+    const unsubscribe = vi.fn();
+    runtimeEvents.onAgentEvent.mockImplementationOnce((nextListener) => {
+      listener = nextListener;
+      return unsubscribe;
+    });
+    const controller = createCardTaskProgressController({
+      sessionKey: "s1",
+      runtimeEvents,
+      updateProgress,
+      clearProgress,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await controller.dispose();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(clearProgress).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/inbound-handler-card-streaming.test.ts
+++ b/tests/unit/inbound-handler-card-streaming.test.ts
@@ -304,6 +304,82 @@ describe("inbound-handler card streaming", () => {
       expect(shared.createAICardMock).toHaveBeenCalledTimes(1);
       expect(shared.commitAICardBlocksMock).toHaveBeenCalledTimes(1);
     });
+
+    it("updates the same card with sanitized runtime task progress before the final answer", async () => {
+      const runtime = buildRuntime() as ReturnType<typeof buildRuntime> & {
+        events: { onAgentEvent: (listener: (event: unknown) => void) => () => void };
+      };
+      let agentEventListener: ((event: unknown) => void) | undefined;
+      runtime.events = {
+        onAgentEvent: vi.fn((listener) => {
+          agentEventListener = listener;
+          return vi.fn();
+        }),
+      };
+      runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher = vi
+        .fn()
+        .mockImplementation(async ({ dispatcherOptions }) => {
+          agentEventListener?.({
+            stream: "lifecycle",
+            runId: "run-progress",
+            sessionKey: "s1",
+            data: { phase: "start" },
+          });
+          agentEventListener?.({
+            stream: "tool",
+            runId: "run-progress",
+            sessionKey: "s1",
+            data: {
+              phase: "start",
+              name: "exec",
+              toolCallId: "tool-progress",
+              args: { cmd: "curl -H 'Authorization: secret-token' https://example.com" },
+            },
+          });
+          await Promise.resolve();
+          await Promise.resolve();
+          await dispatcherOptions.deliver({ text: "完成" }, { kind: "final" });
+          return { queuedFinal: false };
+        });
+      shared.getRuntimeMock.mockReturnValueOnce(runtime);
+      shared.createAICardMock.mockResolvedValueOnce({
+        cardInstanceId: "card_progress",
+        state: "1",
+        lastUpdated: Date.now(),
+      });
+
+      await handleDingTalkMessage({
+        cfg: {},
+        accountId: "main",
+        sessionWebhook: "https://session.webhook",
+        log: undefined,
+        dingtalkConfig: {
+          dmPolicy: "open",
+          messageType: "card",
+          ackReaction: "",
+          cardStreamingMode: "answer",
+        } as unknown as DingTalkConfig,
+        data: {
+          msgId: "m_progress",
+          msgtype: "text",
+          text: { content: "执行一个长任务" },
+          conversationType: "1",
+          conversationId: "cid_ok",
+          senderId: "user_1",
+          chatbotUserId: "bot_1",
+          sessionWebhook: "https://session.webhook",
+          createAt: Date.now(),
+        },
+      } as unknown as { data: unknown });
+
+      const progressFrames = shared.updateAICardBlockListMock.mock.calls
+        .map((call) => String(call[1] ?? ""))
+        .filter((frame) => frame.includes("任务处理中"));
+      expect(progressFrames).not.toHaveLength(0);
+      expect(progressFrames.at(-1)).toContain("当前阶段：正在执行检查");
+      expect(progressFrames.at(-1)).not.toContain("secret-token");
+      expect(shared.commitAICardBlocksMock.mock.calls.at(-1)?.[1]?.content).toContain("完成");
+    });
   });
 
   describe("reasoning buffer assembly and flush", () => {

--- a/tests/unit/runtime-events-fanout.test.ts
+++ b/tests/unit/runtime-events-fanout.test.ts
@@ -28,4 +28,25 @@ describe("runtime events fanout", () => {
     unsubscribeSecond?.();
     expect(upstreamUnsubscribe).toHaveBeenCalledOnce();
   });
+
+  it("delivers the current event to a snapshot when a listener unsubscribes another listener", () => {
+    let upstreamListener: ((event: unknown) => void) | undefined;
+    const upstream = {
+      onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+        upstreamListener = listener;
+        return vi.fn();
+      }),
+    };
+    const fanout = createRuntimeEventsFanout(upstream);
+    const second = vi.fn();
+    let unsubscribeSecond: (() => void) | undefined;
+    const first = vi.fn(() => unsubscribeSecond?.());
+
+    fanout.onAgentEvent?.(first);
+    unsubscribeSecond = fanout.onAgentEvent?.(second);
+    upstreamListener?.({ stream: "tool" });
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/unit/runtime-events-fanout.test.ts
+++ b/tests/unit/runtime-events-fanout.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeEventsFanout } from "../../src/ack-reaction/dynamic-ack-reaction-events";
+
+describe("runtime events fanout", () => {
+  it("uses one upstream subscription while delivering events to multiple local consumers", () => {
+    let upstreamListener: ((event: unknown) => void) | undefined;
+    const upstreamUnsubscribe = vi.fn();
+    const upstream = {
+      onAgentEvent: vi.fn((listener: (event: unknown) => void) => {
+        upstreamListener = listener;
+        return upstreamUnsubscribe;
+      }),
+    };
+    const fanout = createRuntimeEventsFanout(upstream);
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const unsubscribeFirst = fanout.onAgentEvent?.(first);
+    const unsubscribeSecond = fanout.onAgentEvent?.(second);
+    upstreamListener?.({ stream: "tool" });
+
+    expect(upstream.onAgentEvent).toHaveBeenCalledOnce();
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+
+    unsubscribeFirst?.();
+    expect(upstreamUnsubscribe).not.toHaveBeenCalled();
+    unsubscribeSecond?.();
+    expect(upstreamUnsubscribe).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- add a replaceable live task-progress block to DingTalk AI Cards
- derive concise stages from correlated OpenClaw lifecycle/tool events
- refresh elapsed time every 30 seconds during quiet periods
- remove progress before normal finalization or abort handling
- fan out the runtime event stream so task progress and ACK reactions coexist

## User experience

Long-running tasks now keep one card updated with:

- current stage
- completed tool-step count
- elapsed time
- last update time

The progress block appears after 10 seconds, or immediately when a correlated tool starts. It is cleared before the final answer is committed.

## Security

Progress text is derived only from normalized tool names. Raw arguments, commands, tool output, URLs, tokens, and credentials are never rendered into the card.

## Validation

- `pnpm type-check`
- `pnpm lint` (0 errors; existing baseline warnings remain)
- `pnpm build`
- `pnpm test`: 127 files / 1265 tests passed
- deployed and probed on OpenClaw 2026.8.1 with DingTalk Stream connected

## Dependency / base branch

This PR intentionally targets `fix/openclaw-2026.8-sdk-compat` because the implementation was developed and verified on top of #601. Once #601 lands, the PR can be retargeted to `main` without including the compatibility commits in this feature diff.

Closes #604
