### PR TITLE
fix: use standalone formatInboundEnvelope from plugin-sdk/channel-inbound

### DIFF
--- a/src/inbound-handler.ts
+++ b/src/inbound-handler.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import * as path from "node:path";
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
 import { parseInlineDirectives } from "openclaw/plugin-sdk/text-runtime";
+import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
 import { normalizeAllowFrom, isSenderAllowed, resolveGroupAccess } from "./access-control";
 import { classifyAckReactionEmoji } from "./ack-reaction-classifier";
 import { attachNativeAckReaction } from "./ack-reaction-service";
@@ -1765,7 +1766,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
       targetId: data.conversationId,
       content,
     });
-    const envelopeOptions = rt.channel.reply.resolveEnvelopeFormatOptions(cfg);
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
     const previousTimestamp = rt.channel.session.readSessionUpdatedAt({
       storePath,
       sessionKey: route.sessionKey,
@@ -1792,7 +1793,7 @@ async function handleDingTalkMessageInner(params: HandleDingTalkMessageParams): 
     const groupMembers = !isDirect ? formatGroupMembers(storePath, groupId) : undefined;
 
     const fromLabel = isDirect ? `${senderName} (${senderId})` : `${groupName} - ${senderName}`;
-    const body = rt.channel.reply.formatInboundEnvelope({
+    const body = formatInboundEnvelope({
       channel: "DingTalk",
       from: fromLabel,
       timestamp: data.createAt,

--- a/tests/unit/inbound-handler-quote.test.ts
+++ b/tests/unit/inbound-handler-quote.test.ts
@@ -27,6 +27,8 @@ const shared = vi.hoisted(() => ({
   formatContentForCardMock: vi.fn((s: string) => s),
   sendProactiveMediaMock: vi.fn(),
   uploadMediaMock: vi.fn(),
+  formatInboundEnvelopeMock: vi.fn().mockReturnValue("body"),
+  resolveEnvelopeFormatOptionsMock: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock("../../src/runtime", () => ({
@@ -81,6 +83,11 @@ vi.mock("../../src/media-utils", async () => {
 vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   isAbortRequestText: shared.isAbortRequestTextMock,
   isBtwRequestText: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+  formatInboundEnvelope: shared.formatInboundEnvelopeMock,
+  resolveEnvelopeFormatOptions: shared.resolveEnvelopeFormatOptionsMock,
 }));
 
 vi.mock("../../src/message-context-store", async () => {
@@ -442,7 +449,7 @@ describe("inbound-handler quote handling", () => {
         },
       } as unknown as { data: unknown });
 
-      const envelopeArg = (runtime.channel.reply.formatInboundEnvelope as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      const envelopeArg = (shared.formatInboundEnvelopeMock as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
       expect(envelopeArg.body).toContain("我在讨论字符串 [引用消息:] 本身");
       expect(runtime.channel.reply.finalizeInboundContext).toHaveBeenCalledWith(
         expect.objectContaining({


### PR DESCRIPTION
## Problem

OpenClaw gateway v2026.8.1 moved `formatInboundEnvelope` and `resolveEnvelopeFormatOptions` from `rt.channel.reply` runtime methods to standalone exports in `openclaw/plugin-sdk/channel-inbound`.

The old `rt.channel.reply.formatInboundEnvelope()` path no longer exists, causing:

```
Error processing message: rt.channel.reply.formatInboundEnvelope is not a function
```

DingTalk messages are received and authorized, but fail at the envelope formatting step, so the bot never responds.

## Fix

Import `formatInboundEnvelope` and `resolveEnvelopeFormatOptions` directly from `openclaw/plugin-sdk/channel-inbound` instead of calling them via `rt.channel.reply.*`.

```diff
+import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";

-    const envelopeOptions = rt.channel.reply.resolveEnvelopeFormatOptions(cfg);
+    const envelopeOptions = resolveEnvelopeFormatOptions(cfg);

-    const body = rt.channel.reply.formatInboundEnvelope({...});
+    const body = formatInboundEnvelope({...});
```

Other `rt.channel.reply.*` calls (`finalizeInboundContext`, `dispatchReplyWithBufferedBlockDispatcher`) are unchanged — they still exist on the runtime.