### PR TITLE
fix(security): isolate SecretInput env resolution to authorized keys

### DIFF
--- a/docs/user/getting-started/configure.md
+++ b/docs/user/getting-started/configure.md
@@ -102,7 +102,30 @@ openclaw configure --section channels
 }
 ```
 
-插件把 SecretInput 交给 OpenClaw 宿主解析；文件路径来自 `secrets.providers`，不会把 `clientSecret.id` 当作路径读取。修改 provider 指向的文件后，建议重启 gateway，让 Stream 连接使用新的凭据。
+插件把 SecretInput 交给 OpenClaw 宿主解析；文件路径来自 `secrets.providers`，不会把 `clientSecret.id` 当作路径读取。
+
+`env` 引用会先经过宿主只读路径授权，插件只读取该引用对应的单个环境变量。推荐显式配置 `allowlist`：
+
+```json5
+{
+  "secrets": {
+    "providers": {
+      "env": {
+        "source": "env",
+        "allowlist": ["DINGTALK_CLIENT_SECRET"]
+      }
+    }
+  }
+}
+```
+
+**请务必配置 `allowlist`**：如果 env provider 省略 `allowlist`，宿主会认为它授权**任意**环境变量名。省略白名单不是更宽松的“默认拒绝”，而是“全量放行”。
+
+- 未授权（provider 不是 `source: "env"`，或 `allowlist` 存在但未包含该变量名）的 `env` 引用会在发起请求前直接报错
+- 已授权但变量未设置或为空同样会报错，失败原因会区分这两种情况
+- 修改 provider 指向的文件或 allowlist 后，建议重启 gateway，让 Stream 连接使用新的凭据
+
+> **宿主版本要求**：该解析路径依赖 OpenClaw `2026.8.1` 起的 `openclaw/plugin-sdk/secret-ref-readonly`，宿主低于该版本时插件无法加载。
 
 卡片模式示例：
 

--- a/docs/user/getting-started/update.md
+++ b/docs/user/getting-started/update.md
@@ -39,13 +39,24 @@ openclaw gateway restart
 
 使用推荐的独立仓库布局时，更新插件不需要改动本地 `openclaw` 主仓库。
 
+## 宿主版本要求
+
+插件已开始使用 OpenClaw `2026.8.1` 起提供的 `openclaw/plugin-sdk/secret-ref-readonly`，用于把 `clientSecret` 的 `env` 引用收敛为“只读取该引用对应的单个环境变量、读取前先做只读路径授权”。
+
+- 宿主低于 `2026.8.1`：插件会因缺少该 SDK 子路径而加载失败，请先升级 OpenClaw 宿主
+- 宿主为 `2026.8.1` 及以上：无需额外配置；使用 `env` 引用时**务必**在 `secrets.providers` 中显式配置 `allowlist`
+  - 省略 `allowlist` 会让该 env provider 授权**任意**环境变量名，等于没有白名单边界
+- 文件 provider 的密钥文件需要位于受信状态目录并满足宿主权限校验（2026.8 起不再接受 `allowInsecurePath`）
+
 ## 更新后建议检查
 
 1. 重新确认 `plugins.allow` 中仍包含 `dingtalk`
 2. 重启 gateway
 3. 查看变更说明或发布记录
+4. 如果使用了 `env` 类型的 SecretInput，确认 `secrets.providers` 中的 provider 已配置 `allowlist`，且覆盖了实际使用的变量名
 
 ## 相关文档
 
 - [配置](configure.md)
+- [安全策略](../reference/security-policies.md)
 - [发布记录](../../releases/index.md)

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -87,12 +87,21 @@ SecretInput 对象字段：
 - 获取 DingTalk access token 时，如果 token 缓存未命中，会解析 `clientSecret`
 - 启动 Stream 连接时，会为每个账号解析一次运行时凭据
 - 状态展示、配置向导展示等路径只显示规范化引用，不会解析密钥
-- 运行时解析统一委托给 OpenClaw SecretInput provider
 
 安全边界：
 
-- 插件不会把 SecretInput 的 `id` 当作环境变量或本地路径直接读取
-- 环境变量 allowlist、文件路径和访问策略由 `secrets.providers` 控制
+- `env` 引用通过宿主只读路径授权校验后才读取，且**只读取该引用对应的单个环境变量**，插件不会把整个 `process.env` 交给解析器
+- 授权规则与宿主一致：
+  - `secrets.providers.<provider>` 声明为 `source: "env"` 且 `allowlist` 包含该 `id` → 授权通过
+  - `secrets.providers.<provider>` 声明为 `source: "env"` 但**未配置 `allowlist`** → 该 provider 会对**任意** `id` 放行，等效于不做白名单限制
+  - `provider` 指向内置默认 env provider（未声明 `secrets.providers` 中的同名项）→ 按宿主内置默认规则判定
+  - 以上都不满足 → 判定为未授权，插件在发起任何 DingTalk 请求前抛本地错误
+- 强烈建议显式配置 `allowlist`：省略它会让该 provider 授权所有环境变量，等于放弃白名单边界
+- 授权通过但对应环境变量未设置或为空 → 判定为未解析，失败原因会区分“未授权”与“已授权但未设置”，便于定位
+- `file` 引用由 `secrets.providers` 的文件 provider 读取，插件不会把 `id` 当作本地路径
+- 文件 Provider 的路径与权限要求由 OpenClaw 宿主校验（2026.8 起不再接受 `allowInsecurePath`，密钥文件应放在受信状态目录下）
+
+> **宿主版本要求**：本改动使用了 OpenClaw 2026.8.1 起提供的 `openclaw/plugin-sdk/secret-ref-readonly`。宿主版本低于 2026.8.1 时插件无法加载，请先升级 OpenClaw 宿主。
 
 如果 SecretInput 解析失败，插件会在发起 DingTalk API 请求前抛出本地错误，并在日志中带上 `source` / `provider` / `id` / 失败原因，方便定位配置问题。
 

--- a/docs/user/reference/security-policies.md
+++ b/docs/user/reference/security-policies.md
@@ -59,13 +59,41 @@
 - 单个 IP
 - CIDR 网段
 
+## 凭据解析（SecretInput）
+
+`clientSecret` 支持普通的 `env` / `file` SecretInput 引用，解析过程遵循以下边界：
+
+- `env` 引用必须先通过宿主只读路径授权，规则与宿主完全一致：
+  - provider 在 `secrets.providers` 中声明为 `source: "env"` 且 `allowlist` 包含该 `id` → 通过
+  - provider 声明为 `source: "env"` 但**省略 `allowlist`** → 该 provider 对**任意** `id` 放行，**不做白名单限制**
+  - provider 是宿主内置的默认 env provider（`secrets.providers` 中无同名项）→ 按宿主内置默认规则判定
+  - 都不满足 → 未授权
+- 通过授权后，插件只读取该引用对应的**单个**环境变量；插件不会读取、也不会把整个 `process.env` 交给解析器
+- 未通过授权的引用判定为 blocked；已授权但变量未设置或为空判定为未解析。两者都在发起任何 DingTalk API 请求前抛出本地错误，并在日志中给出 `source` / `provider` / `id` 与对应的修复指引
+- `file` 引用只通过 `secrets.providers` 的文件 provider 读取，`id` 不会被当作本地路径；密钥文件需要位于受信状态目录并满足宿主权限校验
+
+> **务必显式配置 `allowlist`**：省略 `allowlist` 不是“更安全”，而是让该 env provider 授权所有环境变量名。
+
+## 环境变量读取范围
+
+插件**源码中直接读取**的环境变量限于两类，均为显式且非凭据用途或经授权的单键读取：
+
+| 环境变量 | 用途 | 说明 |
+| --- | --- | --- |
+| 经只读路径授权校验的单个 `env` SecretInput `id` | 解析 `clientSecret` | 每次只读取该引用对应的一个变量；是否授权及是否配置白名单见上一节 |
+| `DINGTALK_CARD_TEMPLATE_ID` | 覆盖内置 AI 卡片模板 ID | **非凭据例外**：该值是钉钉卡片模板 ID，不是密钥；默认值为内置模板，未设置时不读取任何其它变量 |
+
+除上述两类外，插件源码不直接读取宿主环境变量。底层库（例如 HTTP 客户端）可能会按自身约定读取代理类环境变量，这属于宿主既有行为，不受本插件控制。
+
 ## 适用建议
 
 - 对生产环境，优先最小化开放范围
 - 对高风险消息发送，优先显式目标 ID
 - 对 owner 命令与本地状态修改命令，明确限制来源
+- 使用 `env` 引用时，在 `secrets.providers` 中显式配置 `allowlist`，只放行需要的变量名
 
 ## 相关文档
 
 - [配置项参考](configuration.md)
+- [钉钉权限与凭证](../getting-started/permissions.md)
 - [消息类型支持](../features/message-types.md)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/node": "^25.2.0",
     "@vitest/coverage-v8": "^3.2.4",
     "esbuild": "^0.27.3",
-    "openclaw": "2026.7.1-2",
+    "openclaw": "2026.8.1",
     "oxfmt": "0.34.0",
     "oxlint": "1.49.0",
     "oxlint-tsgolint": "0.18.1",
@@ -85,7 +85,7 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.7.1-2"
+    "openclaw": ">=2026.8.1"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -94,10 +94,10 @@
   },
   "openclaw": {
     "compat": {
-      "pluginApi": ">=2026.7.1-2"
+      "pluginApi": ">=2026.8.1"
     },
     "build": {
-      "openclawVersion": "2026.7.1-2"
+      "openclawVersion": "2026.8.1"
     },
     "extensions": [
       "./index.ts"
@@ -123,7 +123,7 @@
       ]
     },
     "install": {
-      "minHostVersion": ">=2026.7.1-2",
+      "minHostVersion": ">=2026.8.1",
       "npmSpec": "@soimy/dingtalk",
       "localPath": ".",
       "defaultChoice": "npm"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^0.27.3
         version: 0.27.3
       openclaw:
-        specifier: 2026.7.1-2
-        version: 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.29)
+        specifier: 2026.8.1
+        version: 2026.8.1(@aws-sdk/credential-provider-node@3.972.29)
       oxfmt:
         specifier: 0.34.0
         version: 0.34.0
@@ -60,8 +60,8 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@1.1.0':
-    resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
+  '@agentclientprotocol/sdk@1.4.0':
+    resolution: {integrity: sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -145,8 +145,60 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@anthropic-ai/sdk@0.109.1':
-    resolution: {integrity: sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.239':
+    resolution: {integrity: sha512-GGVGuCwFEUm6cMlnBX0LTC9JX5NdGzxddbuqWtRxEgo9EetS70SO3FW+reitALlotHghPTfnICQILbBDIRyX+Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.239':
+    resolution: {integrity: sha512-QNbBXz3Pb3pQ7a+Kcbets6t9IrQhStKsfl5D518nYiGFoRMioO7efkZ6zHUcrGDqDC0LIzrs7tY2KNzH4RfwZA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.239':
+    resolution: {integrity: sha512-Ajc3cuszVdOwfMZVsGdxrCTmgWOeJpQWAIqu8jNEvERIeNnBxvWfGrjmLPxYT3/LJ9Uj/tFTpp52J4IcmrJE5w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.239':
+    resolution: {integrity: sha512-RE6tDtzU0xj58tsuxnlXMJO8ckJ4tx/1nUgR+D/fPEQVt84oOyXeVspKt1ffvycogh3Sr3MkCGwZrPmxu/V1nA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.239':
+    resolution: {integrity: sha512-zIUHiG4Romm/t6m/S9n8x4BKluyRCPk0147hPVo4xxkHkp4Di/7TnDMRKO3Wau4x361wRqlE2i5EpYT+CyJjHg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.239':
+    resolution: {integrity: sha512-q4YaDoPgqh0XM23RM1/Zje7OSKccuCTQE89KoppDFOsyGdRsUj5xr01LTtr5hnYQuZD7dfwAbz9zl1g0MF/7TA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.239':
+    resolution: {integrity: sha512-RxA29NdX9g3ZbpcXvSeWxpbg/Eoo3wXfO2eA1Vc7qa5JyAYjrl9xu6dIGAWMiyk/gnFxNh1WoFER77J9P6LTiQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.239':
+    resolution: {integrity: sha512-ylKIX0DfaK1EgWYbVEvBMYATVFdKjFcWvvypTIv2sJhM3KxJT/0lTzvqsai8jYeZN1FBHWlRNEUQJvJMjO/diA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.239':
+    resolution: {integrity: sha512-cIuZhK4u76S5Otq78U890GSA6BFT4SLqOuMqzU/bP/tWRWKhHhNp/3/pvgLwoVGlkdhD7luXWduqXKyLC+VNBQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.120.0':
+    resolution: {integrity: sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -296,12 +348,12 @@ packages:
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
-  '@clack/core@1.4.2':
-    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.6.0':
-    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@docsearch/css@3.8.2':
@@ -327,8 +379,8 @@ packages:
       search-insights:
         optional: true
 
-  '@earendil-works/pi-tui@0.80.3':
-    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
+  '@earendil-works/pi-tui@0.84.2':
+    resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
     engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -625,8 +677,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@google/genai@2.10.0':
-    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
+  '@google/genai@2.18.0':
+    resolution: {integrity: sha512-uy9gWVTAZXuA/2tld0QJl/QNiGEn4QOmfX4PiRgZQmeFQRQhojpD/Gf41SPnBJmjEnT83a+h4AdU1HHYaYvVDw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -646,11 +698,11 @@ packages:
     peerDependencies:
       grammy: ^1.0.0
 
-  '@grammyjs/types@3.28.0':
-    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
+  '@grammyjs/types@4.0.0':
+    resolution: {integrity: sha512-Z8lDLTvOlo12e5Vnly/vQh3JC9ppaitS1dGZ3w068gNitOd/y8tTSiib+Xm38aBGbtYGmUZwOc6afYrLs2CSTg==}
 
-  '@homebridge/ciao@1.3.9':
-    resolution: {integrity: sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==}
+  '@homebridge/ciao@1.3.12':
+    resolution: {integrity: sha512-84/0u0kqKy4qcKupIDaTtbkmk+3qFDuMzxTC0NPfVlHcUT+jHGdP+QCqwEw94/GJxRezDeBLwxaclkBZgCdeUg==}
     hasBin: true
 
   '@hono/node-server@1.19.11':
@@ -690,49 +742,133 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
-    resolution: {integrity: sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==}
+  '@koromix/koffi-darwin-arm64@3.1.6':
+    resolution: {integrity: sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lydell/node-pty-darwin-x64@1.2.0-beta.12':
-    resolution: {integrity: sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==}
+  '@koromix/koffi-darwin-x64@3.1.6':
+    resolution: {integrity: sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==}
     cpu: [x64]
     os: [darwin]
 
-  '@lydell/node-pty-linux-arm64@1.2.0-beta.12':
-    resolution: {integrity: sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==}
+  '@koromix/koffi-freebsd-arm64@3.1.6':
+    resolution: {integrity: sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.6':
+    resolution: {integrity: sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.6':
+    resolution: {integrity: sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.6':
+    resolution: {integrity: sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@lydell/node-pty-linux-x64@1.2.0-beta.12':
-    resolution: {integrity: sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==}
+  '@koromix/koffi-linux-ia32@3.1.6':
+    resolution: {integrity: sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    resolution: {integrity: sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    resolution: {integrity: sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    resolution: {integrity: sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==}
     cpu: [x64]
     os: [linux]
 
-  '@lydell/node-pty-win32-arm64@1.2.0-beta.12':
-    resolution: {integrity: sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==}
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    resolution: {integrity: sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    resolution: {integrity: sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    resolution: {integrity: sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==}
     cpu: [arm64]
     os: [win32]
 
-  '@lydell/node-pty-win32-x64@1.2.0-beta.12':
-    resolution: {integrity: sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==}
+  '@koromix/koffi-win32-ia32@3.1.6':
+    resolution: {integrity: sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    resolution: {integrity: sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==}
     cpu: [x64]
     os: [win32]
 
-  '@lydell/node-pty@1.2.0-beta.12':
-    resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
+  '@lydell/node-pty-darwin-arm64@1.2.0-beta.15':
+    resolution: {integrity: sha512-6TSBbzdcLiNTHl1mTuzflqXrkmcC36USVGvERoDgvHk2ItEDaMaFZuAJ1CqPmwYj0DyhCS16TVS8OGK9xZnjyQ==}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@mistralai/mistralai@2.4.0':
-    resolution: {integrity: sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==}
+  '@lydell/node-pty-darwin-x64@1.2.0-beta.15':
+    resolution: {integrity: sha512-yDT2oqPqYMBScyuk1U9Rg5VKcrbMOD9o9jWYYamDADA3NSbUISroPChrqYRQ74Y7BQtNH4gqYAiWOZRi5uQZ0Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@lydell/node-pty-linux-arm64@1.2.0-beta.15':
+    resolution: {integrity: sha512-wkbNF7dYAmtJv+o2+iztVlNwnUB4B0uX0wh/UD+mwMcmE2gNMnW9GChXO7fEE5XJokD0vB5idiHpGegaN+G/sg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@lydell/node-pty-linux-x64@1.2.0-beta.15':
+    resolution: {integrity: sha512-+U/5AVvHT6W+8OCYcnJgN0Qgc0ycO3TfD6aaFJHK+WHij797f8gsi5dV1HEO9l6YQmWCD+VL5gaLDhx3mxHwCA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@lydell/node-pty-win32-arm64@1.2.0-beta.15':
+    resolution: {integrity: sha512-pyAk91w7wnnKrD4mrHXtIXRfmzSWV5bEzvRhurXcMCtCc2TJ424ciUskIgWMhAPP6y3KyUnqElj+U6kY3iOt0A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@lydell/node-pty-win32-x64@1.2.0-beta.15':
+    resolution: {integrity: sha512-2f8twEmDVxZ7drchAXjtevpmSPhFok0avAnzXro4t5gmz0xsPNKkoZvymwtuIS3xo7PzQqZOPQ/YzwEMb7oIzQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lydell/node-pty@1.2.0-beta.15':
+    resolution: {integrity: sha512-Br8wBxzbxFwdWgk9uQ+rdzE0xfoxOK4QuGH54swhRwc5IxP6H9Y1/bcyazRGvNUs6XkB5qNVkezuKSRxUwZe7A==}
+
+  '@mistralai/mistralai@2.6.4':
+    resolution: {integrity: sha512-PPt4GyJqs2hEsWrYCJZK5f0ORmT+L2MSm75LVGD7kBLf6ZKsoDpld/FRBQXr8xG6iFCBOFJFYzvGYhUb+UCkbw==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/exporter-trace-otlp-http': ^0.220.0
+      '@opentelemetry/resources': ^2.9.0
+      '@opentelemetry/sdk-trace-base': ^2.9.0
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -814,19 +950,19 @@ packages:
     resolution: {integrity: sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==}
     engines: {node: '>= 10'}
 
-  '@openclaw/ai@2026.7.1-2':
-    resolution: {integrity: sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==}
+  '@openclaw/ai@2026.8.1':
+    resolution: {integrity: sha512-gUhfqsEZMRkgNZFegBMhKV5fw5OTziw+Pk2w0hOwOpNkT2W20VL2uS5Yz3ZbiC4snd5BQDBmmO33cVUgwr2aUg==}
     engines: {node: '>=22.19.0'}
 
-  '@openclaw/fs-safe@0.4.1':
-    resolution: {integrity: sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==}
+  '@openclaw/fs-safe@0.5.6':
+    resolution: {integrity: sha512-0M1vz1PEFAgCwTxhB1lt/B7z+TRTTWmlYJ3dSbdhjZp2AcfM7rXPGjQVJqHXpzpsb9SRxvKGrAM454Uul/Xy5g==}
     engines: {node: '>=22'}
 
-  '@openclaw/proxyline@0.3.3':
-    resolution: {integrity: sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==}
+  '@openclaw/proxyline@0.3.7':
+    resolution: {integrity: sha512-RWkt4mPcBOj7E8euyeqynkIFXvEIxVStYH0YHDC08feq5qFyBXGmfdWC+MTMVJXfHN2ituoxLlrIyjpyJpW7ew==}
     engines: {node: '>=22.19.0'}
     peerDependencies:
-      undici: '>=8.3.0 <9'
+      undici: '>=8.5.0 <9'
 
   '@opentelemetry/semantic-conventions@1.43.0':
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
@@ -1278,6 +1414,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1304,6 +1443,10 @@ packages:
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@smithy/config-resolver@4.4.13':
     resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
@@ -1483,6 +1626,41 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@trycua/cua-driver-darwin-arm64@0.21.0':
+    resolution: {integrity: sha512-wiQRixfS+zkakpcBI1zAfPQrE3slN1mozvkcFYgp0HufuzDuO/aShX+qLrTyw1a0MiKa7JjjyNdPXpJBE1wUiA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@trycua/cua-driver-darwin-x64@0.21.0':
+    resolution: {integrity: sha512-MFWkXLESSmr1LxE8FGwNWWUcZgZM+4kIFSPCV6uwy5W2ctSn5O/G4DrjjCAiuONRZzMpU0jlovcfQEB55Eje4g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@trycua/cua-driver-linux-arm64-gnu@0.21.0':
+    resolution: {integrity: sha512-Udb+CeHmogSndIR8yChucYPg70zFqAC595ykeXOWUOs+oGE2QN1a92uJRZSqCYtx1hi2MkLamW/tQksigJTFrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@trycua/cua-driver-linux-x64-gnu@0.21.0':
+    resolution: {integrity: sha512-CuT/FNR2/zShtIK6cSbIZVCUc6khlH88SgQi8w1mYjDx7xEDyuLxuoBhu9JRpMKDvj2EOf4bqlSUOBa4zJSSyA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@trycua/cua-driver-win32-arm64-msvc@0.21.0':
+    resolution: {integrity: sha512-qVwBJgsYHyhP/LZih0km+TJrVcV4vFB8h1URtcYgHgiZ+XdT/WwXzTAuB/34+gb2acyI2oddQPw/JQE3klM5Lw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@trycua/cua-driver-win32-x64-msvc@0.21.0':
+    resolution: {integrity: sha512-BTHCfX2t6ht6TsJxIBjBxF3FfkMVsuOuakOqCBRhE8eYbfhouqKHHF8dwwCtOKk6g1KJSOkYC83+Qkq2yuoVdQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@trycua/cua-driver@0.21.0':
+    resolution: {integrity: sha512-5oe8+1mm40pvMYSuXvPf5RTMPITgeGAUJhwQkkrL8nX57Goe2n5zs48q5e5kpT+jaGwGuxX4PotOn5UuNVSymA==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1518,6 +1696,56 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@ubjs/core@0.31.0-3':
+    resolution: {integrity: sha512-39XrJgUZ2VVb561sSnkXPhczNoeBsNiSRArecsV0JE7CJq69ajFkcn9/tBAUS2NpgHkLIDU+z6Ks2+1wXnboxg==}
+
+  '@ubjs/node-darwin-arm64@0.31.0-3':
+    resolution: {integrity: sha512-GGQVPLkVo4Gc8qVLW4IGvS8bjl8eHXyeP4a97ntGmsAdXwE5gsS29o8xUEFROjhwHKD+9sgVeblCSWVG3CpHsw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ubjs/node-darwin-x64@0.31.0-3':
+    resolution: {integrity: sha512-2sc47u4XFYOsbmP5EW+Gx8m/yGrYnfFDFQm6+kz7goSWTNg84eEiz3COs9HKJDVuNJ5Khv5XipTO8CFadMLXCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ubjs/node-linux-arm64-gnu@0.31.0-3':
+    resolution: {integrity: sha512-YStVXhYz/5jvlWf/p4fhiVT72unYAbGugifFC9QmO/+hnroQDAQ5t8SARbsc15G4olMcamdIB+GETiUB7gmaYg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ubjs/node-linux-arm64-musl@0.31.0-3':
+    resolution: {integrity: sha512-Izp4nvfy/LmibzFowAztkoDOksCR2fb2zl6fh1ojR1HEsg0rAGruxtI8d3fn8DI0lBXwqmn6SF///oD4mFNJPQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@ubjs/node-linux-x64-gnu@0.31.0-3':
+    resolution: {integrity: sha512-Xdm21blyg5U/kW6s7OMvgrr8coGTkUlt26DVR9x8gKISif+E3YwdEskbFScWqystAiJnfjw7xHEc8UMu0Qlz7Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ubjs/node-linux-x64-musl@0.31.0-3':
+    resolution: {integrity: sha512-fFQ9BWS6i2LUH9SJgD9oEiKXXo/say59vHy7usFe1t7C2xvwvP34f5SuxXmWP9R8fHyA0aC4kIZ+TTwyHSv1Kw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@ubjs/node-win32-arm64-msvc@0.31.0-3':
+    resolution: {integrity: sha512-ID6rSz1NmPsWTNBBNAw4OnJ5Dj8pcbtNJtdPB3OxcGigLBd/e0x7buhSI7os6Mo5iYtEdCynBRQHFJwub5XSPg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ubjs/node-win32-x64-msvc@0.31.0-3':
+    resolution: {integrity: sha512-wevs+Y+szwcCUT8IJFbB4/1nfxyRv/51l8oG7FGUPWD1xLPyuHfJBG27C+PDeC7KRzes/2n6aLo4DGZbr/LYTw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@ubjs/node@0.31.0-3':
+    resolution: {integrity: sha512-qNMpi2LICNwxGXZyRF8fSDBSpbezyZbEsydrbiMPJOmtOWr4tmZIEl7jkWGHVGShoBvHfFo4eHp5B4UVP928Cg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1667,6 +1895,11 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1744,8 +1977,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
 
   bottleneck@2.19.5:
     resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
@@ -1794,9 +2028,9 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+  chalk@6.0.0:
+    resolution: {integrity: sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==}
+    engines: {node: '>=22'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1816,9 +2050,9 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  clawpdf@0.3.0:
-    resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
-    engines: {node: '>=20'}
+  clawpdf@0.3.1:
+    resolution: {integrity: sha512-HZ8gz3cm8arzT/V2CnMZlHlRJbsrUYQ71u+A4nymeyvNnYzpZ8RQwkr2EIZiXCOzRkzFy8sOiHBXBuSUDDcXqQ==}
+    engines: {node: '>=22'}
     hasBin: true
 
   cliui@6.0.0:
@@ -1881,12 +2115,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-select@5.2.2:
-    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
 
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
@@ -1946,15 +2181,31 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -1996,6 +2247,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2055,6 +2310,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  execa@10.0.1:
+    resolution: {integrity: sha512-ge98qjkRK4IB7tL7Ju/6qmm5LHoH1eEMt5FNZrz3f4UIYhF28lggX20z3FaX1sgc67msLEn0N0BscOs29iuwyw==}
+    engines: {node: '>=22'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2110,8 +2369,12 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  file-type@22.0.1:
-    resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
+  file-type@22.0.2:
+    resolution: {integrity: sha512-0H8TsCUGBLx+V5adH3EY52hTAcyLKbV1D4gq5cIOJ6DnQAHeV9Z2Hhuc5CoBX4YmvB2oL+JIC84z0qO7JsCoNw==}
     engines: {node: '>=22'}
 
   finalhandler@2.1.1:
@@ -2186,14 +2449,14 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
-
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -2207,11 +2470,8 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  grammy@1.44.0:
-    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
+  grammy@1.45.1:
+    resolution: {integrity: sha512-Y4VL/hqJMZZxwlUr5ZgM68CFu2iIeEkNLR1cY3+Ww68CIvWARDsoXFix7+31rmyC0+7L85ZI+Pq3E5JSG5+nLQ==}
     engines: {node: ^12.20.0 || >=14.13.1}
 
   has-flag@4.0.0:
@@ -2236,8 +2496,8 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  highlight.js@11.11.1:
-    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+  highlight.js@11.12.0:
+    resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
     engines: {node: '>=12.0.0'}
 
   hono@4.12.9:
@@ -2275,15 +2535,19 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
   immediate@3.0.6:
@@ -2304,8 +2568,20 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
@@ -2380,15 +2656,18 @@ packages:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
 
-  kysely@0.29.2:
-    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
+  koffi@3.1.6:
+    resolution: {integrity: sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==}
+
+  kysely@0.29.5:
+    resolution: {integrity: sha512-ooa+eSbBNPTo3MycPEuW5jdrxQdQwdtB3LC3h43FiXQbIry5tR0C5lDG7eealK0E4D7XjrnOP5DIUg/LyjRMYQ==}
     engines: {node: '>=22.0.0'}
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
-  linkedom@0.18.12:
-    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+  linkedom@0.18.13:
+    resolution: {integrity: sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==}
     engines: {node: '>=16'}
     peerDependencies:
       canvas: '>= 2'
@@ -2488,8 +2767,8 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@9.0.6:
@@ -2555,8 +2834,13 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2576,8 +2860,9 @@ packages:
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
-  openai@6.45.0:
-    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+  openai@7.5.0:
+    resolution: {integrity: sha512-ZbDBz8FSB8Mv8fFYIUvzTFMdV5vl93/octp1MdtK2lfYepSpfv/ewmeugpKz/cwGtFSx+YuUM4NwpZ2P55YiPA==}
+    engines: {node: '>=22.0.0'}
     peerDependencies:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
@@ -2596,8 +2881,8 @@ packages:
       zod:
         optional: true
 
-  openclaw@2026.7.1-2:
-    resolution: {integrity: sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==}
+  openclaw@2026.8.1:
+    resolution: {integrity: sha512-bSaFeaDFnQH/bU1vgKMac6eHkHHPHG0C/uwduXGI3eIS3lyiYSwmDU5ehhBUUhlPeV85tL5/KVwmoH48nX1tWw==}
     engines: {node: '>=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0'}
     hasBin: true
 
@@ -2627,9 +2912,17 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@7.3.1:
+    resolution: {integrity: sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==}
+    engines: {node: '>=20'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
+    engines: {node: '>=18'}
 
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -2644,6 +2937,10 @@ packages:
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2668,13 +2965,13 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -2709,9 +3006,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@5.0.0:
@@ -2729,11 +3026,12 @@ packages:
   preact@10.29.0:
     resolution: {integrity: sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
-  proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -2758,15 +3056,15 @@ packages:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
-  quickjs-wasi@3.0.2:
-    resolution: {integrity: sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==}
+  quickjs-wasi@3.5.0:
+    resolution: {integrity: sha512-/4LKs62eqqqQyr0uVEgSvB3QeOlIpM0Wc4XPgomOfucVurDWssH2eNfDS0Y4NjQoIzoD8jVO7qWvR5drkgnRVg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  rastermill@0.3.1:
-    resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
+  rastermill@0.3.2:
+    resolution: {integrity: sha512-Qr4Q+PKsAyAPn4sHwY+hJ2P7rv+WJ4HZ8X+KjwVmm0tOpkb1IrtCb7sbwDZ8iJLUgiYafhmG4VHwo7Pjej0pgQ==}
     engines: {node: '>=22'}
 
   raw-body@3.0.2:
@@ -2800,10 +3098,6 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
-  retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
-
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -2831,6 +3125,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2880,9 +3179,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2975,6 +3271,10 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
@@ -2996,8 +3296,8 @@ packages:
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   test-exclude@7.0.1:
@@ -3058,16 +3358,16 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tslog@4.10.2:
-    resolution: {integrity: sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==}
+  tslog@4.11.0:
+    resolution: {integrity: sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==}
     engines: {node: '>=16'}
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typebox@1.3.3:
-    resolution: {integrity: sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==}
+  typebox@1.3.16:
+    resolution: {integrity: sha512-Jac8dgnin+g2p1w1v9sk92Wvp49ZqsmSgNhrXDK+RqrovsjiORMZvYZ8t8id9b9XQp6LMfaAwnIRSHGsM+3FMw==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3092,9 +3392,13 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3261,14 +3565,19 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-tree-sitter@0.26.10:
-    resolution: {integrity: sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==}
+  web-tree-sitter@0.26.12:
+    resolution: {integrity: sha512-fvqTNZQBGUgUgfP0mHw+iHf9Yf6bRQrp0A3pSf2v/hSKxkT1beCoIWoLVmlPL7O6dmySfSb/t1aJoJvrgTRStw==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-command@0.1.0:
+    resolution: {integrity: sha512-XZyoF5/5hZtXitIwzrU4NKK+Wtbb9aB9CezUEw2Q0wlYK8NUYQxC1rRXgNueYLtBAJwXIb+/tFVk4dozciNJMA==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -3310,8 +3619,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3358,6 +3667,14 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
+
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
@@ -3371,7 +3688,7 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.4.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
@@ -3492,7 +3809,46 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@anthropic-ai/sdk@0.109.1(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.239':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.239(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.120.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.239
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.239
+
+  '@anthropic-ai/sdk@0.120.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -3831,14 +4187,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
-  '@clack/core@1.4.2':
+  '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.6.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 1.4.2
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -3867,7 +4223,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@earendil-works/pi-tui@0.80.3':
+  '@earendil-works/pi-tui@0.84.2':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -4019,32 +4375,32 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.18.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.21.0
+      ws: 8.21.3
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@grammyjs/runner@2.0.3(grammy@1.44.0)':
+  '@grammyjs/runner@2.0.3(grammy@1.45.1)':
     dependencies:
       abort-controller: 3.0.0
-      grammy: 1.44.0
+      grammy: 1.45.1
 
-  '@grammyjs/transformer-throttler@1.2.1(grammy@1.44.0)':
+  '@grammyjs/transformer-throttler@1.2.1(grammy@1.45.1)':
     dependencies:
       bottleneck: 2.19.5
-      grammy: 1.44.0
+      grammy: 1.45.1
 
-  '@grammyjs/types@3.28.0': {}
+  '@grammyjs/types@4.0.0': {}
 
-  '@homebridge/ciao@1.3.9':
+  '@homebridge/ciao@1.3.12':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3
@@ -4092,44 +4448,89 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lydell/node-pty-darwin-arm64@1.2.0-beta.12':
+  '@koromix/koffi-darwin-arm64@3.1.6':
     optional: true
 
-  '@lydell/node-pty-darwin-x64@1.2.0-beta.12':
+  '@koromix/koffi-darwin-x64@3.1.6':
     optional: true
 
-  '@lydell/node-pty-linux-arm64@1.2.0-beta.12':
+  '@koromix/koffi-freebsd-arm64@3.1.6':
     optional: true
 
-  '@lydell/node-pty-linux-x64@1.2.0-beta.12':
+  '@koromix/koffi-freebsd-ia32@3.1.6':
     optional: true
 
-  '@lydell/node-pty-win32-arm64@1.2.0-beta.12':
+  '@koromix/koffi-freebsd-x64@3.1.6':
     optional: true
 
-  '@lydell/node-pty-win32-x64@1.2.0-beta.12':
+  '@koromix/koffi-linux-arm64@3.1.6':
     optional: true
 
-  '@lydell/node-pty@1.2.0-beta.12':
+  '@koromix/koffi-linux-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.6':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.6':
+    optional: true
+
+  '@lydell/node-pty-darwin-arm64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty-darwin-x64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty-linux-arm64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty-linux-x64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty-win32-arm64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty-win32-x64@1.2.0-beta.15':
+    optional: true
+
+  '@lydell/node-pty@1.2.0-beta.15':
     optionalDependencies:
-      '@lydell/node-pty-darwin-arm64': 1.2.0-beta.12
-      '@lydell/node-pty-darwin-x64': 1.2.0-beta.12
-      '@lydell/node-pty-linux-arm64': 1.2.0-beta.12
-      '@lydell/node-pty-linux-x64': 1.2.0-beta.12
-      '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
-      '@lydell/node-pty-win32-x64': 1.2.0-beta.12
+      '@lydell/node-pty-darwin-arm64': 1.2.0-beta.15
+      '@lydell/node-pty-darwin-x64': 1.2.0-beta.15
+      '@lydell/node-pty-linux-arm64': 1.2.0-beta.15
+      '@lydell/node-pty-linux-x64': 1.2.0-beta.15
+      '@lydell/node-pty-win32-arm64': 1.2.0-beta.15
+      '@lydell/node-pty-win32-x64': 1.2.0-beta.15
 
-  '@mistralai/mistralai@2.4.0':
+  '@mistralai/mistralai@2.6.4':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.43.0
-      ws: 8.21.0
+      ws: 8.21.3
       zod: 4.4.3
       zod-to-json-schema: 3.25.1(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0
@@ -4196,18 +4597,21 @@ snapshots:
       '@napi-rs/canvas-linux-x64-musl': 0.1.80
       '@napi-rs/canvas-win32-x64-msvc': 0.1.80
 
-  '@openclaw/ai@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.29)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@openclaw/ai@2026.8.1(@aws-sdk/credential-provider-node@3.972.29)(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
-      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@mistralai/mistralai': 2.4.0
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.0)(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.120.0(zod@4.4.3)
+      '@google/genai': 2.18.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.6.4
+      openai: 7.5.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.3)(zod@4.4.3)
       partial-json: 0.1.7
-      typebox: 1.3.3
+      typebox: 1.3.16
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - '@modelcontextprotocol/sdk'
       - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/resources'
+      - '@opentelemetry/sdk-trace-base'
       - '@smithy/hash-node'
       - '@smithy/signature-v4'
       - bufferutil
@@ -4216,14 +4620,14 @@ snapshots:
       - ws
       - zod
 
-  '@openclaw/fs-safe@0.4.1':
+  '@openclaw/fs-safe@0.5.6':
     optionalDependencies:
       jszip: 3.10.1
-      tar: 7.5.19
+      tar: 7.5.22
 
-  '@openclaw/proxyline@0.3.3(undici@8.5.0)':
+  '@openclaw/proxyline@0.3.7(undici@8.10.0)':
     dependencies:
-      undici: 8.5.0
+      undici: 8.10.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}
 
@@ -4460,6 +4864,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.58.0':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -4501,6 +4907,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@smithy/config-resolver@4.4.13':
     dependencies:
@@ -4824,6 +5232,36 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@trycua/cua-driver-darwin-arm64@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver-darwin-x64@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver-linux-arm64-gnu@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver-linux-x64-gnu@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver-win32-arm64-msvc@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver-win32-x64-msvc@0.21.0':
+    optional: true
+
+  '@trycua/cua-driver@0.21.0':
+    dependencies:
+      '@ubjs/core': 0.31.0-3
+      '@ubjs/node': 0.31.0-3
+    optionalDependencies:
+      '@trycua/cua-driver-darwin-arm64': 0.21.0
+      '@trycua/cua-driver-darwin-x64': 0.21.0
+      '@trycua/cua-driver-linux-arm64-gnu': 0.21.0
+      '@trycua/cua-driver-linux-x64-gnu': 0.21.0
+      '@trycua/cua-driver-win32-arm64-msvc': 0.21.0
+      '@trycua/cua-driver-win32-x64-msvc': 0.21.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4859,6 +5297,43 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
+
+  '@ubjs/core@0.31.0-3': {}
+
+  '@ubjs/node-darwin-arm64@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-darwin-x64@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-arm64-gnu@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-arm64-musl@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-x64-gnu@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-linux-x64-musl@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-win32-arm64-msvc@0.31.0-3':
+    optional: true
+
+  '@ubjs/node-win32-x64-msvc@0.31.0-3':
+    optional: true
+
+  '@ubjs/node@0.31.0-3':
+    optionalDependencies:
+      '@ubjs/node-darwin-arm64': 0.31.0-3
+      '@ubjs/node-darwin-x64': 0.31.0-3
+      '@ubjs/node-linux-arm64-gnu': 0.31.0-3
+      '@ubjs/node-linux-arm64-musl': 0.31.0-3
+      '@ubjs/node-linux-x64-gnu': 0.31.0-3
+      '@ubjs/node-linux-x64-musl': 0.31.0-3
+      '@ubjs/node-win32-arm64-msvc': 0.31.0-3
+      '@ubjs/node-win32-x64-msvc': 0.31.0-3
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -5041,6 +5516,8 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn@8.18.0: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
@@ -5128,7 +5605,7 @@ snapshots:
       content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
       qs: 6.15.0
       raw-body: 3.0.2
@@ -5136,7 +5613,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  boolbase@1.0.0: {}
+  boolbase@2.0.0: {}
 
   bottleneck@2.19.5: {}
 
@@ -5181,7 +5658,7 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
-  chalk@5.6.2: {}
+  chalk@6.0.0: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5195,7 +5672,7 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  clawpdf@0.3.0: {}
+  clawpdf@0.3.1: {}
 
   cliui@6.0.0:
     dependencies:
@@ -5250,15 +5727,15 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-select@5.2.2:
+  css-select@7.0.0:
     dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 5.0.3
-      domutils: 3.2.2
-      nth-check: 2.1.1
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
 
-  css-what@6.2.2: {}
+  css-what@8.0.0: {}
 
   cssom@0.5.0: {}
 
@@ -5306,17 +5783,35 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dotenv@17.4.2: {}
 
@@ -5349,6 +5844,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -5442,6 +5939,21 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  execa@10.0.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      which-command: 0.1.0
+      yoctocolors: 2.2.0
+
   expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
@@ -5521,7 +6033,11 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  file-type@22.0.1:
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
+
+  file-type@22.0.2:
     dependencies:
       '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.5
@@ -5618,6 +6134,11 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -5626,12 +6147,6 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      path-scurry: 2.0.2
 
   google-auth-library@10.6.2:
     dependencies:
@@ -5648,11 +6163,9 @@ snapshots:
 
   gopd@1.2.0: {}
 
-  graceful-fs@4.2.11: {}
-
-  grammy@1.44.0:
+  grammy@1.45.1:
     dependencies:
-      '@grammyjs/types': 3.28.0
+      '@grammyjs/types': 4.0.0
       abort-controller: 3.0.0
       debug: 4.4.3
       node-fetch: 2.7.0
@@ -5690,7 +6203,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  highlight.js@11.11.1: {}
+  highlight.js@11.12.0: {}
 
   hono@4.12.9: {}
 
@@ -5730,13 +6243,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  iconv-lite@0.7.2:
+  human-signals@8.0.1: {}
+
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   immediate@3.0.6: {}
 
@@ -5748,7 +6263,13 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-promise@4.0.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-what@5.5.0: {}
 
@@ -5827,15 +6348,33 @@ snapshots:
   jwt-decode@4.0.0:
     optional: true
 
-  kysely@0.29.2: {}
+  koffi@3.1.6:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.6
+      '@koromix/koffi-darwin-x64': 3.1.6
+      '@koromix/koffi-freebsd-arm64': 3.1.6
+      '@koromix/koffi-freebsd-ia32': 3.1.6
+      '@koromix/koffi-freebsd-x64': 3.1.6
+      '@koromix/koffi-linux-arm64': 3.1.6
+      '@koromix/koffi-linux-ia32': 3.1.6
+      '@koromix/koffi-linux-loong64': 3.1.6
+      '@koromix/koffi-linux-riscv64': 3.1.6
+      '@koromix/koffi-linux-x64': 3.1.6
+      '@koromix/koffi-openbsd-ia32': 3.1.6
+      '@koromix/koffi-openbsd-x64': 3.1.6
+      '@koromix/koffi-win32-arm64': 3.1.6
+      '@koromix/koffi-win32-ia32': 3.1.6
+      '@koromix/koffi-win32-x64': 3.1.6
+
+  kysely@0.29.5: {}
 
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
 
-  linkedom@0.18.12:
+  linkedom@0.18.13:
     dependencies:
-      css-select: 5.2.2
+      css-select: 7.0.0
       cssom: 0.5.0
       html-escaper: 3.0.3
       htmlparser2: 10.1.0
@@ -5939,7 +6478,7 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.8
 
@@ -5972,7 +6511,7 @@ snapshots:
   node-edge-tts@1.2.10:
     dependencies:
       https-proxy-agent: 7.0.6
-      ws: 8.21.0
+      ws: 8.21.3
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
@@ -5991,9 +6530,14 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  nth-check@2.1.1:
+  npm-run-path@6.0.0:
     dependencies:
-      boolbase: 1.0.0
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
 
   object-assign@4.1.1: {}
 
@@ -6013,68 +6557,78 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.0)(zod@4.4.3):
+  openai@7.5.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.3)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.29
-      ws: 8.21.0
+      ws: 8.21.3
       zod: 4.4.3
 
-  openclaw@2026.7.1-2(@aws-sdk/credential-provider-node@3.972.29):
+  openclaw@2026.8.1(@aws-sdk/credential-provider-node@3.972.29):
     dependencies:
-      '@agentclientprotocol/sdk': 1.1.0(zod@4.4.3)
-      '@anthropic-ai/sdk': 0.109.1(zod@4.4.3)
-      '@clack/core': 1.4.2
-      '@clack/prompts': 1.6.0
-      '@earendil-works/pi-tui': 0.80.3
-      '@google/genai': 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.44.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.44.0)
-      '@homebridge/ciao': 1.3.9
-      '@lydell/node-pty': 1.2.0-beta.12
-      '@mistralai/mistralai': 2.4.0
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
+      '@anthropic-ai/claude-agent-sdk': 0.3.239(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.120.0(zod@4.4.3)
+      '@clack/core': 1.4.3
+      '@clack/prompts': 1.7.0
+      '@earendil-works/pi-tui': 0.84.2
+      '@google/genai': 2.18.0(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))
+      '@grammyjs/runner': 2.0.3(grammy@1.45.1)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.45.1)
+      '@homebridge/ciao': 1.3.12
+      '@lydell/node-pty': 1.2.0-beta.15
+      '@mistralai/mistralai': 2.6.4
+      '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/ai': 2026.7.1-2(@aws-sdk/credential-provider-node@3.972.29)(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@openclaw/fs-safe': 0.4.1
-      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
+      '@openclaw/ai': 2026.8.1(@aws-sdk/credential-provider-node@3.972.29)(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(ws@8.21.3)(zod@4.4.3)
+      '@openclaw/fs-safe': 0.5.6
+      '@openclaw/proxyline': 0.3.7(undici@8.10.0)
       '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
+      '@trycua/cua-driver': 0.21.0
+      acorn: 8.18.0
+      chalk: 6.0.0
       chokidar: 5.0.0
-      clawpdf: 0.3.0
+      clawpdf: 0.3.1
       commander: 15.0.0
       croner: 10.0.1
       diff: 9.0.0
       dotenv: 17.4.2
+      entities: 8.0.0
+      execa: 10.0.1
       express: 5.2.1
-      file-type: 22.0.1
-      glob: 13.0.6
-      grammy: 1.44.0
-      highlight.js: 11.11.1
+      file-type: 22.0.2
+      grammy: 1.45.1
+      highlight.js: 11.12.0
       hosted-git-info: 10.1.1
-      ignore: 7.0.5
+      iconv-lite: 0.7.3
+      ignore: 7.0.6
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
-      kysely: 0.29.2
-      linkedom: 0.18.12
-      minimatch: 10.2.5
+      koffi: 3.1.6
+      kysely: 0.29.5
+      linkedom: 0.18.13
+      minimatch: 10.2.6
+      ms: 2.1.3
       node-edge-tts: 1.2.10
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.0)(zod@4.4.3)
+      openai: 7.5.0(@aws-sdk/credential-provider-node@3.972.29)(ws@8.21.3)(zod@4.4.3)
+      p-limit: 7.3.1
+      p-map: 7.0.6
       partial-json: 0.1.7
-      playwright-core: 1.61.1
-      proper-lockfile: 4.1.2
+      playwright-core: 1.62.1
+      pretty-ms: 9.3.0
       qrcode: 1.5.4
-      quickjs-wasi: 3.0.2
-      rastermill: 0.3.1
-      tar: 7.5.19
+      quickjs-wasi: 3.5.0
+      rastermill: 0.3.2
+      semver: 7.8.5
+      tar: 7.5.22
       tree-sitter-bash: 0.25.1
-      tslog: 4.10.2
-      typebox: 1.3.3
+      tslog: 4.11.0
+      typebox: 1.3.16
       typescript: 6.0.3
-      undici: 8.5.0
+      undici: 8.10.0
       web-push: 3.6.7
-      web-tree-sitter: 0.26.10
-      ws: 8.21.0
+      web-tree-sitter: 0.26.12
+      ws: 8.21.3
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
@@ -6083,6 +6637,9 @@ snapshots:
       - '@aws-sdk/credential-provider-node'
       - '@cfworker/json-schema'
       - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/resources'
+      - '@opentelemetry/sdk-trace-base'
       - '@smithy/hash-node'
       - '@smithy/signature-v4'
       - bufferutil
@@ -6154,9 +6711,15 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@7.3.1:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-map@7.0.6: {}
 
   p-retry@4.6.2:
     dependencies:
@@ -6168,6 +6731,8 @@ snapshots:
   package-json-from-dist@1.0.1: {}
 
   pako@1.0.11: {}
+
+  parse-ms@4.0.0: {}
 
   parseurl@1.3.3: {}
 
@@ -6182,14 +6747,11 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.7
       minipass: 7.1.3
 
   path-to-regexp@8.3.0: {}
@@ -6215,7 +6777,7 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.1: {}
 
   pngjs@5.0.0: {}
 
@@ -6233,13 +6795,11 @@ snapshots:
 
   preact@10.29.0: {}
 
-  process-nextick-args@2.0.1: {}
-
-  proper-lockfile@4.1.2:
+  pretty-ms@9.3.0:
     dependencies:
-      graceful-fs: 4.2.11
-      retry: 0.12.0
-      signal-exit: 3.0.7
+      parse-ms: 4.0.0
+
+  process-nextick-args@2.0.1: {}
 
   property-information@7.1.0: {}
 
@@ -6275,11 +6835,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  quickjs-wasi@3.0.2: {}
+  quickjs-wasi@3.5.0: {}
 
   range-parser@1.2.1: {}
 
-  rastermill@0.3.1:
+  rastermill@0.3.2:
     dependencies:
       '@silvia-odwyer/photon-node': 0.3.4
 
@@ -6287,7 +6847,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   readable-stream@2.3.8:
@@ -6317,8 +6877,6 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
-
-  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -6372,6 +6930,8 @@ snapshots:
   search-insights@2.17.3: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -6450,8 +7010,6 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
-
-  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -6536,6 +7094,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-final-newline@4.0.0: {}
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
@@ -6557,7 +7117,7 @@ snapshots:
 
   tabbable@6.4.0: {}
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -6609,7 +7169,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tslog@4.10.2: {}
+  tslog@4.11.0: {}
 
   type-is@2.0.1:
     dependencies:
@@ -6617,7 +7177,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.3.3: {}
+  typebox@1.3.16: {}
 
   typescript@5.9.3: {}
 
@@ -6631,7 +7191,9 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@8.5.0: {}
+  undici@8.10.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -6828,7 +7390,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-tree-sitter@0.26.10: {}
+  web-tree-sitter@0.26.12: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -6836,6 +7398,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-command@0.1.0: {}
 
   which-module@2.0.1: {}
 
@@ -6870,7 +7434,7 @@ snapshots:
 
   ws@8.19.0: {}
 
-  ws@8.21.0: {}
+  ws@8.21.3: {}
 
   xmlbuilder@10.1.1: {}
 
@@ -6912,6 +7476,10 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@1.2.2: {}
+
+  yoctocolors@2.2.0: {}
 
   zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:

--- a/scripts/verify-runtime-package.mjs
+++ b/scripts/verify-runtime-package.mjs
@@ -30,4 +30,16 @@ if (processExecutionCall.test(runtime)) {
     throw new Error("Runtime package must not include process execution calls");
 }
 
+// Secret resolvers must never receive the whole ambient environment: reading one
+// authorized variable at a time keeps credential ownership with the host.
+//
+// This is a shape heuristic against the exact fingerprint that ClawHub flagged
+// (Issue #608), not an exhaustive dataflow analysis: indirect forms such as
+// `env: { ...process.env }`, `const e = process.env; env: e`, or `env: process.env
+// as any` would not match, and a single-key read (`process.env[id]`) is allowed.
+const ambientEnvPassThrough = /\benv\s*:\s*process\.env\s*(?:,|\}|\))/u;
+if (ambientEnvPassThrough.test(runtime)) {
+    throw new Error("Runtime package must not pass the whole process.env to a secret resolver");
+}
+
 console.log(`Runtime package check passed: ${requiredFiles.join(", ")}`);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -98,13 +98,6 @@ export const dingtalkPlugin: DingTalkChannelPlugin = {
       }
       return config.groupPolicy !== "open";
     },
-    resolveGroupIntroHint: ({ groupId, groupChannel }: any): string | undefined => {
-      const parts = [`conversationId=${groupId}`];
-      if (groupChannel) {
-        parts.push(`sessionKey=${groupChannel}`);
-      }
-      return `DingTalk IDs: ${parts.join(", ")}.`;
-    },
   },
   messaging: {
     normalizeTarget: (raw: string) => (raw ? normalizeDingTalkTarget(raw) : undefined),

--- a/src/gateway/channel-gateway.ts
+++ b/src/gateway/channel-gateway.ts
@@ -1,5 +1,12 @@
 import { DWClient, TOPIC_CARD, TOPIC_ROBOT } from "dingtalk-stream";
 import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  deliveryContextFromSession,
+  sessionDeliveryChannel,
+  sessionDeliveryOrigin,
+  sessionDeliveryRoute,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import type { SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { analyzeCardCallback } from "../card-callback-service";
 import { finalizeActiveCardsForAccount, recoverPendingCardsForAccount } from "../card-service";
 import { recoverAskUserQuestionsForAccount } from "../card/ask-user-question";
@@ -46,6 +53,82 @@ type InstrumentedDWClient = {
   config?: Record<string, unknown> & { endpoint?: { endpoint?: string } | string };
   dw_url?: string;
 };
+
+/**
+ * Runtime read of a session entry that may still carry pre-`delivery`
+ * delivery fields.
+ *
+ * Session entries persist `origin` / `lastChannel` / `lastTo` / `lastAccountId`
+ * only until `openclaw doctor --fix` migrates them into the canonical
+ * `delivery` state, so both shapes can appear when the plugin scans an existing
+ * store. The index signature keeps legacy reads without reintroducing the
+ * retired fields into typed code paths.
+ */
+type SessionEntryWithLegacyDelivery = SessionEntry & Record<string, unknown>;
+
+function readLegacySessionString(
+  entry: SessionEntryWithLegacyDelivery,
+  key: string,
+): string | undefined {
+  const value = entry[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizeOptionalSessionString(value: string | undefined): string | undefined {
+  return value && value.length > 0 ? value : undefined;
+}
+
+function readLegacySessionOrigin(
+  entry: SessionEntryWithLegacyDelivery,
+  key: "provider" | "surface" | "accountId" | "from" | "to",
+): string | undefined {
+  const origin = entry.origin;
+  if (!origin || typeof origin !== "object") {
+    return undefined;
+  }
+  const value = (origin as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Reads one session entry's delivery identity across canonical and legacy shapes. */
+function readSessionDeliveryIdentity(entry: SessionEntry): {
+  channels: Array<string | undefined>;
+  accountId: string | undefined;
+  peerIds: Array<string | undefined>;
+} {
+  const legacy = entry as SessionEntryWithLegacyDelivery;
+  const origin = sessionDeliveryOrigin(entry);
+  const context = deliveryContextFromSession(entry);
+  const route = sessionDeliveryRoute(entry);
+  return {
+    channels: [
+      sessionDeliveryChannel(entry),
+      route?.channel,
+      context?.channel,
+      readLegacySessionString(legacy, "lastChannel"),
+      readLegacySessionString(legacy, "channel"),
+      origin?.provider,
+      origin?.surface,
+      readLegacySessionOrigin(legacy, "provider"),
+      readLegacySessionOrigin(legacy, "surface"),
+    ],
+    // Canonical `delivery.context` wins, then the pre-`delivery` fields. Empty
+    // strings fall through so the chain matches the original `||` semantics.
+    accountId:
+      normalizeOptionalSessionString(context?.accountId) ??
+      normalizeOptionalSessionString(readLegacySessionString(legacy, "lastAccountId")) ??
+      normalizeOptionalSessionString(origin?.accountId) ??
+      normalizeOptionalSessionString(readLegacySessionOrigin(legacy, "accountId")),
+    peerIds: [
+      context?.to,
+      readLegacySessionString(legacy, "lastTo"),
+      origin?.from,
+      origin?.to,
+      readLegacySessionOrigin(legacy, "from"),
+      readLegacySessionOrigin(legacy, "to"),
+    ],
+  };
+}
 
 function attachConnectionErrorContext(
   err: unknown,
@@ -205,17 +288,12 @@ export function createDingTalkGateway(): NonNullable<DingTalkChannelPlugin["gate
             storePath: sessionStorePath,
             readConsistency: "latest",
           })) {
-            const isDingTalkSession = [
-              entry.lastChannel,
-              entry.channel,
-              entry.origin?.provider,
-              entry.origin?.surface,
-            ].some((value) => value === "dingtalk");
-            const sessionAccountId = entry.lastAccountId || entry.origin?.accountId;
-            if (!isDingTalkSession || sessionAccountId !== account.accountId) {
+            const identity = readSessionDeliveryIdentity(entry);
+            const isDingTalkSession = identity.channels.some((value) => value === "dingtalk");
+            if (!isDingTalkSession || identity.accountId !== account.accountId) {
               continue;
             }
-            for (const peerId of [entry.lastTo, entry.origin?.from, entry.origin?.to]) {
+            for (const peerId of identity.peerIds) {
               if (typeof peerId !== "string" || !peerId.startsWith("cid")) {
                 continue;
               }

--- a/src/secret-input.ts
+++ b/src/secret-input.ts
@@ -1,8 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import {
+  coerceSecretRef,
   hasConfiguredSecretInput as hasConfiguredOpenClawSecretInput,
   resolveConfiguredSecretInputString,
 } from "openclaw/plugin-sdk/secret-input-runtime";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { z } from "zod";
 import { getDingTalkRuntime } from "./runtime";
 
@@ -28,6 +30,16 @@ type SecretInputLog = {
 const SECRET_INPUT_PROVIDER_PATTERN = /^[^:>]+$/;
 const SECRET_INPUT_ID_PATTERN = /^[^>]+$/;
 
+const SECRET_INPUT_PATH = "channels.dingtalk.clientSecret";
+
+function normalizeOptionalSecretString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
 function buildSecretInputFailure(
   value: SecretInputRef,
   reason: string,
@@ -37,6 +49,105 @@ function buildSecretInputFailure(
     provider: value.provider,
     id: value.id,
     reason,
+  };
+}
+
+/**
+ * Resolve one `env` SecretInput reference without handing the whole ambient
+ * environment to the host resolver.
+ *
+ * Mirrors the official channel pattern (`openclaw/plugin-sdk/secret-ref-readonly`):
+ * inspect the reference, require the host to authorize this provider/id for a
+ * read-only path, and only then read the single `process.env[id]`. The SDK's
+ * own `resolveReadOnlyEnvSecretRef` collapses "not authorized" and "authorized
+ * but the variable is unset" into one `blocked` status, which would tell an
+ * operator with a correct allowlist to change it; re-deriving the same checks
+ * here keeps the failure reason actionable. Both branches fail closed.
+ */
+function resolveEnvSecretInputRef(
+  value: SecretInputRef,
+  hostConfig: OpenClawConfig,
+): { value?: string; failure?: SecretInputResolutionFailure } {
+  const refLabel = `${value.source}:${value.provider}:${value.id}`;
+  const unresolved = (detail?: string) =>
+    buildSecretInputFailure(
+      value,
+      `${SECRET_INPUT_PATH} SecretRef is unresolved (${refLabel}).${detail ? ` ${detail}` : ""}`,
+    );
+
+  const ref = coerceSecretRef(value, hostConfig.secrets?.defaults);
+  if (!ref) {
+    return { failure: unresolved("SecretRef shape is not coercible.") };
+  }
+
+  if (ref.source !== "env") {
+    return {
+      failure: unresolved(
+        `Source "${ref.source}" is not usable from the DingTalk clientSecret env path.`,
+      ),
+    };
+  }
+
+  const providerConfig = hostConfig.secrets?.providers?.[ref.provider];
+  if (providerConfig && providerConfig.source !== "env") {
+    return {
+      failure: unresolved(
+        `Secret provider "${ref.provider}" has source "${providerConfig.source}" but the ref requests "env".`,
+      ),
+    };
+  }
+
+  if (
+    !canResolveEnvSecretRefInReadOnlyPath({
+      cfg: hostConfig,
+      provider: ref.provider,
+      id: ref.id,
+    })
+  ) {
+    return {
+      failure: unresolved(
+        `Environment variable "${value.id}" is not authorized for a read-only path: ` +
+          `set secrets.providers.${value.provider}.source to "env" and include ` +
+          `"${value.id}" in its allowlist.`,
+      ),
+    };
+  }
+
+  const envValue = normalizeOptionalSecretString(process.env[ref.id]);
+  if (envValue) {
+    return { value: envValue };
+  }
+  return {
+    failure: unresolved(`Environment variable "${value.id}" is authorized but unset or empty.`),
+  };
+}
+
+/**
+ * Resolve a `file` SecretInput reference with a scoped resolver call.
+ *
+ * The explicit empty `env` means this branch never reads ambient credentials.
+ * It does not stop the host from expanding a configured provider path (for
+ * example a leading `~`) against its own environment.
+ */
+async function resolveFileSecretInputRef(
+  value: SecretInputRef,
+  hostConfig: OpenClawConfig,
+): Promise<{ value?: string; failure?: SecretInputResolutionFailure }> {
+  const resolved = await resolveConfiguredSecretInputString({
+    config: hostConfig,
+    env: {},
+    value,
+    path: SECRET_INPUT_PATH,
+    unresolvedReasonStyle: "detailed",
+  });
+  if (resolved.value) {
+    return { value: resolved.value };
+  }
+  return {
+    failure: buildSecretInputFailure(
+      value,
+      resolved.unresolvedRefReason || "secret reference is unresolved",
+    ),
   };
 }
 
@@ -133,20 +244,15 @@ export async function resolveSecretInputStringWithFailure(
     }
   }
   try {
-    const resolved = await resolveConfiguredSecretInputString({
-      config: hostConfig,
-      env: process.env,
-      value,
-      path: "channels.dingtalk.clientSecret",
-      unresolvedReasonStyle: "detailed",
-    });
+    const resolved =
+      value.source === "env"
+        ? resolveEnvSecretInputRef(value, hostConfig)
+        : await resolveFileSecretInputRef(value, hostConfig);
     if (resolved.value) {
       return { value: resolved.value };
     }
-    const failure = buildSecretInputFailure(
-      value,
-      resolved.unresolvedRefReason || "secret reference is unresolved",
-    );
+    const failure =
+      resolved.failure ?? buildSecretInputFailure(value, "secret reference is unresolved");
     log?.warn?.("[DingTalk][SecretInput] Failed to resolve secret", {
       provider: value.provider,
       id: value.id,

--- a/tests/integration/gateway-start-flow.test.ts
+++ b/tests/integration/gateway-start-flow.test.ts
@@ -298,6 +298,37 @@ describe('gateway.startAccount lifecycle', () => {
         expect(resolveOriginalPeerId('cidunscoped+abc')).toBe('cidunscoped+abc');
     });
 
+    it('migrates sessions that only carry the canonical delivery state', async () => {
+        shared.storePath = mkdtempSync(join(tmpdir(), 'dingtalk-peer-registry-'));
+        shared.listSessionEntriesMock.mockReturnValue([
+            {
+                sessionKey: 'agent:main:dingtalk:group:cidcanonical+abc',
+                entry: {
+                    sessionId: 'canonical-session',
+                    updatedAt: 1000,
+                    delivery: {
+                        kind: 'external',
+                        route: { channel: 'dingtalk', accountId: 'main' },
+                        context: {
+                            channel: 'dingtalk',
+                            accountId: 'main',
+                            to: 'cidCanonical+AbC',
+                        },
+                        origin: {
+                            provider: 'dingtalk',
+                            surface: 'dingtalk',
+                            from: 'cidCanonical+AbC',
+                        },
+                    },
+                },
+            },
+        ]);
+
+        await startGatewayAccount(createStartContext().ctx);
+
+        expect(resolveOriginalPeerId('cidcanonical+abc')).toBe('cidCanonical+AbC');
+    });
+
     it('handles abort signal by stopping connection manager and setting stopped status', async () => {
         const controller = new AbortController();
         const { ctx, setStatusCalls } = createStartContext(controller.signal);

--- a/tests/unit/plugin-manifest.test.ts
+++ b/tests/unit/plugin-manifest.test.ts
@@ -140,9 +140,9 @@ describe("plugin manifest channel metadata", () => {
             };
         }>("package.json");
 
-        expect(packageJson.peerDependencies?.openclaw).toBe(">=2026.7.1-2");
-        expect(packageJson.openclaw?.compat?.pluginApi).toBe(">=2026.7.1-2");
-        expect(packageJson.openclaw?.build?.openclawVersion).toBe("2026.7.1-2");
-        expect(packageJson.openclaw?.install?.minHostVersion).toBe(">=2026.7.1-2");
+        expect(packageJson.peerDependencies?.openclaw).toBe(">=2026.8.1");
+        expect(packageJson.openclaw?.compat?.pluginApi).toBe(">=2026.8.1");
+        expect(packageJson.openclaw?.build?.openclawVersion).toBe("2026.8.1");
+        expect(packageJson.openclaw?.install?.minHostVersion).toBe(">=2026.8.1");
     });
 });

--- a/tests/unit/sdk-import-structure.test.ts
+++ b/tests/unit/sdk-import-structure.test.ts
@@ -87,9 +87,9 @@ describe("plugin-sdk import structure", () => {
                 };
             };
         };
-        expect(packageJson.devDependencies?.openclaw).toBe("2026.7.1-2");
+        expect(packageJson.devDependencies?.openclaw).toBe("2026.8.1");
         expect(packageJson.peerDependencies?.openclaw).toBeDefined();
-        expect(packageJson.peerDependencies?.openclaw).toBe(">=2026.7.1-2");
-        expect(packageJson.openclaw?.install?.minHostVersion).toBe(">=2026.7.1-2");
+        expect(packageJson.peerDependencies?.openclaw).toBe(">=2026.8.1");
+        expect(packageJson.openclaw?.install?.minHostVersion).toBe(">=2026.8.1");
     });
 });

--- a/tests/unit/secret-input-env-isolation.test.ts
+++ b/tests/unit/secret-input-env-isolation.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Verifies that DingTalk reads one allowlisted environment secret at a time
+ * through the host read-only guard instead of handing the whole ambient
+ * `process.env` object to the secret resolver.
+ *
+ * Only the host's configured/file resolver is mocked here; the read-only
+ * authorization guard (`canResolveEnvSecretRefInReadOnlyPath`) and the literal
+ * inspection path run against the real SDK.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolveConfiguredSecretInputStringMock = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/secret-input-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/secret-input-runtime")>();
+  return {
+    ...actual,
+    resolveConfiguredSecretInputString: (...args: unknown[]) =>
+      resolveConfiguredSecretInputStringMock(...args),
+  };
+});
+
+import {
+  resolveDingTalkSecretConfig,
+  resolveSecretInputStringWithFailure,
+} from "../../src/secret-input";
+
+const ALLOWLISTED_VAR = "DINGTALK_TEST_ALLOWLISTED_SECRET";
+const UNAUTHORIZED_VAR = "DINGTALK_TEST_UNAUTHORIZED_SECRET";
+const UNSET_VAR = "DINGTALK_TEST_UNSET_SECRET";
+
+describe("SecretInput env isolation", () => {
+  beforeEach(() => {
+    resolveConfiguredSecretInputStringMock.mockReset();
+    delete process.env[ALLOWLISTED_VAR];
+    delete process.env[UNAUTHORIZED_VAR];
+    delete process.env[UNSET_VAR];
+  });
+
+  function allowlistedConfig(id: string) {
+    return {
+      secrets: {
+        providers: {
+          env: { source: "env", allowlist: [id] },
+        },
+      },
+    };
+  }
+
+  it("reads one allowlisted env variable and returns its value", async () => {
+    process.env[ALLOWLISTED_VAR] = "  resolved-secret  ";
+
+    const resolved = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "env", id: ALLOWLISTED_VAR },
+      undefined,
+      allowlistedConfig(ALLOWLISTED_VAR) as any,
+    );
+
+    expect(resolved.value).toBe("resolved-secret");
+    expect(resolved.failure).toBeUndefined();
+    // The env branch never falls back to the file/config resolver.
+    expect(resolveConfiguredSecretInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the allowlist does not cover the variable", async () => {
+    process.env[ALLOWLISTED_VAR] = "ambient-secret";
+
+    const resolved = await resolveDingTalkSecretConfig(
+      {
+        clientId: "ding-client-id",
+        clientSecret: { source: "env", provider: "env", id: ALLOWLISTED_VAR },
+      },
+      undefined,
+    );
+
+    // The allowlist for this config covers a different id, so the ambient value is not used.
+    expect(resolved.clientSecret).toBeUndefined();
+    expect(resolved.clientSecretResolutionFailure).toMatchObject({
+      source: "env",
+      provider: "env",
+      id: ALLOWLISTED_VAR,
+    });
+    expect(resolveConfiguredSecretInputStringMock).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes an unauthorized variable from an authorized but unset one", async () => {
+    const unauthorized = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "env", id: UNAUTHORIZED_VAR },
+      undefined,
+      allowlistedConfig(ALLOWLISTED_VAR) as any,
+    );
+    const unset = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "env", id: UNSET_VAR },
+      undefined,
+      allowlistedConfig(UNSET_VAR) as any,
+    );
+
+    expect(unauthorized.failure?.reason).toContain("is not authorized for a read-only path");
+    expect(unset.failure?.reason).toContain("is authorized but unset or empty");
+    expect(unset.failure?.reason).not.toContain("include");
+  });
+
+  it("treats a whitespace-only variable as unset rather than resolved", async () => {
+    process.env[UNSET_VAR] = "   ";
+
+    const resolved = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "env", id: UNSET_VAR },
+      undefined,
+      allowlistedConfig(UNSET_VAR) as any,
+    );
+
+    expect(resolved.value).toBeUndefined();
+    expect(resolved.failure?.reason).toContain("is authorized but unset or empty");
+  });
+
+  it("accepts a built-in default env provider when no provider is declared", async () => {
+    process.env[ALLOWLISTED_VAR] = "default-provider-secret";
+
+    const resolved = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "default", id: ALLOWLISTED_VAR },
+      undefined,
+      {} as any,
+    );
+
+    expect(resolved.value).toBe("default-provider-secret");
+  });
+
+  it("rejects an env ref whose provider is declared with another source", async () => {
+    const resolved = await resolveSecretInputStringWithFailure(
+      { source: "env", provider: "local", id: ALLOWLISTED_VAR },
+      undefined,
+      {
+        secrets: {
+          providers: {
+            local: { source: "file", path: "/var/lib/openclaw/client-secret" },
+          },
+        },
+      } as any,
+    );
+
+    expect(resolved.value).toBeUndefined();
+    expect(resolved.failure?.reason).toContain('has source "file" but the ref requests "env"');
+  });
+
+  it("keeps file SecretInput resolution on a scoped resolver with an empty env", async () => {
+    resolveConfiguredSecretInputStringMock.mockResolvedValue({ value: "file-secret" });
+
+    const hostConfig = {
+      secrets: {
+        providers: {
+          local: { source: "file", path: "/var/lib/openclaw/client-secret", mode: "singleValue" },
+        },
+      },
+    };
+
+    const resolved = await resolveSecretInputStringWithFailure(
+      { source: "file", provider: "local", id: "value" },
+      undefined,
+      hostConfig as any,
+    );
+
+    expect(resolved.value).toBe("file-secret");
+    expect(resolveConfiguredSecretInputStringMock).toHaveBeenCalledTimes(1);
+
+    const call = resolveConfiguredSecretInputStringMock.mock.calls[0][0] as {
+      config: unknown;
+      env: unknown;
+    };
+    expect(call.config).toBe(hostConfig);
+    // An empty env keeps ambient variables out of the file branch.
+    expect(call.env).toEqual({});
+  });
+});

--- a/tests/unit/secret-input.test.ts
+++ b/tests/unit/secret-input.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -14,15 +14,37 @@ import {
 
 describe("SecretInput support", () => {
   let tempDir: string | undefined;
+  let previousStateDir: string | undefined;
 
   afterEach(async () => {
     delete process.env.DINGTALK_TEST_SECRET;
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    previousStateDir = undefined;
     if (tempDir) {
       const dir = tempDir;
       tempDir = undefined;
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  /**
+   * Host SDK 2026.8+ requires file SecretRef payloads to live under the trusted
+   * state dir with strict permissions (`allowInsecurePath` was removed), so the
+   * fixture points OPENCLAW_STATE_DIR at the temp dir instead of /tmp directly.
+   */
+  async function createSecureSecretFixture(): Promise<string> {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    tempDir = await mkdtemp(join(tmpdir(), "dingtalk-secret-input-"));
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    const secretPath = join(tempDir, "client-secret.txt");
+    await writeFile(secretPath, "secret-from-file\n", { encoding: "utf8", mode: 0o600 });
+    await chmod(secretPath, 0o600);
+    return secretPath;
+  }
 
   it("accepts SecretInput references in the DingTalk config schema", () => {
     const parsed = DingTalkConfigSchema.parse({
@@ -92,9 +114,7 @@ describe("SecretInput support", () => {
   });
 
   it("resolves file SecretInput values from a local file", async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "dingtalk-secret-input-"));
-    const secretPath = join(tempDir, "client-secret.txt");
-    await writeFile(secretPath, "secret-from-file\n", "utf8");
+    const secretPath = await createSecureSecretFixture();
 
     await expect(
       resolveSecretInputString(
@@ -111,7 +131,6 @@ describe("SecretInput support", () => {
                 source: "file",
                 path: secretPath,
                 mode: "singleValue",
-                allowInsecurePath: true,
               },
             },
           },
@@ -138,16 +157,63 @@ describe("SecretInput support", () => {
     );
 
     expect(result.value).toBeUndefined();
-    expect(result.failure).toEqual({
-      source: "env",
-      provider: "env",
-      id: "DINGTALK_MISSING_SECRET",
-      reason:
-        "channels.dingtalk.clientSecret SecretRef is unresolved (env:env:DINGTALK_MISSING_SECRET).",
-    });
-    expect(formatSecretInputResolutionFailure(result.failure!)).toBe(
-      "env:env:DINGTALK_MISSING_SECRET - channels.dingtalk.clientSecret SecretRef is unresolved (env:env:DINGTALK_MISSING_SECRET).",
+    expect(result.failure?.source).toBe("env");
+    expect(result.failure?.provider).toBe("env");
+    expect(result.failure?.id).toBe("DINGTALK_MISSING_SECRET");
+    // Allowlisted but unset must not be reported as a missing allowlist entry.
+    expect(result.failure?.reason).toBe(
+      "channels.dingtalk.clientSecret SecretRef is unresolved (env:env:DINGTALK_MISSING_SECRET). " +
+        `Environment variable "DINGTALK_MISSING_SECRET" is authorized but unset or empty.`,
     );
+    expect(formatSecretInputResolutionFailure(result.failure!)).toBe(
+      "env:env:DINGTALK_MISSING_SECRET - channels.dingtalk.clientSecret SecretRef is unresolved (env:env:DINGTALK_MISSING_SECRET). " +
+        `Environment variable "DINGTALK_MISSING_SECRET" is authorized but unset or empty.`,
+    );
+  });
+
+  it("resolves an allowlisted env SecretInput value from the environment", async () => {
+    process.env.DINGTALK_TEST_SECRET = "secret-from-env";
+
+    await expect(
+      resolveSecretInputString(
+        {
+          source: "env",
+          provider: "env",
+          id: "DINGTALK_TEST_SECRET",
+        },
+        undefined,
+        {
+          secrets: {
+            providers: {
+              env: { source: "env", allowlist: ["DINGTALK_TEST_SECRET"] },
+            },
+          },
+        } as any,
+      ),
+    ).resolves.toBe("secret-from-env");
+  });
+
+  it("refuses an env SecretInput value that the allowlist does not cover", async () => {
+    process.env.DINGTALK_TEST_SECRET = "ambient-secret";
+
+    const result = await resolveSecretInputStringWithFailure(
+      {
+        source: "env",
+        provider: "env",
+        id: "DINGTALK_TEST_SECRET",
+      },
+      undefined,
+      {
+        secrets: {
+          providers: {
+            env: { source: "env", allowlist: ["SOME_OTHER_SECRET"] },
+          },
+        },
+      } as any,
+    );
+
+    expect(result.value).toBeUndefined();
+    expect(result.failure?.reason).toContain("is not authorized for a read-only path");
   });
 
   it("does not treat a file SecretInput id as a local path", async () => {

--- a/tests/unit/verify-runtime-package.test.ts
+++ b/tests/unit/verify-runtime-package.test.ts
@@ -23,15 +23,7 @@ export { match };
 `);
 
         expect(() => {
-            execFileSync(process.execPath, [scriptPath], {
-                cwd: packageDir,
-                encoding: "utf8",
-                env: {
-                    ...process.env,
-                    npm_config_cache: join(packageDir, ".npm-cache"),
-                },
-                stdio: ["ignore", "pipe", "pipe"],
-            });
+            runVerification(packageDir);
         }).not.toThrow();
     });
 
@@ -41,15 +33,7 @@ exec("open https://example.com");
 `);
 
         expect(() => {
-            execFileSync(process.execPath, [scriptPath], {
-                cwd: packageDir,
-                encoding: "utf8",
-                env: {
-                    ...process.env,
-                    npm_config_cache: join(packageDir, ".npm-cache"),
-                },
-                stdio: ["ignore", "pipe", "pipe"],
-            });
+            runVerification(packageDir);
         }).toThrow("Runtime package must not include process execution calls");
     });
 
@@ -63,17 +47,51 @@ exec("open https://example.com");
         writeJson(join(packageDir, "package.json"), packageJson);
 
         expect(() => {
-            execFileSync(process.execPath, [scriptPath], {
-                cwd: packageDir,
-                encoding: "utf8",
-                env: {
-                    ...process.env,
-                    npm_config_cache: join(packageDir, ".npm-cache"),
-                },
-                stdio: ["ignore", "pipe", "pipe"],
-            });
+            runVerification(packageDir);
         }).toThrow("Runtime package must not include source maps");
     });
+
+    it("rejects passing the whole process.env to a secret resolver", () => {
+        const packageDir = createRuntimePackageFixture(`
+const resolved = await resolveConfiguredSecretInputString({
+  config: hostConfig,
+  env: process.env,
+  value,
+  path: "channels.dingtalk.clientSecret",
+});
+export { resolved };
+`);
+
+        expect(() => {
+            runVerification(packageDir);
+        }).toThrow("Runtime package must not pass the whole process.env to a secret resolver");
+    });
+
+    it("allows reading a single allowlisted environment variable", () => {
+        const packageDir = createRuntimePackageFixture(`
+const templateId = process.env.DINGTALK_CARD_TEMPLATE_ID || "builtin.schema";
+function readSecret(id) {
+  return process.env[id];
+}
+export { templateId, readSecret };
+`);
+
+        expect(() => {
+            runVerification(packageDir);
+        }).not.toThrow();
+    });
+
+    function runVerification(packageDir: string): void {
+        execFileSync(process.execPath, [scriptPath], {
+            cwd: packageDir,
+            encoding: "utf8",
+            env: {
+                ...process.env,
+                npm_config_cache: join(packageDir, ".npm-cache"),
+            },
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+    }
 
     function createRuntimePackageFixture(runtimeCode: string): string {
         tempDir = mkdtempSync(join(tmpdir(), "dingtalk-runtime-package-"));


### PR DESCRIPTION
## 背景

ClawHub 对 `@soimy/dingtalk v3.6.11` 的安全审核结论为 `Review / suspicious`，其中明确的静态触发点是 [`Issue #608`](https://github.com/soimy/openclaw-channel-dingtalk/issues/608) 记录的第一项：

```text
Code: suspicious.env_credential_access
Location: dist/index.js:94
Evidence: env: process.env,
```

根因是 `src/secret-input.ts` 把**整个** `process.env` 交给 OpenClaw 宿主的 SecretInput 解析器：

```ts
resolveConfiguredSecretInputString({
  config: hostConfig,
  env: process.env,   // 整对象透传：静态规则无法与“环境变量外传”区分
  value,
  path: "channels.dingtalk.clientSecret",
});
```

运行时虽然由宿主的 env provider 做校验，并不存在越权读取，但代码形态与官方频道（Feishu / Telegram）的“只读路径”实现不一致，静态扫描无法区分。

## 目标

1. 对齐 OpenClaw 官方频道的 SecretInput 做法：只读取**该引用对应的单个环境变量**，读取前先做只读路径授权，不再透传整个 `process.env`。
2. 未授权引用必须在**发起任何 DingTalk 网络请求之前**本地失败，并给出与真实原因一致的修复指引。
3. `file` 类型的 SecretInput 引用行为保持不变。
4. 增加构建产物守卫，防止该形态回归。

本次范围严格限定在 Issue #608 的第 1 项（含同源的 `process.env` 静态指纹）。第 2–4 项（媒体本机路径边界、docs/send RPC capability gate、`dmPolicy`/`groupPolicy` 默认值）不在本 PR 范围内，另行跟踪。

## 实现

### 凭据解析隔离（`src/secret-input.ts`）

- `env` 引用改为：`coerceSecretRef` 归一化引用 → `openclaw/plugin-sdk/secret-ref-readonly` 的 `canResolveEnvSecretRefInReadOnlyPath` 做只读路径授权 → 通过后仅读取 `process.env[ref.id]`。
- 授权规则与宿主完全一致：provider 为 `source: "env"` 且 `allowlist` 包含该 `id`；provider 为宿主内置默认 env provider；**注意：env provider 省略 `allowlist` 时对任意 `id` 放行**。
- 失败原因区分三类，避免误导：
  - 未授权 → 提示配置 `source: "env"` 并把变量名加入 `allowlist`
  - 已授权但变量未设置或为空 → 明确提示“is authorized but unset or empty”
  - provider 声明的 `source` 与引用不匹配 / 引用形状不可归一化 → 各自给出对应原因
- （不使用 SDK 的 `resolveReadOnlyEnvSecretRef` 直接返回 `blocked`，是因为它把“未授权”与“已授权但变量未设置”折叠成同一状态，会让 allowlist 配置正确的用户按错误指引排查。）
- `file` 引用继续走 `resolveConfiguredSecretInputString`，但显式传入 `env: {}`，该分支不读取环境变量。
- `source: "exec"` 仍被 schema 与 `isSecretInputRef` 拒绝，行为不变。

### 宿主版本门槛（`package.json`）

`openclaw/plugin-sdk/secret-ref-readonly` 自 OpenClaw **2026.8.1** 起公开导出，因此最低宿主版本从 `2026.7.1-2` 抬到 `2026.8.1`：

| 字段 | 变更 |
| --- | --- |
| `peerDependencies.openclaw` | `>=2026.8.1` |
| `openclaw.compat.pluginApi` | `>=2026.8.1` |
| `openclaw.install.minHostVersion` | `>=2026.8.1` |
| `openclaw.build.openclawVersion` / `devDependencies.openclaw` | `2026.8.1` |

> **破坏性变更**：宿主低于 2026.8.1 时插件会因缺少该 SDK 子路径而加载失败，需要 minor 发布说明。

### 2026.8 类型面适配（抬门槛的连带成本）

devDependency 抬到 2026.8.1 后，`tsc` 会暴露两处与本 issue 无关的既有不兼容，已一并修复：

- `src/channel.ts`：移除 `ChannelGroupAdapter.resolveGroupIntroHint`。宿主已在上游 commit `d2b6573690e`（PR `#113533`）删除该 hook，且 core 从未消费该 adapter，该字段此前即为死代码，仓库内已无引用。
- `src/gateway/channel-gateway.ts`：历史会话扫描改从 canonical `delivery` 状态读取投递身份（`sessionDeliveryChannel` / `deliveryContextFromSession` / `sessionDeliveryOrigin` / `sessionDeliveryRoute`），并保留对尚未被 `openclaw doctor --fix` 迁移的旧字段（`origin` / `lastChannel` / `lastTo` / `lastAccountId`）的运行时兼容读取，且沿用原有 `||` 语义（空串继续向后回退），避免升级后历史群的 peer 恢复能力丢失。

### 构建产物守卫（`scripts/verify-runtime-package.mjs`）

新增检查：构建产物命中 `env: process.env` 形态即失败。这是针对 Issue #608 指纹的**形态检查**（已在注释中说明它不做完整数据流分析，`env: { ...process.env }` 之类的间接写法不会命中），单键读取不受影响。修复后 `dist/index.js` 中的环境变量读取只剩两处：

```js
// 经授权校验的单个 SecretInput id
const envValue = normalizeOptionalSecretString(process.env[ref.id]);
// 非凭据模板 ID 例外
var BUILTIN_DINGTALK_CARD_TEMPLATE_ID = process.env.DINGTALK_CARD_TEMPLATE_ID || "675cde2f-f526-40cb-b828-f5b2b57b8b77.schema";
```

`docs/user/reference/security-policies.md` 新增“环境变量读取范围”一节，把上述两处登记为插件源码中的**直接读取**（底层 HTTP 客户端按自身约定读取代理类环境变量属于宿主既有行为），便于 ClawHub 复核时逐条对照。

## 实现 TODO

- [x] `src/secret-input.ts` 改为“归一化 → 只读路径授权 → 单键读取”，并区分失败原因
- [x] 抬升宿主版本门槛并同步 4 处声明与锁定文件
- [x] 适配 2026.8 类型面（`resolveGroupIntroHint`、session `delivery`）
- [x] 构建产物守卫 + 正反用例
- [x] 单元/集成测试：授权通过、未授权、已授权但未设置、白名单外变量、内置默认 provider、provider source 不匹配、file 分支空 env、canonical `delivery` 历史会话迁移
- [x] 更新安全文档、配置文档与更新文档，并修正 allowlist 语义描述
- [ ] 发布说明（版本号待维护者确定；属于破坏性变更，建议 minor）

## 验证 TODO

- [x] `pnpm run type-check`
- [x] `pnpm run lint`（0 error，90 warning，与 main 基线一致）
- [x] `pnpm test`（127 files / 1274 tests 全绿）
- [x] `pnpm run build:runtime` + `pnpm run build:types` + `pnpm run pack:check`
- [x] `grep -n "process.env" dist/index.js` 仅剩“经授权单键读取”与卡片模板 ID 两处，`env: process.env` 已消失
- [x] 独立子代理按验收标准复核实现（发现的两项问题——失败原因误导与文档高估 allowlist 门槛——已在本 PR 内修复）
- [ ] 真实设备验证（`pnpm run build:runtime` 后 `openclaw gateway restart`）：分别用 allowlist 命中的 `env` 引用、`file` 引用各跑一次消息收发，确认凭据解析与 Stream 连接正常
- [ ] 未授权 `env` 引用（allowlist 存在但未包含变量名）确认真实环境下在发起请求前报错
- [ ] 发布后复查 ClawHub 审核页面，确认 `dist/index.js:94` 的 `suspicious.env_credential_access` 证据消失

## 备注

- 本 PR 不含版本号变更与 `docs/releases/` 发布说明，按仓库发布流程由维护者在发布提交中处理（`release-process.md` / `npm-publish.md`）。
- 测试侧需注意：宿主 2026.8 起移除了 `allowInsecurePath`，文件 SecretRef 的 fixture 因此改为落在 `OPENCLAW_STATE_DIR` 指向的受信目录（原 /tmp 直接路径在新宿主上会被宿主拒绝）。
- 复核用到的宿主语义依据（已在本机安装的 2026.8.1 SDK 中逐条确认）：`secret-ref-readonly.internal` 的 `!allowlist || allowlist.includes(id)`；`secret-ref-readonly` 的 `blocked` 同时覆盖未授权与已授权未设置。
