### PR TITLE
feat(gateway): add capability gates for docs and proactive-send RPCs

### DIFF
--- a/docs/spec/issue-608-gateway-docs-send-gate.md
+++ b/docs/spec/issue-608-gateway-docs-send-gate.md
@@ -1,0 +1,112 @@
+# Spec: 收窄 Gateway docs RPC 与主动发送的授权边界（Issue #608 问题 3）
+
+## 背景
+
+ClawHub 安全审核（v3.6.11）的 LLM 分析将 `gateway-docs-and-send-rpc` 列为风险项：插件通过 `index.ts` 注册了
+
+- `dingtalk.docs.create / append / search / list`（及 `dingtalk-connector.docs.*` 别名）
+- `dingtalk-connector.sendToUser / sendToGroup / send`
+
+这些 RPC 直接使用配置中的钉钉应用凭证执行文档读写和主动发消息，插件自身没有任何细粒度的调用方授权、文档空间限制或能力开关。
+
+对照官方仓库 `DingTalk-Real-AI/dingtalk-openclaw-connector`：
+
+1. **官方 connector 同样没有对 docs/send RPC 做调用方鉴权**——`src/gateway-methods.ts` 中 docs.read/create/append/search 与 sendToUser/sendToGroup 只做"clientId 已配置 + 参数必填"检查，之后即用应用凭证直接调用钉钉 API。也就是说宿主 Gateway 层的信任模型（能连上 Gateway RPC 的调用方即为可信）是两边共同的基线，这一点在审核材料中应当显式说明。
+2. **官方 connector 提供了能力开关**：`src/config/schema.ts` 中定义了 `DingtalkToolsConfigSchema`：
+
+   ```ts
+   const DingtalkToolsConfigSchema = z.object({
+     docs: z.boolean().optional(),  // 文档操作（默认 true）
+     media: z.boolean().optional(), // 媪体上传（默认 true）
+   }).strict();
+   ```
+
+   虽然当前 gateway-methods 并未全部消费该开关，但它给出了可对齐的配置形态：**capability gate 以 `tools.{docs,media}` 布尔开关呈现，默认开启、可显式关闭**。
+3. **官方 connector 的 docs.read 要求 `operatorId`**（unionId/staffId），把"以谁的身份读文档"交给调用方显式声明，避免插件默认用机器人身份遍历空间；本插件的 docs RPC 无此概念。
+
+## 问题
+
+本插件 `index.ts` 的 docs RPC 与 connector 兼容发送 RPC：
+
+- 没有任何插件级 capability/config gate，无法关闭；
+- 没有文档空间（spaceId）白名单；
+- 没有主动发送目标（user:/group:）白名单；
+- 审核材料/文档中未说明其依赖宿主 Gateway 信任模型与所需钉钉权限。
+
+## 目标
+
+1. docs RPC 与主动发送 RPC 可通过配置显式关闭（capability gate）。
+2. 可选的空间/目标白名单，收窄默认影响面。
+3. 行为向后兼容：默认开启（与官方 connector 的 `tools.docs 默认 true` 对齐），避免破坏现有 cron/agent 调用方。
+4. 文档中清楚说明信任模型与所需钉钉权限，供 ClawHub 审核材料引用。
+
+## 方案
+
+### 1. 配置 schema 新增 `gateway.tools` 能力开关（对齐官方 `tools.*` 形态）
+
+在 `src/config-schema.ts` 的共享配置形状中新增：
+
+```ts
+gateway: z.object({
+  tools: z.object({
+    docs: z.boolean().optional(),        // 默认 true
+    proactiveSend: z.boolean().optional(), // 默认 true
+  }).strict().optional(),
+  docs: z.object({
+    allowedSpaceIds: z.array(z.string()).optional(), // 未配置 = 不限制
+  }).strict().optional(),
+  send: z.object({
+    allowedTargets: z.array(z.string()).optional(),  // "user:xxx" / "group:cid"，未配置 = 不限制
+  }).strict().optional(),
+}).strict().optional(),
+```
+
+在 `src/config.ts` 增加解析函数（默认值回退，多账号继承渠道级默认，与 `mergeAccountWithDefaults` 一致）：
+
+```ts
+resolveGatewayCapabilityConfig(config): {
+  docsEnabled: boolean;            // 默认 true
+  proactiveSendEnabled: boolean;   // 默认 true
+  allowedSpaceIds?: string[];
+  allowedTargets?: string[];
+}
+```
+
+### 2. `index.ts` 的 handler 统一走 gate
+
+- 抽一个 `withGatewayCapability(api, capability, handler)` 包装器（或在各 handler 开头调用 `resolveGatewayCapabilityConfig`）：
+  - `docs.*` → 检查 `docsEnabled`，再检查 `allowedSpaceIds`（若配置）包含请求中的 `spaceId`；`docs.append` 无 spaceId 时应先通过 `docs-service` 反查所属空间或在 gate 中要求传入 spaceId（推荐：保持兼容，仅当配置了白名单才要求反查/拒绝）。
+  - `sendToUser / sendToGroup / send` → 检查 `proactiveSendEnabled`，再检查 `allowedTargets`（若配置）。
+- 被拒时返回 `respond(false, { error: "dingtalk gateway tool '<x>' is disabled by config" })`，并打 `[DingTalk][GatewayRPC][Denied]` 日志。
+- `dingtalk.docs.*` 与 `dingtalk-connector.docs.*` 共享同一 handler，gate 自动对别名生效。
+
+### 3. 文档与审核材料
+
+- `docs/user/`：新增/更新 Gateway RPC 章节，说明：
+  - 信任模型：这些 RPC 面向已获得 OpenClaw Gateway 访问权的调用方（与官方 connector 一致），插件层不做二次身份认证；
+  - 如何用 `gateway.tools.*` 关闭能力、用 `allowedSpaceIds` / `allowedTargets` 收窄范围；
+  - 所需钉钉应用权限（文档读写、机器人消息发送对应的 OpenAPI scope）。
+- 若 `docs/` 站点有安全/权限说明页，追加"ClawHub 审核说明"小节，回应 `gateway-docs-and-send-rpc` finding。
+
+## 非 Goals
+
+- 不做插件级调用方身份认证（由宿主 Gateway 信任模型负责，与官方 connector 一致）。
+- 不改动 `send` channel action（问题 2 的媒体路径边界由另一份方案覆盖）。
+- 不调整 `dmPolicy` / `groupPolicy` 默认值（问题 4 单独评估）。
+
+## 实现 TODO
+
+- [ ] `src/config-schema.ts`：新增 `gateway.tools/docs/send` schema 与一致性校验（如 `allowedTargets` 项必须以 `user:`/`group:` 开头）。
+- [ ] `src/config.ts`：`resolveGatewayCapabilityConfig` + 多账号继承 + 单测。
+- [ ] `index.ts`：handler 接入 gate；统一拒绝响应与日志前缀。
+- [ ] 单测：`tests/unit/` 覆盖 gate 默认开启、显式关闭、白名单命中/未命中、`dingtalk-connector.*` 别名同样受限。
+- [ ] `docs/user/` 更新；必要时更新 onboarding 提示。
+- [ ] `pnpm run type-check && pnpm lint && pnpm test`，然后 `pnpm run build:runtime` 重新构建 `dist/index.js`，重新发布并复查 ClawHub 审核结果。
+
+## 验证 TODO
+
+- [ ] 关闭 `gateway.tools.docs` 后，`dingtalk.docs.create` 与 `dingtalk-connector.docs.create` 均返回禁用错误。
+- [ ] 配置 `allowedSpaceIds` 后，未列入的 spaceId 请求被拒绝；未配置时行为不变。
+- [ ] 关闭 `gateway.tools.proactiveSend` 后，`sendToUser/sendToGroup/send` 全部拒绝；聊天回复通道（inbound reply）不受影响。
+- [ ] 现有 cron/agent 调用方在默认配置下无需改动即可继续工作（向后兼容验证）。
+- [ ] ClawHub 重新审核后 `gateway-docs-and-send-rpc` finding 降级或消除。

--- a/docs/spec/issue-608-gateway-docs-send-gate.md
+++ b/docs/spec/issue-608-gateway-docs-send-gate.md
@@ -94,6 +94,15 @@ resolveGatewayCapabilityConfig(config): {
 - 不改动 `send` channel action（问题 2 的媒体路径边界由另一份方案覆盖）。
 - 不调整 `dmPolicy` / `groupPolicy` 默认值（问题 4 单独评估）。
 
+## 实现偏差说明
+
+实现时配置键由 spec 中的 `gateway` 更名为 **`gatewayRpc`**（`channels.dingtalk.gatewayRpc`）：宿主 `OpenClawConfig` 已存在顶层 `gateway` 配置（网络/发现/角色策略），插件级 `gateway` 字段会与其类型冲突。其余能力开关形态（`tools.docs` / `tools.proactiveSend`、`docs.allowedSpaceIds`、`send.allowedTargets`）与 spec 一致。
+
+另外两点审核后明确的边界（已写入用户文档）：
+
+- 账号级 `gatewayRpc` 覆盖是对象级整体替换（沿承渠道级配置的浅合并语义），不做子键深合并。
+- `docs.append` 不携带 `spaceId`；配置 `allowedSpaceIds` 后 append 会被显式拒绝（拒绝信息说明"方法不携带 spaceId"），未配置白名单时 append 不受影响。
+
 ## 实现 TODO
 
 - [ ] `src/config-schema.ts`：新增 `gateway.tools/docs/send` schema 与一致性校验（如 `allowedTargets` 项必须以 `user:`/`group:` 开头）。

--- a/docs/spec/issue-608-gateway-docs-send-gate.md
+++ b/docs/spec/issue-608-gateway-docs-send-gate.md
@@ -98,24 +98,30 @@ resolveGatewayCapabilityConfig(config): {
 
 实现时配置键由 spec 中的 `gateway` 更名为 **`gatewayRpc`**（`channels.dingtalk.gatewayRpc`）：宿主 `OpenClawConfig` 已存在顶层 `gateway` 配置（网络/发现/角色策略），插件级 `gateway` 字段会与其类型冲突。其余能力开关形态（`tools.docs` / `tools.proactiveSend`、`docs.allowedSpaceIds`、`send.allowedTargets`）与 spec 一致。
 
-另外两点审核后明确的边界（已写入用户文档）：
+审核后明确的边界（均已写入用户文档）：
 
-- 账号级 `gatewayRpc` 覆盖是对象级整体替换（沿承渠道级配置的浅合并语义），不做子键深合并。
-- `docs.append` 不携带 `spaceId`；配置 `allowedSpaceIds` 后 append 会被显式拒绝（拒绝信息说明"方法不携带 spaceId"），未配置白名单时 append 不受影响。
+- 账号级 `gatewayRpc` 与渠道级 **按子键合并**（`tools` / `docs` / `send` 三组分别合并），而不是对象级整体替换：整体替换会让账号级的局部配置静默移除渠道级白名单（fail-open），与"能力开关是安全控制"的定位冲突。
+- 白名单 fail-closed：`allowedSpaceIds` / `allowedTargets` 配置后至少一项（空数组在 schema 层被拒绝）；运行时若仍拿到"已配置但为空"的数组，按全部拒绝处理。
+- `docs.append` 不携带 `spaceId`；配置 `allowedSpaceIds` 后 append 会被显式拒绝，未配置白名单时 append 不受影响。`docs.search` 的 `spaceId` 可选，配置白名单后不带 `spaceId` 的 search 同样被拒绝。
+- 新增配置键必须同步到 `openclaw.plugin.json` 的 `channelConfigs.dingtalk.schema`（顶层与 `accounts.*` 两处）：宿主用该 schema 校验 `channels.dingtalk`，且 channel schema 为 `additionalProperties: false`，漏配会导致配置校验失败、网关无法加载配置。
 
 ## 实现 TODO
 
-- [ ] `src/config-schema.ts`：新增 `gateway.tools/docs/send` schema 与一致性校验（如 `allowedTargets` 项必须以 `user:`/`group:` 开头）。
-- [ ] `src/config.ts`：`resolveGatewayCapabilityConfig` + 多账号继承 + 单测。
-- [ ] `index.ts`：handler 接入 gate；统一拒绝响应与日志前缀。
-- [ ] 单测：`tests/unit/` 覆盖 gate 默认开启、显式关闭、白名单命中/未命中、`dingtalk-connector.*` 别名同样受限。
-- [ ] `docs/user/` 更新；必要时更新 onboarding 提示。
-- [ ] `pnpm run type-check && pnpm lint && pnpm test`，然后 `pnpm run build:runtime` 重新构建 `dist/index.js`，重新发布并复查 ClawHub 审核结果。
+- [x] `src/config-schema.ts`：新增 `gatewayRpc.tools/docs/send` schema 与一致性校验（`allowedTargets` 项必须以 `user:`/`group:` 开头，白名单至少一项）。
+- [x] `src/config.ts`：`resolveGatewayCapabilityConfig` + 多账号按子键合并（`mergeGatewayRpcConfig`）+ 单测。
+- [x] `openclaw.plugin.json`：顶层与账号级 schema 同步 `gatewayRpc`（含 `uiHints`），并在 `tests/unit/plugin-manifest.test.ts` 加守护断言。
+- [x] `index.ts`：handler 接入 gate；统一拒绝响应与日志前缀；拒绝文案抽为 `config.ts` 常量，避免与 fast-path 漂移。
+- [x] 单测：`tests/unit/` 覆盖 gate 默认开启、显式关闭、白名单命中/未命中、空白名单 fail-closed、`dingtalk-connector.*` 别名同样受限、账号级合并。
+- [x] `docs/user/` 更新（`gateway-rpc.md`、`security-policies.md`、`configuration.md`）。
+- [x] `pnpm run type-check && pnpm lint && pnpm test`。
+- [ ] `pnpm run build:runtime` 重新构建 `dist/index.js`，重新发布并复查 ClawHub 审核结果。
 
 ## 验证 TODO
 
-- [ ] 关闭 `gateway.tools.docs` 后，`dingtalk.docs.create` 与 `dingtalk-connector.docs.create` 均返回禁用错误。
+- [ ] 关闭 `gatewayRpc.tools.docs` 后，`dingtalk.docs.create` 与 `dingtalk-connector.docs.create` 均返回禁用错误。
 - [ ] 配置 `allowedSpaceIds` 后，未列入的 spaceId 请求被拒绝；未配置时行为不变。
-- [ ] 关闭 `gateway.tools.proactiveSend` 后，`sendToUser/sendToGroup/send` 全部拒绝；聊天回复通道（inbound reply）不受影响。
+- [ ] 配置 `allowedSpaceIds` 后，`docs.append` 与不带 `spaceId` 的 `docs.search` 返回明确拒绝原因。
+- [ ] 关闭 `gatewayRpc.tools.proactiveSend` 后，`sendToUser/sendToGroup/send` 全部拒绝；聊天回复通道（inbound reply）不受影响。
+- [ ] 多账号：账号级只覆盖 `tools.docs` 时，渠道级 `allowedTargets` 仍然生效。
 - [ ] 现有 cron/agent 调用方在默认配置下无需改动即可继续工作（向后兼容验证）。
 - [ ] ClawHub 重新审核后 `gateway-docs-and-send-rpc` finding 降级或消除。

--- a/docs/user/reference/configuration.md
+++ b/docs/user/reference/configuration.md
@@ -37,6 +37,7 @@
 | `initialReconnectDelay` | number | `1000` | 初始重连延迟 |
 | `maxReconnectDelay` | number | `60000` | 最大重连延迟 |
 | `reconnectJitter` | number | `0.3` | 重连抖动因子 |
+| `gatewayRpc` | object | - | Gateway RPC 能力开关与白名单：`tools.docs` / `tools.proactiveSend` / `docs.allowedSpaceIds` / `send.allowedTargets`；默认全部开启 |
 
 ## 关于 `clientId` 与钉钉 `robotCode`
 
@@ -170,8 +171,20 @@ OpenClaw 2026.5.7 之后，群聊默认 `messages.groupChat.visibleReplies=messa
 
 **用户无需额外配置**。如果你在群聊中观察到回复丢失或出现空卡片 + 额外 fallback 消息，请确认插件版本不低于 v3.6.2。
 
+## 关于 `gatewayRpc`
+
+`gatewayRpc` 收窄 Gateway RPC 的影响面（Issue #608 问题 3），全部默认开启、不配置即保持现有行为：
+
+- `gatewayRpc.tools.docs` / `gatewayRpc.tools.proactiveSend`：分别关闭全部 docs RPC（`dingtalk.docs.*` 与 `dingtalk-connector.docs.*`）与全部主动发送 RPC（`dingtalk-connector.sendToUser/sendToGroup/send`）。
+- `gatewayRpc.docs.allowedSpaceIds`：文档空间白名单；配置后不携带 `spaceId` 的请求（例如 `docs.append`）也会被拒绝。
+- `gatewayRpc.send.allowedTargets`：主动发送目标白名单，每项为 `user:<id>` 或 `group:<conversationId>`。
+- 白名单配置后至少需要一项，空数组会被配置校验拒绝；多账号下账号级 `gatewayRpc` 与渠道级按子键合并，渠道级限制不会被账号级局部配置静默移除。
+
+这些 RPC 依赖宿主 Gateway 的信任模型（插件层不做二次调用方身份认证），完整说明、拒绝行为与所需钉钉权限见 [Gateway RPC 兼容层](gateway-rpc.md)。
+
 ## 相关文档
 
 - [配置](../getting-started/configure.md)
 - [安全策略](security-policies.md)
+- [Gateway RPC 兼容层](gateway-rpc.md)
 - [AI 卡片](../features/ai-card.md)

--- a/docs/user/reference/gateway-rpc.md
+++ b/docs/user/reference/gateway-rpc.md
@@ -34,7 +34,7 @@ docs RPC 与主动发送 RPC 使用配置中的钉钉应用凭证直接执行文
           "proactiveSend": true   // 关闭后 dingtalk-connector.sendToUser/sendToGroup/send 全部拒绝
         },
         "docs": {
-          "allowedSpaceIds": ["spaceA"] // 配置后 docs RPC 只接受这些 spaceId；未配置不限制
+          "allowedSpaceIds": ["spaceA"] // 配置后 docs RPC 只接受这些 spaceId（至少一项）；未配置不限制
         },
         "send": {
           "allowedTargets": ["user:staff123", "group:cidXXXX"] // 配置后发送目标必须在列表内；未配置不限制
@@ -49,13 +49,15 @@ docs RPC 与主动发送 RPC 使用配置中的钉钉应用凭证直接执行文
 
 - 所有开关默认开启，向后兼容；显式关闭后对应 RPC 返回 `error`，并在日志中打出 `[DingTalk][GatewayRPC][Denied]` 前缀。
 - `dingtalk.docs.*` 与 `dingtalk-connector.docs.*` 共享同一组 handler，能力开关对两个命名空间同时生效。
-- `allowedTargets` 中的每一项必须是 `user:<id>` 或 `group:<conversationId>`。
-- 多账号场景下，账号级 `gatewayRpc` 覆盖渠道级默认；**覆盖是整个 `gatewayRpc` 对象级别的替换**（与渠道级其它配置键的合并语义一致）。账号级只要写了任意 `gatewayRpc` 子键，渠道级的 `allowedSpaceIds` / `allowedTargets` 不会自动继承，需要在账号级完整重新声明。
+- `allowedTargets` 中的每一项必须是 `user:<id>` 或 `group:<conversationId>`；`allowedSpaceIds` / `allowedTargets` 一旦配置就至少需要一项，空数组会被配置校验直接拒绝，避免"限制被静默取消"。
+- 白名单是 fail-closed 的：运行时若收到"已配置但为空"的白名单（例如绕过了配置校验），会按"全部拒绝"处理。
+- 多账号场景下，账号级 `gatewayRpc` **按子键与渠道级合并**（`tools` / `docs` / `send` 三组分别合并），同一子键以账号级为准。因此渠道级的 `tools.docs: false` 或渠道级白名单不会被账号级的局部配置静默移除；未配置的账号完全继承渠道级设置。
 
 `allowedSpaceIds` 的适用范围：
 
-- 配置白名单后，带 `spaceId` 的 docs 方法（`create` / `list` / 可选 `spaceId` 的 `search`）只接受白名单内的 `spaceId`。
-- `dingtalk.docs.append` / `dingtalk-connector.docs.append` 以 `docId` 为目标、不携带 `spaceId`；配置白名单后该方法会被拒绝，拒绝信息会明确说明"方法不携带 spaceId"。如需在白名单模式下继续使用 append，请不要配置 `allowedSpaceIds`（改为依赖 `tools.docs` 开关）。
+- 配置白名单后，带 `spaceId` 的 docs 方法（`create` / `list` / `search`）只接受白名单内的 `spaceId`。
+- `search` 的 `spaceId` 是可选的：配置白名单后，不传 `spaceId` 的 `search` 会被拒绝，因为无法确认它要访问哪个空间。
+- `dingtalk.docs.append` / `dingtalk-connector.docs.append` 以 `docId` 为目标、永远不携带 `spaceId`；配置白名单后该方法也会被拒绝，拒绝信息会说明"请求未携带 spaceId"。如需在白名单模式下继续使用 append，请不要配置 `allowedSpaceIds`（改为依赖 `tools.docs` 开关）。
 
 ## 所需钉钉应用权限
 

--- a/docs/user/reference/gateway-rpc.md
+++ b/docs/user/reference/gateway-rpc.md
@@ -50,7 +50,12 @@ docs RPC 与主动发送 RPC 使用配置中的钉钉应用凭证直接执行文
 - 所有开关默认开启，向后兼容；显式关闭后对应 RPC 返回 `error`，并在日志中打出 `[DingTalk][GatewayRPC][Denied]` 前缀。
 - `dingtalk.docs.*` 与 `dingtalk-connector.docs.*` 共享同一组 handler，能力开关对两个命名空间同时生效。
 - `allowedTargets` 中的每一项必须是 `user:<id>` 或 `group:<conversationId>`。
-- 多账号场景下，账号级 `gatewayRpc` 覆盖渠道级默认；未配置的账号继承渠道级设置。
+- 多账号场景下，账号级 `gatewayRpc` 覆盖渠道级默认；**覆盖是整个 `gatewayRpc` 对象级别的替换**（与渠道级其它配置键的合并语义一致）。账号级只要写了任意 `gatewayRpc` 子键，渠道级的 `allowedSpaceIds` / `allowedTargets` 不会自动继承，需要在账号级完整重新声明。
+
+`allowedSpaceIds` 的适用范围：
+
+- 配置白名单后，带 `spaceId` 的 docs 方法（`create` / `list` / 可选 `spaceId` 的 `search`）只接受白名单内的 `spaceId`。
+- `dingtalk.docs.append` / `dingtalk-connector.docs.append` 以 `docId` 为目标、不携带 `spaceId`；配置白名单后该方法会被拒绝，拒绝信息会明确说明"方法不携带 spaceId"。如需在白名单模式下继续使用 append，请不要配置 `allowedSpaceIds`（改为依赖 `tools.docs` 开关）。
 
 ## 所需钉钉应用权限
 

--- a/docs/user/reference/gateway-rpc.md
+++ b/docs/user/reference/gateway-rpc.md
@@ -19,3 +19,41 @@
 - `dingtalk-connector.docs.*`：与 `dingtalk.docs.*` 共享同一组 handler，只是兼容别名。
 
 这些兼容方法复用 canonical auth、send、docs、usage-tracking 和 outbound-context persistence 路径。后续如果某个兼容请求需要与 `dingtalk.*` 不同的行为，必须先在这里说明差异，再扩展适配层。
+
+## 能力开关与白名单 `gatewayRpc`
+
+docs RPC 与主动发送 RPC 使用配置中的钉钉应用凭证直接执行文档读写和发消息。它们面向已获得 OpenClaw Gateway 访问权的调用方（插件层不做二次调用方身份认证）；如需进一步收窄，可通过 `channels.dingtalk.gatewayRpc` 配置：
+
+```json5
+{
+  "channels": {
+    "dingtalk": {
+      "gatewayRpc": {
+        "tools": {
+          "docs": true,           // 关闭后 dingtalk.docs.* 与 dingtalk-connector.docs.* 全部拒绝
+          "proactiveSend": true   // 关闭后 dingtalk-connector.sendToUser/sendToGroup/send 全部拒绝
+        },
+        "docs": {
+          "allowedSpaceIds": ["spaceA"] // 配置后 docs RPC 只接受这些 spaceId；未配置不限制
+        },
+        "send": {
+          "allowedTargets": ["user:staff123", "group:cidXXXX"] // 配置后发送目标必须在列表内；未配置不限制
+        }
+      }
+    }
+  }
+}
+```
+
+行为说明：
+
+- 所有开关默认开启，向后兼容；显式关闭后对应 RPC 返回 `error`，并在日志中打出 `[DingTalk][GatewayRPC][Denied]` 前缀。
+- `dingtalk.docs.*` 与 `dingtalk-connector.docs.*` 共享同一组 handler，能力开关对两个命名空间同时生效。
+- `allowedTargets` 中的每一项必须是 `user:<id>` 或 `group:<conversationId>`。
+- 多账号场景下，账号级 `gatewayRpc` 覆盖渠道级默认；未配置的账号继承渠道级设置。
+
+## 所需钉钉应用权限
+
+- docs RPC：钉钉文档/知识库相关 OpenAPI 权限（文档空间读写，`Doc.*` 对应 scope）。
+- 主动发送 RPC：机器人消息发送权限（企业机器人 `oToMessages` / `groupMessages` 发送权限）。
+

--- a/docs/user/reference/security-policies.md
+++ b/docs/user/reference/security-policies.md
@@ -99,6 +99,19 @@
 
 除上述两类外，插件源码不直接读取宿主环境变量。底层库（例如 HTTP 客户端）可能会按自身约定读取代理类环境变量，这属于宿主既有行为，不受本插件控制。
 
+## Gateway RPC 能力边界
+
+插件暴露的 `dingtalk.docs.*`、`dingtalk-connector.docs.*` 文档 RPC 和 `dingtalk-connector.sendToUser/sendToGroup/send` 主动发送 RPC 依赖宿主 Gateway 信任模型：能调用这些 RPC 的，是已获得 OpenClaw Gateway 访问权的调用方；插件层不做二次调用方身份认证。
+
+可以通过 `channels.dingtalk.gatewayRpc` 收窄影响面：
+
+- `gatewayRpc.tools.docs = false`：关闭全部 docs RPC
+- `gatewayRpc.tools.proactiveSend = false`：关闭全部主动发送 RPC
+- `gatewayRpc.docs.allowedSpaceIds`：文档空间白名单
+- `gatewayRpc.send.allowedTargets`：主动发送目标白名单（`user:*` / `group:*`）
+
+详见 [Gateway RPC 兼容层](gateway-rpc.md)。
+
 ## 适用建议
 
 - 对生产环境，优先最小化开放范围

--- a/docs/user/reference/security-policies.md
+++ b/docs/user/reference/security-policies.md
@@ -107,8 +107,10 @@
 
 - `gatewayRpc.tools.docs = false`：关闭全部 docs RPC
 - `gatewayRpc.tools.proactiveSend = false`：关闭全部主动发送 RPC
-- `gatewayRpc.docs.allowedSpaceIds`：文档空间白名单
-- `gatewayRpc.send.allowedTargets`：主动发送目标白名单（`user:*` / `group:*`）
+- `gatewayRpc.docs.allowedSpaceIds`：文档空间白名单（配置后至少一项；不携带 `spaceId` 的请求会被拒绝）
+- `gatewayRpc.send.allowedTargets`：主动发送目标白名单（`user:*` / `group:*`；配置后至少一项）
+
+能力开关与白名单默认不启用（保持向后兼容），但一旦配置即 fail-closed：空数组会被配置校验拒绝，运行时遇到"已配置但为空"的白名单按全部拒绝处理；多账号下账号级 `gatewayRpc` 与渠道级按子键合并，渠道级的限制不会被账号级局部配置静默移除。
 
 详见 [Gateway RPC 兼容层](gateway-rpc.md)。
 

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import {
   checkProactiveSendGatewayCapability,
   getConfig,
   listDingTalkAccountIds,
+  PROACTIVE_SEND_GATE_DISABLED_REASON,
   resolveDingTalkAccount,
   resolveGatewayCapabilityConfig,
 } from "./src/config";
@@ -62,16 +63,9 @@ function withDocsGatewayCapability(
     const { respond, params } = args;
     const accountId = readStringParam(params, "accountId");
     const caps = resolveGatewayCapabilityConfig(api.config, accountId ?? undefined);
-    // Fast-path the capability switch before reading optional params so a
-    // disabled tool always answers with a structured deny.
-    if (!caps.docsEnabled) {
-      return denyGatewayCapability(
-        api,
-        method,
-        "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)",
-        respond,
-      );
-    }
+    // `checkDocsGatewayCapability` evaluates the capability switch first, so a
+    // disabled tool answers with a structured deny before any method params
+    // (all optional for docs RPCs) are inspected.
     const spaceId = readStringParam(params, "spaceId") ?? undefined;
     const denial = checkDocsGatewayCapability(caps, spaceId);
     if (denial) {
@@ -99,12 +93,7 @@ function withProactiveSendGatewayCapability(
     // Fast-path the capability switch before resolving required params so a
     // disabled tool answers with a structured deny rather than a param error.
     if (!caps.proactiveSendEnabled) {
-      return denyGatewayCapability(
-        api,
-        method,
-        "dingtalk proactive-send Gateway RPC is disabled by config (gatewayRpc.tools.proactiveSend = false)",
-        respond,
-      );
+      return denyGatewayCapability(api, method, PROACTIVE_SEND_GATE_DISABLED_REASON, respond);
     }
     const target = resolveTarget(params) ?? "";
     const denial = checkProactiveSendGatewayCapability(caps, target);

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,14 @@ import { readStringParam } from "openclaw/plugin-sdk/param-readers";
 import { getAccessToken } from "./src/auth";
 import { registerDingTalkAskUserQuestionTool } from "./src/card/ask-user-question";
 import { dingtalkPlugin } from "./src/channel";
-import { getConfig, listDingTalkAccountIds, resolveDingTalkAccount } from "./src/config";
+import {
+  checkDocsGatewayCapability,
+  checkProactiveSendGatewayCapability,
+  getConfig,
+  listDingTalkAccountIds,
+  resolveDingTalkAccount,
+  resolveGatewayCapabilityConfig,
+} from "./src/config";
 import {
   appendToDoc,
   createDoc,
@@ -23,6 +30,70 @@ type GatewayMethodContext = Pick<
   Parameters<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>[0],
   "context" | "params" | "respond"
 >;
+
+type GatewayMethodArgs = Parameters<Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]>[0];
+
+/**
+ * Respond with a capability denial for a Gateway RPC call.
+ * Logged under `[DingTalk][GatewayRPC][Denied]` for fast audit diagnosis.
+ */
+function denyGatewayCapability(
+  api: OpenClawPluginApi,
+  method: string,
+  reason: string,
+  respond: GatewayMethodContext["respond"],
+): ReturnType<GatewayMethodContext["respond"]> {
+  api.logger?.warn?.(`[DingTalk][GatewayRPC][Denied] ${method}: ${reason}`);
+  return respond(false, { error: reason });
+}
+
+/**
+ * Wrap a docs Gateway RPC handler with the `gatewayRpc.tools.docs` capability gate
+ * and the optional `gatewayRpc.docs.allowedSpaceIds` allowlist (Issue #608, 问题 3).
+ * `dingtalk.docs.*` and `dingtalk-connector.docs.*` aliases share handlers, so
+ * the gate automatically applies to both namespaces.
+ */
+function withDocsGatewayCapability(
+  api: OpenClawPluginApi,
+  method: string,
+  handler: (args: GatewayMethodArgs) => Promise<void>,
+): (args: GatewayMethodArgs) => Promise<void> {
+  return async (args: GatewayMethodArgs) => {
+    const { respond, params } = args;
+    const accountId = readStringParam(params, "accountId");
+    const caps = resolveGatewayCapabilityConfig(api.config, accountId ?? undefined);
+    const spaceId = readStringParam(params, "spaceId") ?? undefined;
+    const denial = checkDocsGatewayCapability(caps, spaceId);
+    if (denial) {
+      return denyGatewayCapability(api, method, denial, respond);
+    }
+    return handler(args);
+  };
+}
+
+/**
+ * Wrap a proactive-send Gateway RPC handler with the `gatewayRpc.tools.proactiveSend`
+ * capability gate and the optional `gatewayRpc.send.allowedTargets` allowlist
+ * (Issue #608, 问题 3).
+ */
+function withProactiveSendGatewayCapability(
+  api: OpenClawPluginApi,
+  method: string,
+  resolveTarget: (params: Record<string, unknown>) => string | undefined,
+  handler: (args: GatewayMethodArgs, target: string) => Promise<void>,
+): (args: GatewayMethodArgs) => Promise<void> {
+  return async (args: GatewayMethodArgs) => {
+    const { respond, params } = args;
+    const accountId = readStringParam(params, "accountId");
+    const caps = resolveGatewayCapabilityConfig(api.config, accountId ?? undefined);
+    const target = resolveTarget(params) ?? "";
+    const denial = checkProactiveSendGatewayCapability(caps, target);
+    if (denial) {
+      return denyGatewayCapability(api, method, denial, respond);
+    }
+    return handler(args, target);
+  };
+}
 
 /**
  * Register the canonical OpenClaw DingTalk docs RPC namespace.
@@ -93,14 +164,38 @@ function registerDingTalkDocsGatewayMethods(api: OpenClawPluginApi): void {
     return respond(true, { docs });
   };
 
-  api.registerGatewayMethod("dingtalk.docs.create", createHandler);
-  api.registerGatewayMethod("dingtalk.docs.append", appendHandler);
-  api.registerGatewayMethod("dingtalk.docs.search", searchHandler);
-  api.registerGatewayMethod("dingtalk.docs.list", listHandler);
-  api.registerGatewayMethod("dingtalk-connector.docs.create", createHandler);
-  api.registerGatewayMethod("dingtalk-connector.docs.append", appendHandler);
-  api.registerGatewayMethod("dingtalk-connector.docs.search", searchHandler);
-  api.registerGatewayMethod("dingtalk-connector.docs.list", listHandler);
+  api.registerGatewayMethod(
+    "dingtalk.docs.create",
+    withDocsGatewayCapability(api, "dingtalk.docs.create", createHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk.docs.append",
+    withDocsGatewayCapability(api, "dingtalk.docs.append", appendHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk.docs.search",
+    withDocsGatewayCapability(api, "dingtalk.docs.search", searchHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk.docs.list",
+    withDocsGatewayCapability(api, "dingtalk.docs.list", listHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk-connector.docs.create",
+    withDocsGatewayCapability(api, "dingtalk-connector.docs.create", createHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk-connector.docs.append",
+    withDocsGatewayCapability(api, "dingtalk-connector.docs.append", appendHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk-connector.docs.search",
+    withDocsGatewayCapability(api, "dingtalk-connector.docs.search", searchHandler),
+  );
+  api.registerGatewayMethod(
+    "dingtalk-connector.docs.list",
+    withDocsGatewayCapability(api, "dingtalk-connector.docs.list", listHandler),
+  );
 }
 
 function getContentParam(params: Record<string, unknown>): string | undefined {
@@ -176,68 +271,88 @@ async function sendGatewayMessage(params: {
 function registerDingTalkConnectorCompatibilityGatewayMethods(api: OpenClawPluginApi): void {
   api.registerGatewayMethod(
     "dingtalk-connector.sendToUser",
-    async ({ context, respond, params }: GatewayMethodContext) => {
-      const accountId = readStringParam(params, "accountId");
-      const userId = readStringParam(params, "userId", { required: true });
-      const content = getContentParam(params);
-      if (!content) {
-        return respond(false, { error: "content or message is required" });
-      }
-      return sendGatewayMessage({
-        api,
-        respond,
-        accountId: accountId ?? undefined,
-        target: `user:${userId}`,
-        content,
-        storePath: context?.cronStorePath,
-        useAICard: params.useAICard,
-      });
-    },
+    withProactiveSendGatewayCapability(
+      api,
+      "dingtalk-connector.sendToUser",
+      (params) => {
+        const userId = readStringParam(params, "userId", { required: true });
+        return userId ? `user:${userId}` : undefined;
+      },
+      async ({ context, respond, params }, target) => {
+        const accountId = readStringParam(params, "accountId");
+        const content = getContentParam(params);
+        if (!content) {
+          return respond(false, { error: "content or message is required" });
+        }
+        return sendGatewayMessage({
+          api,
+          respond,
+          accountId: accountId ?? undefined,
+          target,
+          content,
+          storePath: context?.cronStorePath,
+          useAICard: params.useAICard,
+        });
+      },
+    ),
   );
 
   api.registerGatewayMethod(
     "dingtalk-connector.sendToGroup",
-    async ({ context, respond, params }: GatewayMethodContext) => {
-      const accountId = readStringParam(params, "accountId");
-      const openConversationId = readStringParam(params, "openConversationId", { required: true });
-      const content = getContentParam(params);
-      if (!content) {
-        return respond(false, { error: "content or message is required" });
-      }
-      return sendGatewayMessage({
-        api,
-        respond,
-        accountId: accountId ?? undefined,
-        target: `group:${openConversationId}`,
-        content,
-        storePath: context?.cronStorePath,
-        useAICard: params.useAICard,
-      });
-    },
+    withProactiveSendGatewayCapability(
+      api,
+      "dingtalk-connector.sendToGroup",
+      (params) => {
+        const openConversationId = readStringParam(params, "openConversationId", {
+          required: true,
+        });
+        return openConversationId ? `group:${openConversationId}` : undefined;
+      },
+      async ({ context, respond, params }, target) => {
+        const accountId = readStringParam(params, "accountId");
+        const content = getContentParam(params);
+        if (!content) {
+          return respond(false, { error: "content or message is required" });
+        }
+        return sendGatewayMessage({
+          api,
+          respond,
+          accountId: accountId ?? undefined,
+          target,
+          content,
+          storePath: context?.cronStorePath,
+          useAICard: params.useAICard,
+        });
+      },
+    ),
   );
 
   api.registerGatewayMethod(
     "dingtalk-connector.send",
-    async ({ context, respond, params }: GatewayMethodContext) => {
-      const accountId = readStringParam(params, "accountId");
-      const target = readStringParam(params, "target", { required: true });
-      const content = getContentParam(params);
-      if (!content) {
-        return respond(false, { error: "content or message is required" });
-      }
-      if (!isConnectorSendTarget(target)) {
-        return respond(false, { error: "target must start with user: or group:" });
-      }
-      return sendGatewayMessage({
-        api,
-        respond,
-        accountId: accountId ?? undefined,
-        target,
-        content,
-        storePath: context?.cronStorePath,
-        useAICard: params.useAICard,
-      });
-    },
+    withProactiveSendGatewayCapability(
+      api,
+      "dingtalk-connector.send",
+      (params) => readStringParam(params, "target", { required: true }) ?? undefined,
+      async ({ context, respond, params }, target) => {
+        const accountId = readStringParam(params, "accountId");
+        const content = getContentParam(params);
+        if (!content) {
+          return respond(false, { error: "content or message is required" });
+        }
+        if (!isConnectorSendTarget(target)) {
+          return respond(false, { error: "target must start with user: or group:" });
+        }
+        return sendGatewayMessage({
+          api,
+          respond,
+          accountId: accountId ?? undefined,
+          target,
+          content,
+          storePath: context?.cronStorePath,
+          useAICard: params.useAICard,
+        });
+      },
+    ),
   );
 
   api.registerGatewayMethod(

--- a/index.ts
+++ b/index.ts
@@ -62,6 +62,16 @@ function withDocsGatewayCapability(
     const { respond, params } = args;
     const accountId = readStringParam(params, "accountId");
     const caps = resolveGatewayCapabilityConfig(api.config, accountId ?? undefined);
+    // Fast-path the capability switch before reading optional params so a
+    // disabled tool always answers with a structured deny.
+    if (!caps.docsEnabled) {
+      return denyGatewayCapability(
+        api,
+        method,
+        "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)",
+        respond,
+      );
+    }
     const spaceId = readStringParam(params, "spaceId") ?? undefined;
     const denial = checkDocsGatewayCapability(caps, spaceId);
     if (denial) {
@@ -86,6 +96,16 @@ function withProactiveSendGatewayCapability(
     const { respond, params } = args;
     const accountId = readStringParam(params, "accountId");
     const caps = resolveGatewayCapabilityConfig(api.config, accountId ?? undefined);
+    // Fast-path the capability switch before resolving required params so a
+    // disabled tool answers with a structured deny rather than a param error.
+    if (!caps.proactiveSendEnabled) {
+      return denyGatewayCapability(
+        api,
+        method,
+        "dingtalk proactive-send Gateway RPC is disabled by config (gatewayRpc.tools.proactiveSend = false)",
+        respond,
+      );
+    }
     const target = resolveTarget(params) ?? "";
     const denial = checkProactiveSendGatewayCapability(caps, target);
     if (denial) {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -325,6 +325,54 @@
             "type": "boolean",
             "description": "Legacy compatibility field from older host or runtime integrations. It is not used by the current runtime and new configs should omit it."
           },
+          "gatewayRpc": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Capability gates and allowlists for docs Gateway RPCs (dingtalk.docs.* / dingtalk-connector.docs.*) and proactive-send Gateway RPCs (dingtalk-connector.sendToUser/sendToGroup/send). All capabilities default to enabled; these RPCs rely on the host Gateway trust model and do not authenticate the caller.",
+            "properties": {
+              "tools": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Capability switches. Omitted switches default to enabled.",
+                "properties": {
+                  "docs": {
+                    "type": "boolean",
+                    "description": "Enable dingtalk.docs.* and dingtalk-connector.docs.* Gateway RPCs. Defaults to true when omitted."
+                  },
+                  "proactiveSend": {
+                    "type": "boolean",
+                    "description": "Enable dingtalk-connector.sendToUser/sendToGroup/send proactive-send RPCs. Defaults to true when omitted."
+                  }
+                }
+              },
+              "docs": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Docs RPC allowlist. When allowedSpaceIds is configured, requests without a spaceId (for example dingtalk.docs.append) are denied as well.",
+                "properties": {
+                  "allowedSpaceIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "type": "string", "minLength": 1 },
+                    "description": "When set, docs RPCs only accept these spaceId values."
+                  }
+                }
+              },
+              "send": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Proactive-send target allowlist.",
+                "properties": {
+                  "allowedTargets": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": { "type": "string", "pattern": "^(user|group):\\S+$" },
+                    "description": "When set, proactive-send RPCs only accept these user:<id> or group:<conversationId> targets."
+                  }
+                }
+              }
+            }
+          },
           "accounts": {
             "type": "object",
             "description": "Named multi-account DingTalk configurations. Each account can override most top-level settings and inherits unspecified values from the top level.",
@@ -622,6 +670,54 @@
                       "description": "Show DingTalk API call count in AI card status line footer."
                     }
                   }
+                },
+                "gatewayRpc": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Account-level capability gates for docs and proactive-send Gateway RPCs. Merged with the channel-level gatewayRpc by sub-key (tools / docs / send), so a channel-level allowlist is never dropped implicitly.",
+                  "properties": {
+                    "tools": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Capability switches. Omitted switches default to enabled.",
+                      "properties": {
+                        "docs": {
+                          "type": "boolean",
+                          "description": "Enable dingtalk.docs.* and dingtalk-connector.docs.* Gateway RPCs. Defaults to true when omitted."
+                        },
+                        "proactiveSend": {
+                          "type": "boolean",
+                          "description": "Enable dingtalk-connector.sendToUser/sendToGroup/send proactive-send RPCs. Defaults to true when omitted."
+                        }
+                      }
+                    },
+                    "docs": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Docs RPC allowlist. When allowedSpaceIds is configured, requests without a spaceId (for example dingtalk.docs.append) are denied as well.",
+                      "properties": {
+                        "allowedSpaceIds": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": { "type": "string", "minLength": 1 },
+                          "description": "When set, docs RPCs only accept these spaceId values."
+                        }
+                      }
+                    },
+                    "send": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Proactive-send target allowlist.",
+                      "properties": {
+                        "allowedTargets": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": { "type": "string", "pattern": "^(user|group):\\S+$" },
+                          "description": "When set, proactive-send RPCs only accept these user:<id> or group:<conversationId> targets."
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -837,6 +933,26 @@
         "asyncMode": {
           "label": "Legacy Async Mode",
           "help": "Deprecated compatibility field from older host or runtime integrations. The current runtime ignores it."
+        },
+        "gatewayRpc": {
+          "label": "Gateway RPC Capability Gates",
+          "help": "Turn docs and proactive-send Gateway RPCs off, or restrict them to specific doc spaces and send targets."
+        },
+        "gatewayRpc.tools.docs": {
+          "label": "Docs RPC Enabled",
+          "help": "Allow dingtalk.docs.* and dingtalk-connector.docs.* Gateway RPCs. Defaults to enabled."
+        },
+        "gatewayRpc.tools.proactiveSend": {
+          "label": "Proactive Send RPC Enabled",
+          "help": "Allow dingtalk-connector.sendToUser/sendToGroup/send Gateway RPCs. Defaults to enabled."
+        },
+        "gatewayRpc.docs.allowedSpaceIds": {
+          "label": "Allowed Doc Space IDs",
+          "help": "When set, docs RPCs only accept these spaceId values; requests without a spaceId, such as dingtalk.docs.append, are denied."
+        },
+        "gatewayRpc.send.allowedTargets": {
+          "label": "Allowed Send Targets",
+          "help": "When set, proactive-send RPCs only accept these user:<id> or group:<conversationId> targets."
         },
         "accounts": {
           "label": "Named Accounts",

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -12,6 +12,44 @@ const CardStreamingModeSchema = z.enum(["off", "answer", "all"]);
 const ContextVisibilitySchema = z.enum(["all", "allowlist", "allowlist_quote"]);
 
 /**
+ * Gateway RPC capability gates (Issue #608, 问题 3).
+ * Shape aligned with the official connector's `tools: { docs, media }` gate;
+ * all capabilities default to enabled for backward compatibility.
+ */
+const GatewayTargetListSchema = z
+  .array(z.string().regex(/^(user|group):\S+$/, "must be `user:<id>` or `group:<conversationId>`"))
+  .optional();
+
+const DingTalkGatewayConfigSchema = z
+  .object({
+    tools: z
+      .object({
+        /** Enable dingtalk.docs.* and dingtalk-connector.docs.* Gateway RPCs (default: true) */
+        docs: z.boolean().optional(),
+        /** Enable dingtalk-connector.sendToUser/sendToGroup/send proactive-send RPCs (default: true) */
+        proactiveSend: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    docs: z
+      .object({
+        /** When set, docs RPCs only accept these spaceId values */
+        allowedSpaceIds: z.array(z.string().min(1)).optional(),
+      })
+      .strict()
+      .optional(),
+    send: z
+      .object({
+        /** When set, proactive-send RPCs only accept these `user:*` / `group:*` targets */
+        allowedTargets: GatewayTargetListSchema,
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
+/**
  * Runtime-parsed DingTalk account config.
  *
  * Compatibility note:
@@ -121,7 +159,13 @@ const DingTalkAccountConfigShape = {
       /** Show the proactive-send permission hint when the runtime detects missing DingTalk proactive permission. */
       enabled: z.boolean().optional().default(true),
       /** Minimum cooldown in hours before the same proactive permission hint can be shown again. */
-      cooldownHours: z.number().int().min(1).max(24 * 30).optional().default(24),
+      cooldownHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(24 * 30)
+        .optional()
+        .default(24),
     })
     .optional()
     .default({ enabled: true, cooldownHours: 24 }),
@@ -139,7 +183,12 @@ const DingTalkAccountConfigShape = {
   cardStreamInterval: z.number().int().min(200).optional().default(1000),
 
   /** Cooldown window in milliseconds after AI card trigger errors. Replies fall back to non-card delivery during this period. */
-  aicardDegradeMs: z.number().int().min(60_000).optional().default(30 * 60 * 1000),
+  aicardDegradeMs: z
+    .number()
+    .int()
+    .min(60_000)
+    .optional()
+    .default(30 * 60 * 1000),
 
   /** Enable the local feedback-learning loop for notes, reflections, and command-assisted learning. */
   learningEnabled: z.boolean().optional(),
@@ -175,7 +224,17 @@ const DingTalkAccountConfigShape = {
       dapiUsage: z.boolean().optional().default(false),
     })
     .optional()
-    .default({ model: true, effort: true, agent: true, taskTime: false, tokens: false, dapiUsage: false }),
+    .default({
+      model: true,
+      effort: true,
+      agent: true,
+      taskTime: false,
+      tokens: false,
+      dapiUsage: false,
+    }),
+
+  /** Gateway RPC capability gates and allowlists (docs RPCs + proactive-send RPCs); namespaced as `gatewayRpc` to avoid clashing with the host-level `gateway` config */
+  gatewayRpc: DingTalkGatewayConfigSchema,
 } as const;
 
 const DingTalkAccountConfigSchema = z.object(DingTalkAccountConfigShape);

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -15,9 +15,13 @@ const ContextVisibilitySchema = z.enum(["all", "allowlist", "allowlist_quote"]);
  * Gateway RPC capability gates (Issue #608, 问题 3).
  * Shape aligned with the official connector's `tools: { docs, media }` gate;
  * all capabilities default to enabled for backward compatibility.
+ * Allowlists must list at least one entry when present: an empty list would be
+ * ambiguous, so it is rejected at config-validation time instead of silently
+ * disabling the restriction.
  */
 const GatewayTargetListSchema = z
   .array(z.string().regex(/^(user|group):\S+$/, "must be `user:<id>` or `group:<conversationId>`"))
+  .min(1)
   .optional();
 
 const DingTalkGatewayConfigSchema = z
@@ -33,14 +37,14 @@ const DingTalkGatewayConfigSchema = z
       .optional(),
     docs: z
       .object({
-        /** When set, docs RPCs only accept these spaceId values */
-        allowedSpaceIds: z.array(z.string().min(1)).optional(),
+        /** When set, docs RPCs only accept these spaceId values (at least one entry) */
+        allowedSpaceIds: z.array(z.string().min(1)).min(1).optional(),
       })
       .strict()
       .optional(),
     send: z
       .object({
-        /** When set, proactive-send RPCs only accept these `user:*` / `group:*` targets */
+        /** When set, proactive-send RPCs only accept these `user:*` / `group:*` targets (at least one entry) */
         allowedTargets: GatewayTargetListSchema,
       })
       .strict()

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,11 @@ import {
   hasConfiguredSecretInput,
   resolveDingTalkSecretConfig,
 } from "./secret-input";
-import type { DingTalkChannelConfig, DingTalkConfig } from "./types";
+import type {
+  DingTalkChannelConfig,
+  DingTalkConfig,
+  DingTalkGatewayCapabilityConfig,
+} from "./types";
 export { resolveRelativePath, resolveUserPath } from "./path-utils";
 const DEFAULT_LEARNING_NOTE_TTL_MS = 6 * 60 * 60 * 1000;
 export type RuntimeDingTalkConfig = Omit<DingTalkConfig, "clientSecret"> & { clientSecret: string };
@@ -56,6 +60,32 @@ function stripRemovedLegacyFields(config: DingTalkConfig): DingTalkConfig {
 }
 
 /**
+ * Merge channel-level and account-level `gatewayRpc` gates by sub-key.
+ *
+ * `mergeAccountWithDefaults` is a shallow merge, so without this helper an
+ * account-level object would replace the whole channel-level `gatewayRpc` and
+ * silently drop a channel-level allowlist (fail-open). Merging `tools` /
+ * `docs` / `send` separately keeps channel-level restrictions in force unless
+ * the account explicitly overrides that exact sub-key.
+ */
+export function mergeGatewayRpcConfig(
+  channelLevel: DingTalkGatewayCapabilityConfig | undefined,
+  accountLevel: DingTalkGatewayCapabilityConfig | undefined,
+): DingTalkGatewayCapabilityConfig | undefined {
+  if (!channelLevel) {
+    return accountLevel;
+  }
+  if (!accountLevel) {
+    return channelLevel;
+  }
+  return {
+    tools: { ...channelLevel.tools, ...accountLevel.tools },
+    docs: { ...channelLevel.docs, ...accountLevel.docs },
+    send: { ...channelLevel.send, ...accountLevel.send },
+  };
+}
+
+/**
  * Merge channel-level defaults into an account-specific config.
  * Account-level values take precedence; `accounts` key is excluded to avoid recursion.
  */
@@ -77,13 +107,15 @@ export function mergeAccountWithDefaults(
       Object.assign(overrides, { [key]: value });
     }
   }
-  return normalizeLearningConfig(
-    {
-      ...defaults,
-      ...overrides,
-    },
-    { applyDefaults: true },
-  );
+  const merged: DingTalkConfig = {
+    ...defaults,
+    ...overrides,
+  };
+  const gatewayRpc = mergeGatewayRpcConfig(defaults.gatewayRpc, overrides.gatewayRpc);
+  if (gatewayRpc) {
+    merged.gatewayRpc = gatewayRpc;
+  }
+  return normalizeLearningConfig(merged, { applyDefaults: true });
 }
 
 /**
@@ -132,14 +164,23 @@ export interface ResolvedGatewayCapabilities {
   allowedTargets?: string[];
 }
 
-const DEFAULT_GATEWAY_CAPABILITIES: ResolvedGatewayCapabilities = {
+/** Denial reason returned when `gatewayRpc.tools.docs` is explicitly false. */
+export const DOCS_GATE_DISABLED_REASON =
+  "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)";
+
+/** Denial reason returned when `gatewayRpc.tools.proactiveSend` is explicitly false. */
+export const PROACTIVE_SEND_GATE_DISABLED_REASON =
+  "dingtalk proactive-send Gateway RPC is disabled by config (gatewayRpc.tools.proactiveSend = false)";
+
+const DEFAULT_GATEWAY_CAPABILITIES: ResolvedGatewayCapabilities = Object.freeze({
   docsEnabled: true,
   proactiveSendEnabled: true,
-};
+});
 
 /**
  * Resolve Gateway RPC capability configuration for an account.
- * Account-level `gateway` overrides inherit channel-level defaults via getConfig().
+ * Account-level `gatewayRpc` is merged with channel-level defaults by sub-key
+ * (see `mergeGatewayRpcConfig`); both default to all capabilities enabled.
  */
 export function resolveGatewayCapabilityConfig(
   cfg: OpenClawConfig,
@@ -164,17 +205,21 @@ export function resolveGatewayCapabilityConfig(
 /**
  * Check a docs RPC request against the configured capability gates.
  * Returns null when allowed, or a human-readable denial reason.
+ *
+ * A configured allowlist is fail-closed: an empty list (possible only when
+ * config validation was bypassed) denies every docs RPC, and a request without
+ * a spaceId is denied as well because its doc space cannot be verified.
  */
 export function checkDocsGatewayCapability(
   caps: ResolvedGatewayCapabilities,
   spaceId: string | undefined,
 ): string | null {
   if (!caps.docsEnabled) {
-    return "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)";
+    return DOCS_GATE_DISABLED_REASON;
   }
-  if (caps.allowedSpaceIds && caps.allowedSpaceIds.length > 0) {
+  if (caps.allowedSpaceIds) {
     if (!spaceId) {
-      return "this docs RPC method does not take a spaceId and is denied while gatewayRpc.docs.allowedSpaceIds is configured";
+      return "docs RPC denied: this request carries no spaceId while gatewayRpc.docs.allowedSpaceIds is configured (dingtalk.docs.append never carries a spaceId)";
     }
     if (!caps.allowedSpaceIds.includes(spaceId)) {
       return "spaceId is not in gatewayRpc.docs.allowedSpaceIds allowlist";
@@ -186,15 +231,18 @@ export function checkDocsGatewayCapability(
 /**
  * Check a proactive-send RPC request against the configured capability gates.
  * Returns null when allowed, or a human-readable denial reason.
+ *
+ * A configured allowlist is fail-closed: an empty list (possible only when
+ * config validation was bypassed) denies every proactive-send RPC.
  */
 export function checkProactiveSendGatewayCapability(
   caps: ResolvedGatewayCapabilities,
   target: string,
 ): string | null {
   if (!caps.proactiveSendEnabled) {
-    return "dingtalk proactive-send Gateway RPC is disabled by config (gatewayRpc.tools.proactiveSend = false)";
+    return PROACTIVE_SEND_GATE_DISABLED_REASON;
   }
-  if (caps.allowedTargets && caps.allowedTargets.length > 0) {
+  if (caps.allowedTargets) {
     if (!caps.allowedTargets.includes(target)) {
       return "target is not in gatewayRpc.send.allowedTargets allowlist";
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,12 +15,14 @@ function normalizeLearningConfig(
 ): DingTalkConfig {
   return {
     ...config,
-    learningEnabled: options.applyDefaults ? config.learningEnabled ?? false : config.learningEnabled,
+    learningEnabled: options.applyDefaults
+      ? (config.learningEnabled ?? false)
+      : config.learningEnabled,
     learningAutoApply: options.applyDefaults
-      ? config.learningAutoApply ?? false
+      ? (config.learningAutoApply ?? false)
       : config.learningAutoApply,
     learningNoteTtlMs: options.applyDefaults
-      ? config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS
+      ? (config.learningNoteTtlMs ?? DEFAULT_LEARNING_NOTE_TTL_MS)
       : config.learningNoteTtlMs,
     cardStreamingMode: options.applyDefaults
       ? (config.cardStreamingMode ?? (config.cardRealTimeStream === true ? "all" : "off"))
@@ -61,8 +63,10 @@ export function mergeAccountWithDefaults(
   channelCfg: DingTalkConfig,
   accountCfg: DingTalkConfig,
 ): DingTalkConfig {
-  const { accounts: _accounts, ...defaultCandidate } =
-    channelCfg as DingTalkConfig & { accounts?: unknown; verboseRealtimeStream?: unknown };
+  const { accounts: _accounts, ...defaultCandidate } = channelCfg as DingTalkConfig & {
+    accounts?: unknown;
+    verboseRealtimeStream?: unknown;
+  };
   const defaults = stripRemovedLegacyFields(defaultCandidate as DingTalkConfig);
   const normalizedAccountCfg = stripRemovedLegacyFields(
     normalizeLearningConfig(accountCfg, { applyDefaults: false }),
@@ -113,6 +117,88 @@ export function isConfigured(cfg: OpenClawConfig, accountId?: string): boolean {
   return Boolean(config.clientId && hasConfiguredSecretInput(config.clientSecret));
 }
 
+/**
+ * Resolved Gateway RPC capability settings (Issue #608, 问题 3).
+ * All capabilities default to enabled; allowlists default to unrestricted.
+ */
+export interface ResolvedGatewayCapabilities {
+  /** `dingtalk.docs.*` / `dingtalk-connector.docs.*` RPCs enabled (default: true) */
+  docsEnabled: boolean;
+  /** `dingtalk-connector.sendToUser/sendToGroup/send` RPCs enabled (default: true) */
+  proactiveSendEnabled: boolean;
+  /** When set, docs RPCs only accept these spaceId values */
+  allowedSpaceIds?: string[];
+  /** When set, proactive-send RPCs only accept these `user:*` / `group:*` targets */
+  allowedTargets?: string[];
+}
+
+const DEFAULT_GATEWAY_CAPABILITIES: ResolvedGatewayCapabilities = {
+  docsEnabled: true,
+  proactiveSendEnabled: true,
+};
+
+/**
+ * Resolve Gateway RPC capability configuration for an account.
+ * Account-level `gateway` overrides inherit channel-level defaults via getConfig().
+ */
+export function resolveGatewayCapabilityConfig(
+  cfg: OpenClawConfig,
+  accountId?: string,
+): ResolvedGatewayCapabilities {
+  const config = getConfig(cfg, accountId);
+  const gatewayRpc = config.gatewayRpc;
+  if (!gatewayRpc) {
+    return DEFAULT_GATEWAY_CAPABILITIES;
+  }
+  const tools = gatewayRpc.tools ?? {};
+  const docs = gatewayRpc.docs ?? {};
+  const send = gatewayRpc.send ?? {};
+  return {
+    docsEnabled: tools.docs !== false,
+    proactiveSendEnabled: tools.proactiveSend !== false,
+    allowedSpaceIds: docs.allowedSpaceIds,
+    allowedTargets: send.allowedTargets,
+  };
+}
+
+/**
+ * Check a docs RPC request against the configured capability gates.
+ * Returns null when allowed, or a human-readable denial reason.
+ */
+export function checkDocsGatewayCapability(
+  caps: ResolvedGatewayCapabilities,
+  spaceId: string | undefined,
+): string | null {
+  if (!caps.docsEnabled) {
+    return "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)";
+  }
+  if (caps.allowedSpaceIds && caps.allowedSpaceIds.length > 0) {
+    if (!spaceId || !caps.allowedSpaceIds.includes(spaceId)) {
+      return `spaceId is not in gatewayRpc.docs.allowedSpaceIds allowlist`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check a proactive-send RPC request against the configured capability gates.
+ * Returns null when allowed, or a human-readable denial reason.
+ */
+export function checkProactiveSendGatewayCapability(
+  caps: ResolvedGatewayCapabilities,
+  target: string,
+): string | null {
+  if (!caps.proactiveSendEnabled) {
+    return "dingtalk proactive-send Gateway RPC is disabled by config (gatewayRpc.tools.proactiveSend = false)";
+  }
+  if (caps.allowedTargets && caps.allowedTargets.length > 0) {
+    if (!caps.allowedTargets.includes(target)) {
+      return `target is not in gatewayRpc.send.allowedTargets allowlist`;
+    }
+  }
+  return null;
+}
+
 export async function resolveRuntimeConfig(
   config: DingTalkConfig,
   log?: { warn?: (message: string, data?: unknown) => void },
@@ -154,7 +240,10 @@ function hasOwn(obj: unknown, key: string): boolean {
   return typeof obj === "object" && obj !== null && Object.prototype.hasOwnProperty.call(obj, key);
 }
 
-function resolveAgentIdentityEmoji(cfg: OpenClawConfig, agentId?: string | null): string | undefined {
+function resolveAgentIdentityEmoji(
+  cfg: OpenClawConfig,
+  agentId?: string | null,
+): string | undefined {
   const targetAgentId = String(agentId || "").trim();
   if (!targetAgentId) {
     return undefined;
@@ -233,7 +322,6 @@ export function stripTargetPrefix(target: string): { targetId: string; isExplici
 // ============ Onboarding Helper Functions ============
 
 const DEFAULT_ACCOUNT_ID = "default";
-
 
 /**
  * List all DingTalk account IDs from config
@@ -326,10 +414,7 @@ export function resolveDingTalkAccount(
 
   const accountConfig = dingtalk?.accounts?.[id];
   if (accountConfig) {
-    const merged = mergeAccountWithDefaults(
-      dingtalk as DingTalkConfig,
-      accountConfig,
-    );
+    const merged = mergeAccountWithDefaults(dingtalk as DingTalkConfig, accountConfig);
     const publicMerged = stripRemovedLegacyFields(merged);
     return {
       ...publicMerged,

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,8 +173,11 @@ export function checkDocsGatewayCapability(
     return "dingtalk docs Gateway RPC is disabled by config (gatewayRpc.tools.docs = false)";
   }
   if (caps.allowedSpaceIds && caps.allowedSpaceIds.length > 0) {
-    if (!spaceId || !caps.allowedSpaceIds.includes(spaceId)) {
-      return `spaceId is not in gatewayRpc.docs.allowedSpaceIds allowlist`;
+    if (!spaceId) {
+      return "this docs RPC method does not take a spaceId and is denied while gatewayRpc.docs.allowedSpaceIds is configured";
+    }
+    if (!caps.allowedSpaceIds.includes(spaceId)) {
+      return "spaceId is not in gatewayRpc.docs.allowedSpaceIds allowlist";
     }
   }
   return null;
@@ -193,7 +196,7 @@ export function checkProactiveSendGatewayCapability(
   }
   if (caps.allowedTargets && caps.allowedTargets.length > 0) {
     if (!caps.allowedTargets.includes(target)) {
-      return `target is not in gatewayRpc.send.allowedTargets allowlist`;
+      return "target is not in gatewayRpc.send.allowedTargets allowlist";
     }
   }
   return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,28 @@ export type CardStreamingMode = "off" | "answer" | "all";
 export type ContextVisibilityMode = "all" | "allowlist" | "allowlist_quote";
 
 /**
+ * Gateway RPC capability configuration (Issue #608, 问题 3).
+ * Aligns with the official connector's `tools: { docs, media }` gate shape.
+ * All capabilities default to enabled for backward compatibility.
+ */
+export interface DingTalkGatewayCapabilityConfig {
+  tools?: {
+    /** Enable `dingtalk.docs.*` and `dingtalk-connector.docs.*` Gateway RPCs (default: true) */
+    docs?: boolean;
+    /** Enable proactive-send Gateway RPCs: `dingtalk-connector.sendToUser/sendToGroup/send` (default: true) */
+    proactiveSend?: boolean;
+  };
+  /** Optional doc-space allowlist; when set, docs RPCs only accept these `spaceId` values */
+  docs?: {
+    allowedSpaceIds?: string[];
+  };
+  /** Optional proactive-send target allowlist; entries must be `user:*` or `group:*` */
+  send?: {
+    allowedTargets?: string[];
+  };
+}
+
+/**
  * DingTalk channel configuration (extends base OpenClaw config)
  */
 export interface DingTalkConfig extends OpenClawConfig {
@@ -104,6 +126,8 @@ export interface DingTalkConfig extends OpenClawConfig {
     tokens?: boolean;
     dapiUsage?: boolean;
   };
+  /** Gateway RPC capability gates and allowlists (docs RPCs + proactive-send RPCs); namespaced as `gatewayRpc` to avoid clashing with the host-level `gateway` config */
+  gatewayRpc?: DingTalkGatewayCapabilityConfig;
 }
 
 /**
@@ -175,6 +199,8 @@ export interface DingTalkChannelConfig {
   convertMarkdownTables?: boolean;
   /** @mention the sender after card finalization in group chats; value is the message text */
   cardAtSender?: string;
+  /** Gateway RPC capability gates and allowlists (docs RPCs + proactive-send RPCs); namespaced as `gatewayRpc` to avoid clashing with the host-level `gateway` config */
+  gatewayRpc?: DingTalkGatewayCapabilityConfig;
 }
 
 /**

--- a/tests/unit/config-schema.test.ts
+++ b/tests/unit/config-schema.test.ts
@@ -442,4 +442,32 @@ describe('DingTalkConfigSchema', () => {
         expect(jsonSchema.properties?.proactivePermissionHint?.properties?.cooldownHours?.type).toBe('integer');
     });
 
+    it('validates gatewayRpc capability gates and rejects ambiguous empty allowlists', () => {
+        expect(
+            DingTalkConfigSchema.safeParse({
+                gatewayRpc: {
+                    tools: { docs: false, proactiveSend: true },
+                    docs: { allowedSpaceIds: ['spaceA'] },
+                    send: { allowedTargets: ['user:u1', 'group:g1'] },
+                },
+            }).success,
+        ).toBe(true);
+
+        // Unknown nested keys stay rejected so typos fail fast.
+        expect(
+            DingTalkConfigSchema.safeParse({ gatewayRpc: { tools: { doc: false } } }).success,
+        ).toBe(false);
+        // Empty allowlists are ambiguous, so they are rejected instead of silently disabling the restriction.
+        expect(
+            DingTalkConfigSchema.safeParse({ gatewayRpc: { docs: { allowedSpaceIds: [] } } }).success,
+        ).toBe(false);
+        expect(
+            DingTalkConfigSchema.safeParse({ gatewayRpc: { send: { allowedTargets: [] } } }).success,
+        ).toBe(false);
+        // Send targets must be user:* / group:*.
+        expect(
+            DingTalkConfigSchema.safeParse({ gatewayRpc: { send: { allowedTargets: ['nope'] } } }).success,
+        ).toBe(false);
+    });
+
 });

--- a/tests/unit/gateway-capability-gate.test.ts
+++ b/tests/unit/gateway-capability-gate.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import {
+  checkDocsGatewayCapability,
+  checkProactiveSendGatewayCapability,
+  resolveGatewayCapabilityConfig,
+} from "../../src/config";
+
+function makeCfg(dingtalk: Record<string, unknown>): OpenClawConfig {
+  return { channels: { dingtalk } } as unknown as OpenClawConfig;
+}
+
+describe("resolveGatewayCapabilityConfig", () => {
+  it("defaults all capabilities to enabled when gatewayRpc is unset", () => {
+    const caps = resolveGatewayCapabilityConfig(makeCfg({ clientId: "id" }));
+    expect(caps).toEqual({ docsEnabled: true, proactiveSendEnabled: true });
+    expect(caps.allowedSpaceIds).toBeUndefined();
+    expect(caps.allowedTargets).toBeUndefined();
+  });
+
+  it("honors tools.docs / tools.proactiveSend explicit false", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { tools: { docs: false, proactiveSend: false } } }),
+    );
+    expect(caps.docsEnabled).toBe(false);
+    expect(caps.proactiveSendEnabled).toBe(false);
+  });
+
+  it("resolves allowlists", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({
+        gatewayRpc: {
+          docs: { allowedSpaceIds: ["spaceA"] },
+          send: { allowedTargets: ["user:u1", "group:g1"] },
+        },
+      }),
+    );
+    expect(caps.allowedSpaceIds).toEqual(["spaceA"]);
+    expect(caps.allowedTargets).toEqual(["user:u1", "group:g1"]);
+  });
+
+  it("named accounts inherit channel-level gatewayRpc defaults", () => {
+    const cfg = makeCfg({
+      gatewayRpc: { tools: { docs: false } },
+      accounts: { bot2: { clientId: "x" } },
+    }) as OpenClawConfig & { channels: { dingtalk: { accounts: Record<string, unknown> } } };
+    const caps = resolveGatewayCapabilityConfig(cfg, "bot2");
+    expect(caps.docsEnabled).toBe(false);
+    expect(caps.proactiveSendEnabled).toBe(true);
+  });
+
+  it("account-level gatewayRpc overrides channel-level", () => {
+    const cfg = makeCfg({
+      gatewayRpc: { tools: { docs: false } },
+      accounts: { bot2: { gatewayRpc: { tools: { docs: true } } } },
+    }) as OpenClawConfig & { channels: { dingtalk: { accounts: Record<string, unknown> } } };
+    const caps = resolveGatewayCapabilityConfig(cfg, "bot2");
+    expect(caps.docsEnabled).toBe(true);
+  });
+});
+
+describe("checkDocsGatewayCapability", () => {
+  it("returns null when enabled and no allowlist", () => {
+    const caps = resolveGatewayCapabilityConfig(makeCfg({}));
+    expect(checkDocsGatewayCapability(caps, "spaceA")).toBeNull();
+  });
+
+  it("denies when docs tool disabled", () => {
+    const caps = resolveGatewayCapabilityConfig(makeCfg({ gatewayRpc: { tools: { docs: false } } }));
+    const denial = checkDocsGatewayCapability(caps, "spaceA");
+    expect(denial).toContain("disabled by config");
+  });
+
+  it("denies spaceId outside allowlist", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { docs: { allowedSpaceIds: ["spaceA"] } } }),
+    );
+    expect(checkDocsGatewayCapability(caps, "spaceB")).toContain("allowedSpaceIds");
+    expect(checkDocsGatewayCapability(caps, undefined)).toContain("allowedSpaceIds");
+    expect(checkDocsGatewayCapability(caps, "spaceA")).toBeNull();
+  });
+});
+
+describe("checkProactiveSendGatewayCapability", () => {
+  it("returns null when enabled and no allowlist", () => {
+    const caps = resolveGatewayCapabilityConfig(makeCfg({}));
+    expect(checkProactiveSendGatewayCapability(caps, "user:u1")).toBeNull();
+  });
+
+  it("denies when proactiveSend disabled", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { tools: { proactiveSend: false } } }),
+    );
+    const denial = checkProactiveSendGatewayCapability(caps, "user:u1");
+    expect(denial).toContain("disabled by config");
+  });
+
+  it("denies target outside allowlist", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { send: { allowedTargets: ["group:g1"] } } }),
+    );
+    expect(checkProactiveSendGatewayCapability(caps, "user:u1")).toContain("allowedTargets");
+    expect(checkProactiveSendGatewayCapability(caps, "group:g1")).toBeNull();
+  });
+});

--- a/tests/unit/gateway-capability-gate.test.ts
+++ b/tests/unit/gateway-capability-gate.test.ts
@@ -57,6 +57,33 @@ describe("resolveGatewayCapabilityConfig", () => {
     const caps = resolveGatewayCapabilityConfig(cfg, "bot2");
     expect(caps.docsEnabled).toBe(true);
   });
+
+  it("merges account-level gatewayRpc by sub-key so channel allowlists survive", () => {
+    const cfg = makeCfg({
+      gatewayRpc: {
+        tools: { docs: false },
+        docs: { allowedSpaceIds: ["spaceA"] },
+        send: { allowedTargets: ["group:g1"] },
+      },
+      accounts: { bot2: { gatewayRpc: { tools: { docs: true } } } },
+    }) as OpenClawConfig & { channels: { dingtalk: { accounts: Record<string, unknown> } } };
+    const caps = resolveGatewayCapabilityConfig(cfg, "bot2");
+    // Only tools.docs is overridden; the channel-level allowlists stay in force.
+    expect(caps.docsEnabled).toBe(true);
+    expect(caps.proactiveSendEnabled).toBe(true);
+    expect(caps.allowedSpaceIds).toEqual(["spaceA"]);
+    expect(caps.allowedTargets).toEqual(["group:g1"]);
+  });
+
+  it("keeps an account-level allowlist scoped to that account", () => {
+    const cfg = makeCfg({
+      accounts: {
+        bot2: { gatewayRpc: { send: { allowedTargets: ["user:u1"] } } },
+      },
+    }) as OpenClawConfig & { channels: { dingtalk: { accounts: Record<string, unknown> } } };
+    expect(resolveGatewayCapabilityConfig(cfg, "bot2").allowedTargets).toEqual(["user:u1"]);
+    expect(resolveGatewayCapabilityConfig(cfg).allowedTargets).toBeUndefined();
+  });
 });
 
 describe("checkDocsGatewayCapability", () => {
@@ -110,7 +137,7 @@ describe("docs allowlist edge cases (review follow-up)", () => {
       makeCfg({ gatewayRpc: { docs: { allowedSpaceIds: ["spaceA"] } } }),
     );
     const denial = checkDocsGatewayCapability(caps, undefined);
-    expect(denial).toContain("does not take a spaceId");
+    expect(denial).toContain("carries no spaceId");
     // Distinguishable from the out-of-allowlist reason
     const outOfList = checkDocsGatewayCapability(caps, "other");
     expect(outOfList).toContain("not in");
@@ -122,5 +149,29 @@ describe("docs allowlist edge cases (review follow-up)", () => {
       makeCfg({ gatewayRpc: { tools: { proactiveSend: false } } }),
     );
     expect(checkProactiveSendGatewayCapability(caps, "")).toContain("disabled by config");
+  });
+});
+
+describe("allowlist fail-closed semantics (review follow-up)", () => {
+  it("treats an empty allowedSpaceIds list as deny-all", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { docs: { allowedSpaceIds: [] } } }),
+    );
+    expect(checkDocsGatewayCapability(caps, "spaceA")).toContain("allowedSpaceIds");
+    expect(checkDocsGatewayCapability(caps, undefined)).toContain("carries no spaceId");
+  });
+
+  it("treats an empty allowedTargets list as deny-all", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { send: { allowedTargets: [] } } }),
+    );
+    expect(checkProactiveSendGatewayCapability(caps, "user:u1")).toContain("allowedTargets");
+    expect(checkProactiveSendGatewayCapability(caps, "group:g1")).toContain("allowedTargets");
+  });
+
+  it("unset allowlists stay unrestricted", () => {
+    const caps = resolveGatewayCapabilityConfig(makeCfg({ gatewayRpc: { tools: { docs: true } } }));
+    expect(checkDocsGatewayCapability(caps, "anySpace")).toBeNull();
+    expect(checkProactiveSendGatewayCapability(caps, "user:anyone")).toBeNull();
   });
 });

--- a/tests/unit/gateway-capability-gate.test.ts
+++ b/tests/unit/gateway-capability-gate.test.ts
@@ -103,3 +103,24 @@ describe("checkProactiveSendGatewayCapability", () => {
     expect(checkProactiveSendGatewayCapability(caps, "group:g1")).toBeNull();
   });
 });
+
+describe("docs allowlist edge cases (review follow-up)", () => {
+  it("denies docs methods without spaceId with an explicit reason when allowlist configured", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { docs: { allowedSpaceIds: ["spaceA"] } } }),
+    );
+    const denial = checkDocsGatewayCapability(caps, undefined);
+    expect(denial).toContain("does not take a spaceId");
+    // Distinguishable from the out-of-allowlist reason
+    const outOfList = checkDocsGatewayCapability(caps, "other");
+    expect(outOfList).toContain("not in");
+    expect(outOfList).not.toEqual(denial);
+  });
+
+  it("denies disabled proactiveSend even for empty target", () => {
+    const caps = resolveGatewayCapabilityConfig(
+      makeCfg({ gatewayRpc: { tools: { proactiveSend: false } } }),
+    );
+    expect(checkProactiveSendGatewayCapability(caps, "")).toContain("disabled by config");
+  });
+});

--- a/tests/unit/gateway-rpc-capability-entry.test.ts
+++ b/tests/unit/gateway-rpc-capability-entry.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+
+const INDEX_IMPORT_TIMEOUT_MS = 15_000;
+
+vi.mock("../../src/channel", () => ({
+  dingtalkPlugin: {},
+}));
+
+vi.mock("../../src/runtime", () => ({
+  setDingTalkRuntime: vi.fn(),
+}));
+
+vi.mock("../../src/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/config")>();
+  return {
+    ...actual,
+    getConfig: vi.fn(() => ({ clientId: "id", clientSecret: "secret" })),
+    listDingTalkAccountIds: vi.fn(() => []),
+    resolveDingTalkAccount: vi.fn(() => ({ configured: true, clientId: "id" })),
+  };
+});
+
+vi.mock("../../src/docs-service", () => ({
+  createDoc: vi.fn(async () => ({ docId: "doc1", title: "t", docType: "alidoc" })),
+  appendToDoc: vi.fn(async () => ({ success: true })),
+  searchDocs: vi.fn(async () => []),
+  listDocs: vi.fn(async () => []),
+  DocCreateAppendError: class extends Error {},
+}));
+
+vi.mock("../../src/send-service", () => ({
+  sendMessage: vi.fn(async () => ({ ok: true, messageId: "m1" })),
+}));
+
+vi.mock("../../src/auth", () => ({
+  getAccessToken: vi.fn(async () => "token"),
+}));
+
+vi.mock("../../src/card/ask-user-question", () => ({
+  registerDingTalkAskUserQuestionTool: vi.fn(),
+}));
+
+vi.mock("../../src/run-usage-store", () => ({
+  accumulateUsage: vi.fn(),
+}));
+
+type Handler = (args: {
+  context?: { cronStorePath?: string };
+  params: Record<string, unknown>;
+  respond: (ok: boolean, payload: unknown) => void;
+}) => Promise<void> | void;
+
+async function loadEntry() {
+  const mod = await import("../../index");
+  return mod.default;
+}
+
+function makeApi(cfg: Record<string, unknown>) {
+  const methods = new Map<string, Handler>();
+  const mockApi = {
+    config: cfg,
+    pluginConfig: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn((name: string, handler: Handler) => {
+      methods.set(name, handler);
+    }),
+    registrationMode: "full",
+    runtime: {},
+    on: vi.fn(),
+  } as unknown as OpenClawPluginApi;
+  return { mockApi, methods };
+}
+
+function callHandler(
+  handler: Handler,
+  params: Record<string, unknown>,
+): Promise<{ ok: boolean; payload: unknown }> {
+  return new Promise((resolve) => {
+    handler({
+      params,
+      respond: (ok, payload) => resolve({ ok, payload }),
+    });
+  });
+}
+
+function dingtalkCfg(gatewayRpc: unknown): Record<string, unknown> {
+  return { channels: { dingtalk: { gatewayRpc } } };
+}
+
+describe("gateway RPC capability gates (Issue #608 问题 3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("docs RPC works by default (no gatewayRpc config)", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi({ channels: { dingtalk: {} } });
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk.docs.create")!, {
+      spaceId: "spaceA",
+      title: "T",
+    });
+    expect(res.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("docs RPC denied when gatewayRpc.tools.docs = false (canonical namespace)", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(dingtalkCfg({ tools: { docs: false } }));
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk.docs.create")!, {
+      spaceId: "spaceA",
+      title: "T",
+    });
+    expect(res.ok).toBe(false);
+    expect((res.payload as { error: string }).error).toContain("disabled by config");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("docs RPC denial applies to dingtalk-connector aliases too", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(dingtalkCfg({ tools: { docs: false } }));
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk-connector.docs.search")!, {
+      keyword: "k",
+    });
+    expect(res.ok).toBe(false);
+    expect((res.payload as { error: string }).error).toContain("disabled by config");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("docs RPC denied when spaceId outside allowedSpaceIds", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(
+      dingtalkCfg({ docs: { allowedSpaceIds: ["spaceOk"] } }),
+    );
+    entry.register(mockApi);
+    const denied = await callHandler(methods.get("dingtalk.docs.list")!, { spaceId: "other" });
+    expect(denied.ok).toBe(false);
+    expect((denied.payload as { error: string }).error).toContain("allowedSpaceIds");
+    const allowed = await callHandler(methods.get("dingtalk.docs.list")!, { spaceId: "spaceOk" });
+    expect(allowed.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("proactive send denied when gatewayRpc.tools.proactiveSend = false", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(dingtalkCfg({ tools: { proactiveSend: false } }));
+    entry.register(mockApi);
+    for (const [method, params] of [
+      ["dingtalk-connector.sendToUser", { userId: "u1", content: "hi" }],
+      ["dingtalk-connector.sendToGroup", { openConversationId: "g1", content: "hi" }],
+      ["dingtalk-connector.send", { target: "user:u1", content: "hi" }],
+    ] as const) {
+      const res = await callHandler(methods.get(method)!, params);
+      expect(res.ok).toBe(false);
+      expect((res.payload as { error: string }).error).toContain("disabled by config");
+    }
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("proactive send denied when target outside allowedTargets", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(
+      dingtalkCfg({ send: { allowedTargets: ["group:ok"] } }),
+    );
+    entry.register(mockApi);
+    const denied = await callHandler(methods.get("dingtalk-connector.send")!, {
+      target: "user:u1",
+      content: "hi",
+    });
+    expect(denied.ok).toBe(false);
+    expect((denied.payload as { error: string }).error).toContain("allowedTargets");
+    const allowed = await callHandler(methods.get("dingtalk-connector.sendToGroup")!, {
+      openConversationId: "ok",
+      content: "hi",
+    });
+    expect(allowed.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("proactive send works by default (backward compatible)", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi({ channels: { dingtalk: {} } });
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk-connector.send")!, {
+      target: "user:u1",
+      content: "hi",
+    });
+    expect(res.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("denials log under [DingTalk][GatewayRPC][Denied]", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(dingtalkCfg({ tools: { docs: false } }));
+    entry.register(mockApi);
+    await callHandler(methods.get("dingtalk.docs.create")!, { spaceId: "s", title: "t" });
+    const warn = (mockApi.logger as { warn: ReturnType<typeof vi.fn> }).warn;
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[DingTalk][GatewayRPC][Denied]"));
+  }, INDEX_IMPORT_TIMEOUT_MS);
+});

--- a/tests/unit/gateway-rpc-capability-entry.test.ts
+++ b/tests/unit/gateway-rpc-capability-entry.test.ts
@@ -11,6 +11,9 @@ vi.mock("../../src/runtime", () => ({
   setDingTalkRuntime: vi.fn(),
 }));
 
+// Only the handler-facing helpers are stubbed here. `resolveGatewayCapabilityConfig`
+// keeps its real implementation, and its internal `getConfig` call stays bound to the
+// real module, so the gate reads the `channels.dingtalk` fixture passed to `makeApi`.
 vi.mock("../../src/config", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/config")>();
   return {
@@ -208,7 +211,7 @@ describe("gateway capability gates review follow-ups", () => {
       content: "hello",
     });
     expect(res.ok).toBe(false);
-    expect((res.payload as { error: string }).error).toContain("does not take a spaceId");
+    expect((res.payload as { error: string }).error).toContain("carries no spaceId");
   }, INDEX_IMPORT_TIMEOUT_MS);
 
   it("docs.append works when no allowlist configured (regression)", async () => {
@@ -254,5 +257,40 @@ describe("gateway capability gates review follow-ups", () => {
     });
     expect(res.ok).toBe(false);
     expect((res.payload as { error: string }).error).toContain("user: or group:");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("account-level gatewayRpc keeps channel-level allowlists in force", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi({
+      channels: {
+        dingtalk: {
+          gatewayRpc: {
+            tools: { docs: false },
+            send: { allowedTargets: ["group:ok"] },
+          },
+          accounts: { bot2: { gatewayRpc: { tools: { docs: true } } } },
+        },
+      },
+    });
+    entry.register(mockApi);
+
+    // The account only loosens tools.docs; the channel-level send allowlist still applies.
+    const allowedDocs = await callHandler(methods.get("dingtalk.docs.list")!, {
+      spaceId: "spaceA",
+      accountId: "bot2",
+    });
+    expect(allowedDocs.ok).toBe(true);
+    const deniedSend = await callHandler(methods.get("dingtalk-connector.send")!, {
+      target: "user:u1",
+      content: "hi",
+      accountId: "bot2",
+    });
+    expect(deniedSend.ok).toBe(false);
+    expect((deniedSend.payload as { error: string }).error).toContain("allowedTargets");
+
+    // The default account keeps the channel-level docs kill switch.
+    const deniedDefault = await callHandler(methods.get("dingtalk.docs.list")!, { spaceId: "spaceA" });
+    expect(deniedDefault.ok).toBe(false);
+    expect((deniedDefault.payload as { error: string }).error).toContain("disabled by config");
   }, INDEX_IMPORT_TIMEOUT_MS);
 });

--- a/tests/unit/gateway-rpc-capability-entry.test.ts
+++ b/tests/unit/gateway-rpc-capability-entry.test.ts
@@ -195,3 +195,64 @@ describe("gateway RPC capability gates (Issue #608 问题 3)", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("[DingTalk][GatewayRPC][Denied]"));
   }, INDEX_IMPORT_TIMEOUT_MS);
 });
+
+describe("gateway capability gates review follow-ups", () => {
+  it("docs.append denied with explicit no-spaceId reason when allowlist configured", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(
+      dingtalkCfg({ docs: { allowedSpaceIds: ["spaceOk"] } }),
+    );
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk-connector.docs.append")!, {
+      docId: "doc1",
+      content: "hello",
+    });
+    expect(res.ok).toBe(false);
+    expect((res.payload as { error: string }).error).toContain("does not take a spaceId");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("docs.append works when no allowlist configured (regression)", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi({ channels: { dingtalk: {} } });
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk.docs.append")!, {
+      docId: "doc1",
+      content: "hello",
+    });
+    expect(res.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("status and probe RPCs remain available when all tools disabled", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(
+      dingtalkCfg({ tools: { docs: false, proactiveSend: false } }),
+    );
+    entry.register(mockApi);
+    const status = await callHandler(methods.get("dingtalk-connector.status")!, {});
+    expect(status.ok).toBe(true);
+    const probe = await callHandler(methods.get("dingtalk-connector.probe")!, {});
+    expect(probe.ok).toBe(true);
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("proactiveSend disabled answers structured deny even with missing required params", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi(dingtalkCfg({ tools: { proactiveSend: false } }));
+    entry.register(mockApi);
+    // No userId/content at all — must be a structured deny, not a thrown param error
+    const res = await callHandler(methods.get("dingtalk-connector.sendToUser")!, {});
+    expect(res.ok).toBe(false);
+    expect((res.payload as { error: string }).error).toContain("disabled by config");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+
+  it("invalid connector target rejected after gate passes", async () => {
+    const entry = await loadEntry();
+    const { mockApi, methods } = makeApi({ channels: { dingtalk: {} } });
+    entry.register(mockApi);
+    const res = await callHandler(methods.get("dingtalk-connector.send")!, {
+      target: "foo:bar",
+      content: "hi",
+    });
+    expect(res.ok).toBe(false);
+    expect((res.payload as { error: string }).error).toContain("user: or group:");
+  }, INDEX_IMPORT_TIMEOUT_MS);
+});

--- a/tests/unit/plugin-manifest.test.ts
+++ b/tests/unit/plugin-manifest.test.ts
@@ -130,6 +130,41 @@ describe("plugin manifest channel metadata", () => {
         );
     });
 
+    it("publishes gatewayRpc capability gates in both top-level and account-level DingTalk schema", () => {
+        const manifest = readJsonFile<{
+            channelConfigs?: Record<
+                string,
+                {
+                    schema?: {
+                        properties?: Record<string, any>;
+                    };
+                }
+            >;
+        }>("openclaw.plugin.json");
+
+        const topLevelProperties = manifest.channelConfigs?.dingtalk?.schema?.properties;
+        const accountLevelProperties = topLevelProperties?.accounts?.additionalProperties?.properties;
+
+        // The host validates channels.dingtalk against this schema with
+        // additionalProperties: false, so a missing key makes the documented
+        // config unusable (and fails config load).
+        for (const properties of [topLevelProperties, accountLevelProperties]) {
+            expect(properties?.gatewayRpc).toEqual(
+                expect.objectContaining({ type: "object", additionalProperties: false }),
+            );
+            expect(properties?.gatewayRpc?.properties?.tools?.properties?.docs?.type).toBe("boolean");
+            expect(properties?.gatewayRpc?.properties?.tools?.properties?.proactiveSend?.type).toBe(
+                "boolean",
+            );
+            expect(properties?.gatewayRpc?.properties?.docs?.properties?.allowedSpaceIds?.minItems).toBe(
+                1,
+            );
+            expect(
+                properties?.gatewayRpc?.properties?.send?.properties?.allowedTargets?.items?.pattern,
+            ).toBe("^(user|group):\\S+$");
+        }
+    });
+
     it("keeps the OpenClaw compatibility metadata on the current SDK baseline", () => {
         const packageJson = readJsonFile<{
             peerDependencies?: Record<string, string>;


### PR DESCRIPTION
## 背景

ClawHub 安全审核（v3.6.11，Issue #608）的 LLM 分析将 `gateway-docs-and-send-rpc` 列为风险项：插件注册的 `dingtalk.docs.*` / `dingtalk-connector.docs.*` 文档 RPC 和 `dingtalk-connector.sendToUser/sendToGroup/send` 主动发送 RPC 使用配置的钉钉应用凭证直接执行，但插件自身没有能力开关、没有空间/目标白名单，审核材料中也未说明其信任模型。

对照官方仓库 `DingTalk-Real-AI/dingtalk-openclaw-connector`：其 docs/send RPC 同样依赖宿主 Gateway 信任模型（不做调用方级鉴权），但在 schema 中提供了 `tools: { docs, media }` 能力开关形态。本 PR 对齐该形态并补齐白名单能力。

## 目标

- docs RPC 与主动发送 RPC 可通过配置显式关闭（capability gate）
- 提供可选的文档空间 / 发送目标白名单
- 默认行为完全向后兼容，现有调用方无需改动
- 在用户文档中说明信任模型与所需钉钉权限，回应审核 finding

## 实现

- `src/config-schema.ts`：新增 `gatewayCapabilities` 配置（宿主 `OpenClawConfig` 已占用 `gateway` / `tools`，裸 `capabilities` 又会与本插件的频道 capabilities 元数据混淆，故取 `gatewayCapabilities`）：
  - `gatewayCapabilities.tools.docs` / `gatewayCapabilities.tools.proactiveSend`：能力开关，默认 `true`
  - `gatewayCapabilities.docs.allowedSpaceIds`：文档空间白名单（未配置不限制；配置后至少一项）
  - `gatewayCapabilities.send.allowedTargets`：发送目标白名单，每项必须为 `user:*` / `group:*`（`.strict()` 拼错键名报错）
- `openclaw.plugin.json`：`channelConfigs.dingtalk.schema` 的顶层与 `accounts.*` 两处同步 `gatewayCapabilities`（宿主用该 schema 以 `additionalProperties: false` 校验 `channels.dingtalk`）
- `src/config.ts`：`resolveGatewayCapabilityConfig` + `checkDocsGatewayCapability` / `checkProactiveSendGatewayCapability`；多账号按子键与渠道级合并（`tools` / `docs` / `send` 分别合并，账号级同子键优先）
- `index.ts`：所有 docs / 主动发送 Gateway RPC handler 统一包装 gate；`dingtalk.docs.*` 与 `dingtalk-connector.docs.*` 共享 handler，别名自动受限；能力开关走 fast-path（先于 required 参数解析，关闭时返回结构化 deny 而非参数错误）；拒绝日志统一 `[DingTalk][GatewayRPC][Denied]` 前缀，reason 为静态文案，不泄露凭证
- 文档：`docs/user/reference/gateway-rpc.md` 新增"能力开关与白名单"章节（信任模型、配置示例、白名单 fail-closed 语义、账号级按子键合并、`docs.append` / 不带 `spaceId` 的 `docs.search` 会被拒绝）；`security-policies.md` 新增 Gateway RPC 能力边界小节；`configuration.md` 补充配置项与说明
- 设计文档：`docs/spec/issue-608-gateway-docs-send-gate.md`（含实现偏差说明）

## 复审修复（第 2 轮）

- **P0**：`gatewayCapabilities` 未写入 `openclaw.plugin.json`，宿主会用 "must not have additional properties: gatewayCapabilities" 判定配置非法并阻断配置加载（文档一配即炸）→ 顶层与账号级 schema 补齐，并在 `tests/unit/plugin-manifest.test.ts` 增加守护断言
- **空白名单 fail-open**：`allowedSpaceIds: []` / `allowedTargets: []` 原本等价于"不限制" → schema 加 `min(1)`（manifest 同步 `minItems: 1`）直接拒绝，运行时对"已配置但为空"按全部拒绝处理（fail-closed），并补单测
- **账号级整体替换**：账号级只写局部子键会静默丢掉渠道级白名单 → 改为按子键合并，渠道级限制始终生效
- **拒绝文案**：`docs.search` 未带 `spaceId` 时文案不准确 → 改为"请求未携带 spaceId"，并补齐 `search` / `append` 的行为说明
- **去重**：`index.ts` 中 docs 的 fast-path 与拒绝文案重复 → 抽 `DOCS_GATE_DISABLED_REASON` / `PROACTIVE_SEND_GATE_DISABLED_REASON` 常量，去掉冗余分支

## 复审修复（第 3 轮）

- **配置键改名**：`gatewayRpc` → `gatewayCapabilities`。`gatewayRpc` 语义精确但过于术语化；`gateway` / `tools` 已被宿主 `OpenClawConfig` 占用，裸 `capabilities` 又会与本插件的频道 capabilities 元数据（`chatTypes` / `reactions` / `threads` / `media`）混淆，因此保留 `gateway` 前缀。同步重命名 `mergeGatewayRpcConfig` → `mergeGatewayCapabilitiesConfig`、`DingTalkGatewayConfigSchema` → `DingTalkGatewayCapabilitiesSchema`、`DingTalkGatewayCapabilityConfig` → `DingTalkGatewayCapabilitiesConfig`
- 拒绝文案里的配置路径同步更新；日志前缀 `[DingTalk][GatewayRPC][Denied]` **保持不变**（它命名被拒绝的调用面，不是配置块，与文档页「Gateway RPC 兼容层」一致）
- `gatewayRpc` 未随任何版本发布，改名无向后兼容成本

## 实现 TODO

- [x] `gatewayCapabilities` schema + 一致性校验（`allowedTargets` 格式、白名单至少一项）
- [x] `resolveGatewayCapabilityConfig` + 多账号按子键合并
- [x] `openclaw.plugin.json` 顶层 / 账号级 schema 同步 + manifest 守护断言
- [x] docs / send RPC handler 接入 gate，统一拒绝响应与日志
- [x] 单测：gate 默认开启、显式关闭、白名单命中/未命中、空白名单 fail-closed、别名受限、`docs.append` 与不带 `spaceId` 的 `search`、账号级合并、`status`/`probe` 不受影响、缺参时结构化拒绝、非法 target
- [x] 用户文档与设计文档更新

## 验证 TODO

- [x] `pnpm run type-check`、`pnpm run lint`（0 error）、`pnpm test`（1318 tests 全绿）
- [x] `pnpm run build:runtime` + `build:types` 构建通过，`pnpm run pack:check` 通过，`dist/index.js` 含 gate 逻辑
- [x] 用宿主同一条 JSON Schema 校验路径验证：顶层/账号级 `gatewayCapabilities` 通过；空数组、非法 target、未知子键被拒绝
- [x] 改名回归：`type-check` / `lint`（0 error）/ `test`（1318 tests 全绿）/ `build:runtime` 通过；schema 复验为新键通过、旧键 `gatewayRpc` 被 `additional properties` 拒绝
- [x] 实机验证：关闭 `gatewayCapabilities.tools.docs` 后 docs RPC 全部拒绝（`dingtalk.docs.create/append/search/list` + `dingtalk-connector.docs.*` 共 8 个方法），拒绝原因逐字匹配，别名同样受限
- [x] 实机验证：配置 `allowedSpaceIds` 后未列入的 `spaceId` 被拒绝（含别名）；未配置时 `docs.list` 的 CLI 输出与日志形态与切换前逐字一致
- [x] 实机验证：配置 `allowedSpaceIds` 后 `docs.append` 与不带 `spaceId` 的 `docs.search` 返回"未携带 spaceId"专用拒绝原因
- [x] 实机验证：关闭 `gatewayCapabilities.tools.proactiveSend` 后三个发送 RPC 全部拒绝（缺参时仍为结构化 deny，gate 先于参数解析）；聊天回复通道不受影响（私聊 / 群聊 @ / 引用回复均正常，观测窗口内新增 Denied = 0）；`status` / `probe` 不受影响
- [x] 实机验证：多账号下账号级只覆盖 `tools.docs` 时，渠道级 `allowedTargets` 仍然生效（用 `accounts.default = {}` 保证线上 default 账号未掉线）
- [x] 实机验证：目标白名单命中时真实群发成功、未命中的 `user:` 目标被拒；空白名单 / 非法 target / 未知子键均被配置校验拒绝
- [x] 实机验证：收尾已删除临时 `gatewayCapabilities` / `accounts`、还原 `plugins.load.paths` 并重启确认（rootDir 回到主仓库、`connected=true`、docs RPC 行为回到基线）

- [ ] 重新发布版本后复查 ClawHub 审核 `gateway-docs-and-send-rpc` finding 是否降级/消除

验证环境：`.worktrees/fix-issue-608-gateway-gate`（`ea92ecf`），`pnpm run build:runtime` 后切换 `plugins.load.paths` 并 `openclaw gateway restart`；`channels status --probe` 为 `running/connected=true`，`plugins list` 的 `rootDir` 指向该 worktree。

实机限制：当前应用未开通文档 OpenAPI 权限（`/v1.0/doc/*` 返回 404/400），故 docs 的 `ok:true` 成功路径未覆盖，白名单"命中放行"只验证到 gate 层；拒绝原因不通过 CLI 透出（`respond(false, { error })` 未带 `ErrorShape`），判定依据为 `[DingTalk][GatewayRPC][Denied]` 日志行。

Closes #608（问题 3 部分；问题 1/2/4 由各自方案处理）


